### PR TITLE
modified dsn_cli_run in C++ side

### DIFF
--- a/src/core/core/command_manager.cpp
+++ b/src/core/core/command_manager.cpp
@@ -57,7 +57,8 @@ DSN_API const char* dsn_cli_run(const char* command_line) // return command outp
     dsn::command_manager::instance().run_command(cmd, output);
 
     char* c_output = (char*)malloc(output.length() + 1);
-    strcpy(c_output, output.c_str());
+	memcpy(c_output, &output[0], output.length());
+	c_output[output.length()] = '\0';
     return c_output;
 }
 


### PR DESCRIPTION
This one is related to https://github.com/rDSN-Projects/rDSN.Python/pull/18

Sometimes the output string might be illegal, we need to be careful and use memcpy to handle situations like this.

