### PR TITLE
Bug fixes

### DIFF
--- a/bin/Windows/start_zk.cmd
+++ b/bin/Windows/start_zk.cmd
@@ -50,7 +50,8 @@ for /F  %%A in (%ZK_SRC_CONFIG%) do (
 
 @mkdir %ZOOKEEPER_HOME%\data
 
-powershell -command "Start-Process %ZOOKEEPER_HOME%\bin\zkServer.cmd"
+REM powershell -command "Start-Process %ZOOKEEPER_HOME%\bin\zkServer.cmd"
+powershell -command "Start-Process -FilePath cmd.exe  -ArgumentList '/c title zk-%PORT%-%ZOOKEEPER_HOME%\bin\zkServer.cmd&&%ZOOKEEPER_HOME%\bin\zkServer.cmd'"
 
 REM CALL start cmd.exe /k "title zk-%PORT%&& %ZOOKEEPER_HOME%\bin\zkServer.cmd"
 

--- a/bin/Windows/start_zk.cmd
+++ b/bin/Windows/start_zk.cmd
@@ -51,7 +51,7 @@ for /F  %%A in (%ZK_SRC_CONFIG%) do (
 @mkdir %ZOOKEEPER_HOME%\data
 
 REM powershell -command "Start-Process %ZOOKEEPER_HOME%\bin\zkServer.cmd"
-powershell -command "Start-Process -FilePath cmd.exe  -ArgumentList '/c title zk-%PORT%-%ZOOKEEPER_HOME%\bin\zkServer.cmd&&%ZOOKEEPER_HOME%\bin\zkServer.cmd'"
+powershell -command "Start-Process -FilePath cmd.exe  -ArgumentList '/C title zk-%PORT%-%ZOOKEEPER_HOME%\bin\zkServer.cmd&&%ZOOKEEPER_HOME%\bin\zkServer.cmd'"
 
 REM CALL start cmd.exe /k "title zk-%PORT%&& %ZOOKEEPER_HOME%\bin\zkServer.cmd"
 

--- a/bin/Windows/stop_zk.cmd
+++ b/bin/Windows/stop_zk.cmd
@@ -12,8 +12,12 @@ IF "%PORT%" EQU "" (
     SET PORT=12181
 )
 
-TASKKILL /F /FI "WINDOWTITLE eq zk-%PORT% - %INSTALL_DIR%\%zk%\bin\zkServer.cmd"
-TASKKILL /F /FI "WINDOWTITLE eq zk-%PORT% - %INSTALL_DIR%\%zk%\bin\zkServer.cmd"
+REM TASKKILL /F /FI "WINDOWTITLE eq zk-%PORT% - %INSTALL_DIR%\%zk%\bin\zkServer.cmd"
+REM TASKKILL /F /FI "WINDOWTITLE eq zk-%PORT% - %INSTALL_DIR%\%zk%\bin\zkServer.cmd"
+FOR /L %%i IN (0, 1, 1) DO (
+    TASKKILL /F /FI "WINDOWTITLE eq zk-%PORT%-%ZOOKEEPER_HOME%\bin\zkServer.cmd"
+)
+
 GOTO exit
 
 :usage

--- a/bin/Windows/test.cmd
+++ b/bin/Windows/test.cmd
@@ -17,6 +17,12 @@ IF NOT EXIST %build_dir% (
 
 CALL %bin_dir%\echoc.exe 2 run the tests here ...
 
+:: set the path of built binaries
+SET DSN_BUILD_DIR_IN_PATH=
+@FOR %%P in ("%Path:;=";"%") DO @IF /I %%P=="%build_dir%\bin\%build_type%" SET DSN_BUILD_DIR_IN_PATH=true
+IF NOT DEFINED DSN_BUILD_DIR_IN_PATH SET Path=%build_dir%\bin\%build_type%;%build_dir%\lib;%Path%
+SET DSN_BUILD_DIR_IN_PATH=
+
 :: run dll-embedded unit tests
 SET DSN_TEST_HOST=%DSN_ROOT:/=\%\bin\dsn.svchost.exe
 IF EXIST "%build_dir%\bin\dsn.svchost\%build_type%\dsn.svchost.exe"  SET DSN_TEST_HOST=%build_dir%\bin\dsn.svchost\%build_type%\dsn.svchost.exe

--- a/bin/Windows/test.cmd
+++ b/bin/Windows/test.cmd
@@ -18,10 +18,11 @@ IF NOT EXIST %build_dir% (
 CALL %bin_dir%\echoc.exe 2 run the tests here ...
 
 :: set the path of built binaries
-SET DSN_BUILD_DIR_IN_PATH=
-@FOR %%P in ("%Path:;=";"%") DO @IF /I %%P=="%build_dir%\bin\%build_type%" SET DSN_BUILD_DIR_IN_PATH=true
-IF NOT DEFINED DSN_BUILD_DIR_IN_PATH SET Path=%build_dir%\bin\%build_type%;%build_dir%\lib;%Path%
-SET DSN_BUILD_DIR_IN_PATH=
+SET DSN_TMP_BUILD_DIR_IN_PATH=
+@FOR %%P in ("%Path:;=";"%") DO @IF /I %%P=="%build_dir%\bin\%build_type%" SET DSN_TMP_BUILD_DIR_IN_PATH=true
+:: SET DSN_TMP_OLD_PATH=%Path%
+IF NOT DEFINED DSN_TMP_BUILD_DIR_IN_PATH SET Path=%build_dir%\bin\%build_type%;%build_dir%\lib;%Path%
+SET DSN_TMP_BUILD_DIR_IN_PATH=
 
 :: run dll-embedded unit tests
 SET DSN_TEST_HOST=%DSN_ROOT:/=\%\bin\dsn.svchost.exe


### PR DESCRIPTION
1. Fix issue https://github.com/Microsoft/rDSN/issues/200 by setting the path of built binaries in %Path% environment variable.
2. Fix an issue that stop_zk.cmd cannot stop ZooKeeper because start_zk.cmd now uses powershell to start ZooKeeper so that the cmd window title has changed. Our fix is to set the title to "zk-%port%-%zkcmdpath%" and uses "cmd /C" instead of "/K" to launch ZooKeeper.