### PR TITLE
enable global assertion among other nits

### DIFF
--- a/bin/dsn.templates/check.cpp.php
+++ b/bin/dsn.templates/check.cpp.php
@@ -1,0 +1,63 @@
+<?php
+require_once($argv[1]); // type.php
+require_once($argv[2]); // program.php
+$file_prefix = $argv[3];
+$idl_type = $argv[4];
+?>
+
+# include <dsn/tool/simulator.h>
+# include "check.h"
+
+<?=$_PROG->get_cpp_namespace_begin()?>
+class <?=$_PROG->name?>_checker : public ::dsn::tools::checker
+{
+public:
+	<?=$_PROG->name?>_checker(const char* name) : ::dsn::tools::checker(name)
+	{
+		for (auto& app : _apps)
+		{
+			// TODO: identify your own type of service apps
+			//auto meta = dynamic_cast<meta_service_app *>(app.second);
+			//if (meta != nullptr) _meta_servers.push_back(meta);
+		}
+	}
+
+	virtual void check() override
+	{
+		// nothing to check
+		//if (_meta_servers.size() == 0)
+		//	return;
+
+		// check all invariances
+		/*
+		auto meta = meta_leader();
+		if (!meta) return;
+
+		for (auto& r : _replica_servers)
+		{
+			if (!r->is_started())
+				continue;
+
+			auto ep = r->primary_address();
+			if (!meta->_service->_failure_detector->is_worker_connected(ep))
+			{
+				dassert(!r->_stub->is_connected(), "when meta server says a replica is dead, it must be dead");
+			}
+		}
+		*/
+	}
+
+private:
+	//std::vector<meta_service_app*>        _meta_servers;
+};
+
+void install_checkers(configuration_ptr config)
+{
+	auto sim = dynamic_cast<::dsn::tools::simulator*>(::dsn::tools::get_current_tool());
+	if (nullptr == sim)
+		return;
+
+	sim->add_checker(new <?=$_PROG->name?>_checker("<?=$_PROG->name?>.global-checker"));
+}
+
+<?=$_PROG->get_cpp_namespace_end()?>

--- a/bin/dsn.templates/check.h.php
+++ b/bin/dsn.templates/check.h.php
@@ -1,0 +1,15 @@
+<?php
+require_once($argv[1]); // type.php
+require_once($argv[2]); // program.php
+$file_prefix = $argv[3];
+$idl_type = $argv[4];
+?>
+# pragma once
+
+# include <dsn/internal/configuration.h>
+
+<?=$_PROG->get_cpp_namespace_begin()?>
+
+    void install_checkers(configuration_ptr config);
+	
+<?=$_PROG->get_cpp_namespace_end()?>

--- a/bin/dsn.templates/replication/config.ini.php
+++ b/bin/dsn.templates/replication/config.ini.php
@@ -3,7 +3,7 @@ require_once($argv[1]); // type.php
 require_once($argv[2]); // program.php
 $file_prefix = $argv[3];
 ?>
-[apps.metaserver]
+[apps.meta]
 name = meta
 type = meta
 arguments = 
@@ -11,7 +11,7 @@ ports = 34601
 run = true
 count = 1 
     
-[apps.replicaserver]
+[apps.replica]
 name = replica
 type = replica
 arguments =
@@ -37,8 +37,7 @@ pause_on_start = false
 logging_factory_name = dsn::tools::screen_logger
 
 [tools.simulator]
-random_seed = 2756568580
-use_given_random_seed = false
+random_seed = 0
 
 [network]
 ; how many network threads for network library(used by asio)

--- a/bin/dsn.templates/replication/main.cpp.php
+++ b/bin/dsn.templates/replication/main.cpp.php
@@ -32,6 +32,6 @@ int main(int argc, char** argv)
 	dsn::tools::register_toollet<dsn::tools::fault_injector>("fault_injector");
 
 	// specify what services and tools will run in config file, then run
-	dsn::service::system::run("config.ini", true);
+	dsn::service::system::run(--argc, ++argv, true);
 	return 0;
 }

--- a/bin/dsn.templates/single/config.ini.php
+++ b/bin/dsn.templates/single/config.ini.php
@@ -3,7 +3,7 @@ require_once($argv[1]); // type.php
 require_once($argv[2]); // program.php
 $file_prefix = $argv[3];
 ?>
-[apps.<?=$_PROG->name?>.server]
+[apps.server]
 name = server
 type = <?=$_PROG->name?>_server
 arguments = 
@@ -28,8 +28,7 @@ pause_on_start = false
 logging_factory_name = dsn::tools::screen_logger
 
 [tools.simulator]
-random_seed = 2756568580
-use_given_random_seed = false
+random_seed = 0
 
 [network]
 ; how many network threads for network library(used by asio)

--- a/bin/dsn.templates/single/main.cpp.php
+++ b/bin/dsn.templates/single/main.cpp.php
@@ -35,6 +35,6 @@ int main(int argc, char** argv)
 #endif
 
 	// specify what services and tools will run in config file, then run
-	dsn::service::system::run("config.ini", true);
+	dsn::service::system::run(--argc, ++argv, true);
 	return 0;
 }

--- a/include/dsn/internal/global_config.h
+++ b/include/dsn/internal/global_config.h
@@ -114,7 +114,7 @@ struct service_spec
     bool build_network_spec(int port);
 };
 
-enum syste_exit_type
+enum sys_exit_type
 {
     SYS_EXIT_NORMAL,
     SYS_EXIT_BREAK, // Ctrl-C/Break,Shutdown,LogOff, see SetConsoleCtrlHandler
@@ -123,11 +123,11 @@ enum syste_exit_type
     SYS_EXIT_INVALID
 };
 
-ENUM_BEGIN(syste_exit_type, SYS_EXIT_INVALID)
+ENUM_BEGIN(sys_exit_type, SYS_EXIT_INVALID)
     ENUM_REG(SYS_EXIT_NORMAL)
     ENUM_REG(SYS_EXIT_BREAK)
     ENUM_REG(SYS_EXIT_EXCEPTION)
-ENUM_END(syste_exit_type)
+ENUM_END(sys_exit_type)
 
 }
 

--- a/include/dsn/tool/simulator.h
+++ b/include/dsn/tool/simulator.h
@@ -60,6 +60,9 @@ public:
     virtual void run() override;
 
     void add_checker(checker* chker);
+
+private:
+    static void on_system_exit(sys_exit_type st);
 };
 
 // ---- inline implementation ------

--- a/include/dsn/tool_api.h
+++ b/include/dsn/tool_api.h
@@ -134,7 +134,7 @@ namespace internal_use_only
 
 extern join_point<void, configuration_ptr> sys_init_before_app_created;
 extern join_point<void, configuration_ptr> sys_init_after_app_created;
-extern join_point<long, syste_exit_type, int, void*> sys_exit; // return (see SetUnhandledExceptionFilter), type, error code, context
+extern join_point<void, sys_exit_type>     sys_exit;
 
 template <typename T> bool register_component_provider(const char* name) { return internal_use_only::register_component_provider(name, T::template create<T>, PROVIDER_TYPE_MAIN); }
 template <typename T> bool register_component_aspect(const char* name) { return internal_use_only::register_component_provider(name, T::template create<T>, PROVIDER_TYPE_ASPECT); }

--- a/src/apps/replication/exe/config.ini
+++ b/src/apps/replication/exe/config.ini
@@ -1,4 +1,4 @@
-[apps.metaserver]
+[apps.meta]
 name = meta
 type = meta
 arguments = 
@@ -6,7 +6,7 @@ ports = 34601
 run = true
 count = 1 
     
-[apps.replicaserver]
+[apps.replica]
 name = replica
 type = replica
 arguments =
@@ -26,16 +26,16 @@ count = 1
 tool = simulator
 ;tool = nativerun
 ;toollets = tracer
+toollets = fault_injector
 ;toollets = tracer, fault_injector
 ;toollets = tracer, profiler, fault_injector
 ;toollets = profiler, fault_injector
 pause_on_start = false
 
-logging_factory_name = dsn::tools::screen_logger
+;logging_factory_name = dsn::tools::screen_logger
 
 [tools.simulator]
-random_seed = -1438568420
-use_given_random_seed = false
+random_seed = -1450883816
 
 [network]
 ; how many network threads for network library(used by asio)
@@ -77,6 +77,7 @@ rpc_timeout_milliseconds = 5000
 [task.LPC_AIO_IMMEDIATE_CALLBACK]
 is_trace = false
 allow_inline = false
+disk_write_fail_ratio = 0.01
 
 [task.LPC_RPC_TIMEOUT]
 is_trace = false

--- a/src/apps/replication/exe/test.cmd
+++ b/src/apps/replication/exe/test.cmd
@@ -4,6 +4,6 @@ for /l %%x in (1, 1, 10) do (
 	mkdir test-%%x
 	copy config.ini .\test-%%x
 	cd test-%%x	
-	start ..\dsn.replication.simple_kv.exe
+	start ..\dsn.replication.simple_kv.exe ..\config.ini
 	cd ..
 )

--- a/src/apps/replication/lib/replica.cpp
+++ b/src/apps/replication/lib/replica.cpp
@@ -111,6 +111,9 @@ void replica::on_client_read(const read_request_header& meta, message_ptr& reque
 
 void replica::response_client_message(message_ptr& request, error_code error, decree d/* = invalid_decree*/)
 {
+    if (nullptr == request)
+        return;
+
     message_ptr resp = request->create_response();
     int err = error.get();
     resp->writer().write(err);

--- a/src/core/coredump.posix.cpp
+++ b/src/core/coredump.posix.cpp
@@ -25,6 +25,7 @@
  */
 # include <dsn/internal/logging.h>
 # include <dsn/internal/coredump.h>
+# include <dsn/tool_api.h>
 
 //#ifdef _WIN32
 # if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
@@ -48,6 +49,8 @@ namespace dsn {
         {
             // TODO: not implemented
             //
+
+            ::dsn::tools::sys_exit.execute(SYS_EXIT_EXCEPTION);
         }
     }
 }

--- a/src/core/coredump.win.cpp
+++ b/src/core/coredump.win.cpp
@@ -25,6 +25,7 @@
  */
 # include <dsn/internal/logging.h>
 # include <dsn/internal/coredump.h>
+# include <dsn/tool_api.h>
 
 #ifdef _WIN32
 
@@ -147,9 +148,10 @@ namespace dsn {
                 derror("%s", szResult);
                 printf(szResult);
             }
+
+            ::dsn::tools::sys_exit.execute(SYS_EXIT_EXCEPTION);
             return retval;
         }
-
     }
 }
 

--- a/src/core/service_api.cpp
+++ b/src/core/service_api.cpp
@@ -202,7 +202,7 @@ namespace dsn { namespace service {
             if (service_apps::instance().get_all_apps().size() == 0)
             {
                 printf("no app are created, usually because \n"
-                    "app_name is not specified correctly\n"
+                    "app_name is not specified correctly, should be 'xxx' in [apps.xxx]\n"
                     "or app_index (1-based) is greater than specified count in config file\n"
                     );
                 exit(1);

--- a/src/core/tool_api.cpp
+++ b/src/core/tool_api.cpp
@@ -120,7 +120,7 @@ namespace dsn {
 
         join_point<void, configuration_ptr> sys_init_before_app_created("system.init.1");
         join_point<void, configuration_ptr> sys_init_after_app_created("system.init.2");
-        join_point<long, syste_exit_type, int, void*> sys_exit("system.exit"); // type, error code, context (e.g., exception)
+        join_point<void, sys_exit_type> sys_exit("system.exit");
 
         namespace internal_use_only
         {

--- a/src/tests/core.utils.cpp
+++ b/src/tests/core.utils.cpp
@@ -36,7 +36,8 @@ TEST(core, binary_io)
     binary_writer writer;
     writer.write(value);
 
-    binary_reader reader(writer.get_buffer());
+    auto buf = writer.get_buffer();
+    binary_reader reader(buf);
     int value3;
     reader.read(value3);
 
@@ -54,7 +55,8 @@ TEST(core, binary_io_with_pos)
     writer.write(value);
     writer.write(value2, pos);
     
-    binary_reader reader(writer.get_buffer());
+    auto buf = writer.get_buffer();
+    binary_reader reader(buf);
     int value3, value4;
     reader.read(value3);
     reader.read(value4);

--- a/src/tools/common/fault_injector.cpp
+++ b/src/tools/common/fault_injector.cpp
@@ -62,8 +62,8 @@ namespace dsn {
 
             CONFIG_FLD(double, rpc_request_drop_ratio, 0.0001)
             CONFIG_FLD(double, rpc_response_drop_ratio, 0.001)
-            CONFIG_FLD(double, disk_read_fail_ratio, 0.00001)
-            CONFIG_FLD(double, disk_write_fail_ratio, 0.00001)
+            CONFIG_FLD(double, disk_read_fail_ratio, 0.0)
+            CONFIG_FLD(double, disk_write_fail_ratio, 0.0)
 
             CONFIG_FLD(uint32_t, rpc_message_delay_ms_min, 0)
             CONFIG_FLD(uint32_t, rpc_message_delay_ms_max, 1000)

--- a/src/tools/simulator/env.sim.cpp
+++ b/src/tools/simulator/env.sim.cpp
@@ -61,13 +61,10 @@ sim_env_provider::sim_env_provider(env_provider* inner_provider)
 {
     task_worker::on_start.put_front(on_worker_start, "sim_env_provider::on_worker_start");
 
-    if (config()->get_value<bool>("tools.simulator", "use_given_random_seed", false))
+    _seed = config()->get_value<int>("tools.simulator", "random_seed", 0);
+    if (_seed == 0)
     {
-        _seed = config()->get_value<int>("tools.simulator", "random_seed", std::rand());
-    }
-    else
-    {
-        _seed = static_cast<int>(get_current_physical_time_ns());
+        _seed = static_cast<int>(get_current_physical_time_ns())  * std::rand();
     }
 
     derror("simulation.random seed for this round is %d", _seed);

--- a/src/tools/simulator/env.sim.h
+++ b/src/tools/simulator/env.sim.h
@@ -38,6 +38,8 @@ public:
     virtual uint64_t now_ns() const;
     virtual uint64_t random64(uint64_t min, uint64_t max);
 
+    static int seed() { return _seed; }
+
 private:
     static void on_worker_start(task_worker* worker);
     static int _seed;

--- a/src/tools/simulator/simulator.cpp
+++ b/src/tools/simulator/simulator.cpp
@@ -23,13 +23,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <dsn/tool/simulator.h>
-#include "scheduler.h"
-#include <dsn/tool/providers.common.h>
 
-#include "diske.sim.h"
-#include "env.sim.h"
-#include "task_engine.sim.h"
+# include <dsn/tool/simulator.h>
+# include "scheduler.h"
+# include <dsn/tool/providers.common.h>
+
+# include "diske.sim.h"
+# include "env.sim.h"
+# include "task_engine.sim.h"
+# include <dsn/internal/logging.h>
+
+# define __TITLE__ "tools.simulator"
 
 namespace dsn { namespace tools {
 
@@ -92,6 +96,15 @@ void simulator::install(service_spec& spec)
         if (tspec.queue_factory_name == "")
             tspec.queue_factory_name = ("dsn::tools::sim_task_queue");
     }
+
+    sys_exit.put_back(simulator::on_system_exit, "simulator");
+}
+
+void simulator::on_system_exit(sys_exit_type st)
+{
+    derror("system exits, you can replay this process using random seed %d",        
+        sim_env_provider::seed()
+        );
 }
 
 void simulator::run()


### PR DESCRIPTION
(1) enable global assertion in code generation
(2) use new system::run in code generation to enable starting role instances in separated processes
(3) refine replication checkers
(4) simplify random seed setting
(4) other nits

