### PR TITLE
Use <cinttypes> instead of <inttypes.h>.

### DIFF
--- a/include/dsn/utility/ports.h
+++ b/include/dsn/utility/ports.h
@@ -70,8 +70,8 @@ __pragma(warning(disable:4127))
 # include <list>
 # include <algorithm>
 
-# define __STDC_FORMAT_MACROS
 // common c headers
+# include <cinttypes>
 # include <cassert>
 # include <cstring>
 # include <cstdlib>
@@ -79,8 +79,6 @@ __pragma(warning(disable:4127))
 # include <cstdio>
 # include <climits>
 # include <cerrno>
-# include <cstdint>
-# include <inttypes.h>
 
 // common utilities
 # include <atomic>

--- a/src/plugins/tools.common/native_aio_provider.linux.h
+++ b/src/plugins/tools.common/native_aio_provider.linux.h
@@ -41,12 +41,12 @@
 # include <dsn/tool_api.h>
 # include <dsn/utility/synchronize.h>
 # include <queue>
-# include <stdio.h>        /* for perror() */
-# include <sys/syscall.h>    /* for __NR_* definitions */
+# include <cinttypes>     /* uint64_t */
+# include <cstring>       /* memset() */
+# include <cstdio>        /* for perror() */
+# include <sys/syscall.h> /* for __NR_* definitions */
 # include <libaio.h>
-# include <fcntl.h>        /* O_RDWR */
-# include <string.h>        /* memset() */
-# include <inttypes.h>    /* uint64_t */
+# include <fcntl.h>       /* O_RDWR */
 
 namespace dsn {
     namespace tools {


### PR DESCRIPTION
Use <cinttypes> instead of <inttypes.h>.