### PR TITLE
Fix compile error in sort compare function

### DIFF
--- a/src/tools/common/profiler_output.cpp
+++ b/src/tools/common/profiler_output.cpp
@@ -44,7 +44,7 @@ namespace dsn {
         static const std::string percentail_counter_string[COUNTER_PERCENTILE_COUNT] = { "50%", "90%", "95%", "99%", "999%" };
         profiler_output_data_type* profiler_output_data = new profiler_output_data_type(taskname_width, data_width, call_width);
 
-        static inline bool cmp(sort_node &x, sort_node &y)
+        static inline bool cmp(const sort_node &x, const sort_node &y)
         {
             if (x.val == y.val)
             {


### PR DESCRIPTION
rDSN compile failed in Ubuntu 14.04 LTS with following errors.
```
[ 46%] Building CXX object src/tools/common/CMakeFiles/dsn.tools.common.dir/profiler_output.cpp.o
In file included from /usr/include/c++/4.8/algorithm:62:0,
                 from /home/liushaohui/workspace/opensource/rDSN/src/tools/common/profiler_output.cpp:28:
/usr/include/c++/4.8/bits/stl_algo.h: In instantiation of ‘_RandomAccessIterator std::__unguarded_partition(_RandomAccessIterator, _RandomAccessIterator, const _Tp&, _Compare) [with _RandomAccessIterator = dsn::tools::sort_node*; _Tp = dsn::tools::sort_node; _Compare = bool (*)(dsn::tools::sort_node&, dsn::tools::sort_node&)]’:
/usr/include/c++/4.8/bits/stl_algo.h:2296:78:   required from ‘_RandomAccessIterator std::__unguarded_partition_pivot(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = dsn::tools::sort_node*; _Compare = bool (*)(dsn::tools::sort_node&, dsn::tools::sort_node&)]’
/usr/include/c++/4.8/bits/stl_algo.h:2337:62:   required from ‘void std::__introsort_loop(_RandomAccessIterator, _RandomAccessIterator, _Size, _Compare) [with _RandomAccessIterator = dsn::tools::sort_node*; _Size = long int; _Compare = bool (*)(dsn::tools::sort_node&, dsn::tools::sort_node&)]’
/usr/include/c++/4.8/bits/stl_algo.h:5490:44:   required from ‘void std::sort(_RAIter, _RAIter, _Compare) [with _RAIter = dsn::tools::sort_node*; _Compare = bool (*)(dsn::tools::sort_node&, dsn::tools::sort_node&)]’
/home/liushaohui/workspace/opensource/rDSN/src/tools/common/profiler_output.cpp:76:67:   required from here
/usr/include/c++/4.8/bits/stl_algo.h:2263:35: error: invalid initialization of reference of type ‘dsn::tools::sort_node&’ from expression of type ‘const dsn::tools::sort_node’
    while (__comp(*__first, __pivot))
                                   ^
/usr/include/c++/4.8/bits/stl_algo.h:2266:34: error: invalid initialization of reference of type ‘dsn::tools::sort_node&’ from expression of type ‘const dsn::tools::sort_node’
    while (__comp(__pivot, *__last))
                                  ^
make[2]: *** [src/tools/common/CMakeFiles/dsn.tools.common.dir/profiler_output.cpp.o] Error 1
make[1]: *** [src/tools/common/CMakeFiles/dsn.tools.common.dir/all] Error 2
make: *** [all] Error 2
```

Change the compare function to  bool (*)(conts dsn::tools::sort_node&, const dsn::tools::sort_node&)