### PR TITLE
Update nfs function and linux aio

### DIFF
--- a/src/tools/common/native_aio_provider.linux.cpp
+++ b/src/tools/common/native_aio_provider.linux.cpp
@@ -1,28 +1,28 @@
 /*
-* The MIT License (MIT)
-*
-* Copyright (c) 2015 Microsoft Corporation
-*
-* -=- Robust Distributed System Nucleus (rDSN) -=-
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 
 #include "native_aio_provider.linux.h"

--- a/src/tools/common/nfs_client_impl.h
+++ b/src/tools/common/nfs_client_impl.h
@@ -89,6 +89,7 @@ namespace dsn {
 				get_file_size_request  file_size_req;
 				aio_task_ptr           nfs_task;
                 std::atomic<int>       finished_files;
+				bool				   is_finished;
 
 				std::map<std::string, file_context*> file_context_map; // map file name and file info
 


### PR DESCRIPTION
I have fixed some issues as follows.

[nfs]

1. line 296 in nfs_client_impl.cpp: "bool completed = false; // should be initialized".

2. close file when finishing all copy tasks and delete error files.

3. pop multi-copy requests until reaching the max count.

4. add is_finished in struct user_request.

[linux aio]

1. line159, 289 in nfs_client_impl.cpp: "//reqc->local_write_task == task::get_current_task // commented" (There is a bug in nfs_client when running linux aio).

2. "events.data" seems not return "aio" successfully. But "iocb" can be got from "events.obj", so "aio" can be found through "container_of(iocb)". 

3. replace CONTAINING_RECORD by container_of.(CONTAINING_RECORD seems not work in linux)