### PR TITLE
fix sleep bug

### DIFF
--- a/src/core/service_api.cpp
+++ b/src/core/service_api.cpp
@@ -231,7 +231,7 @@ namespace dsn { namespace service {
                 #ifdef max
                 #undef max
                 #endif
-                std::this_thread::sleep_for(std::chrono::hours::max());
+                std::this_thread::sleep_for(std::chrono::seconds::max());
             }
 
             return true;


### PR DESCRIPTION
对于高版本的gcc，std::this_thread::sleep_for()本身的bug可能会导致函数执行失败。
如果用hours，因为高版本（gcc 5.1）实现用的是int64（以前是int），在std::this_thread::sleep_for()中转换为seconds会溢出成负值，导致nanosleep调用失败，程序提前退出。

gcc lib的diff如下：
```
-    typedef duration<int64_t,        nano> nanoseconds;
-    typedef duration<int64_t,       micro> microseconds;
-    typedef duration<int64_t,       milli> milliseconds;
-    typedef duration<int64_t             > seconds;
-    typedef duration<int,     ratio<  60>> minutes;
-    typedef duration<int,     ratio<3600>> hours;
+    /// nanoseconds
+    typedef duration<int64_t, nano>        nanoseconds;
+
+    /// microseconds
+    typedef duration<int64_t, micro>       microseconds;
+
+    /// milliseconds
+    typedef duration<int64_t, milli>       milliseconds;
+
+    /// seconds
+    typedef duration<int64_t>              seconds;
+
+    /// minutes
+    typedef duration<int64_t, ratio< 60>>   minutes;
+
+    /// hours
+    typedef duration<int64_t, ratio<3600>>  hours;
```

参见：<https://gcc.gnu.org/git/?p=gcc.git;a=blobdiff;f=libstdc%2B%2B-v3/include/std/chrono;h=50a2bbfca9c1727dd572a81b460a8b155fa89345;hp=911bf240b484064b51fbce45539c16e5308a8f10;hb=HEAD;hpb=c785a1c4509971833ab892a17e87d3b2a06ac271>