### PR TITLE
Windows platform update to support both Visual Studio 2015 and 2017

### DIFF
--- a/bin/Windows/install.cmd
+++ b/bin/Windows/install.cmd
@@ -27,7 +27,7 @@ goto exit
 
 :error
     CALL %bin_dir%\echoc.exe 4  "Usage: run.cmd install build_type(Debug|Release|RelWithDebInfo|MinSizeRel) build_dir [install_dir (DSN_ROOT by default)]"
-    exit 1
+    exit /B 1
     
 :exit
-    exit /b 0
+    exit /B 0

--- a/bin/Windows/pre-require.cmd
+++ b/bin/Windows/pre-require.cmd
@@ -1,62 +1,56 @@
 SET bin_dir=%~dp0
-SET TOP_DIR=%bin_dir%\..\..\
-SET has_cl=false
+IF %bin_dir:~-1%==\ SET bin_dir=%bin_dir:~0,-1%
+SET TOP_DIR=%bin_dir%\..\..
 
-cl >nul 2>&1 && SET has_cl=true
-
-IF "%has_cl%" NEQ "true" (
-    IF NOT "%VS140COMNTOOLS%"=="" (
-        CALL "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64
-    )  
+:: check VS environment
+SET DSN_TMP_VS_FOUND=
+IF "%VisualStudioVersion%"=="15.0" SET DSN_TMP_VS_FOUND=true
+IF "%VisualStudioVersion%"=="14.0" SET DSN_TMP_VS_FOUND=true
+IF NOT DEFINED DSN_TMP_VS_FOUND (
+    CALL %bin_dir%\echoc.exe 4 "Visusal Studio 2015 or 2017 is not found, please run 'x64 Native Tools Command Prompt' and try later"
+    SET DSN_TMP_VS_FOUND=
+    exit /B 1
 )
-
-IF NOT "%VS140COMNTOOLS%"=="" (
-    SET cmake_target=Visual Studio 14 2015 Win64
-    SET boost_lib=lib64-msvc-14.0
-    SET boost_package_name=boost_1_59_0_vc14_amd64.7z
-    SET boost_dir_name=boost_1_59_0
-)    
-
-IF "%cmake_target%"=="" (
-    ECHO "error: Visusal studio 2015 is not installed, please fix and try later"
-    GOTO error
-)
+SET DSN_TMP_VS_FOUND=
 
 IF NOT EXIST "%bin_dir%\ssed.exe" (
-    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/ssed.exe?raw=true
-    @move ssed.exe %bin_dir%
+    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/ssed.exe?raw=true -P %bin_dir%
 )
 
 IF NOT EXIST "%bin_dir%\thrift.exe" (
-    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/thrift/raw/master/pre-built/windows8.1/thrift.exe
-    @move thrift.exe %bin_dir%
+    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/thrift/raw/master/pre-built/windows8.1/thrift.exe -P %bin_dir%
 )
 
 
 IF NOT EXIST "%bin_dir%\7z.exe" (
-    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/7z.dll?raw=true
-    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/7z.exe?raw=true
-    @copy /y 7z.dll %bin_dir%\..\
-    @copy /y 7z.exe %bin_dir%\..\
-    @move 7z.dll %bin_dir%
-    @move 7z.exe %bin_dir%
+    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/7z.dll?raw=true -P %bin_dir%
+    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/7z.exe?raw=true -P %bin_dir%
+    @copy /y "%bin_dir%\7z.dll" "%bin_dir%\..\"
+    @copy /y "%bin_dir%\7z.exe" "%bin_dir%\..\"
 )
 
 IF NOT EXIST "%bin_dir%\php.exe" (
-    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/php5.dll?raw=true
-    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/php.exe?raw=true
-    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/php.ini?raw=true
-    @move php5.dll %bin_dir%
-    @move php.exe %bin_dir%
-    @move php.ini %bin_dir%
+    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/php5.dll?raw=true -P %bin_dir%
+    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/php.exe?raw=true -P %bin_dir%
+    CALL %bin_dir%\wget.exe --no-check-certificate https://github.com/imzhenyu/packages/raw/master/windows/php.ini?raw=true -P %bin_dir%
 )
 
-IF NOT EXIST "%TOP_DIR%\ext\%boost_dir_name%" (
-    CALL %bin_dir%\wget.exe --no-check-certificate http://github.com/imzhenyu/packages/blob/master/windows/%boost_package_name%?raw=true
-    CALL %bin_dir%\7z.exe x %boost_package_name% -y -o"%TOP_DIR%\ext\" > nul 
+SET DSN_TMP_BOOST_VERSION=1_64_0
+SET DSN_TMP_BOOST_PACKAGE_NAME=boost_%DSN_TMP_BOOST_VERSION%.7z
+IF NOT EXIST "%TOP_DIR%\ext\boost_%DSN_TMP_BOOST_VERSION%" (
+    IF NOT EXIST "%TOP_DIR%\ext\%DSN_TMP_BOOST_PACKAGE_NAME%" CALL %bin_dir%\wget.exe --no-check-certificate http://github.com/imzhenyu/packages/blob/master/windows/%DSN_TMP_BOOST_PACKAGE_NAME%?raw=true -P %TOP_DIR%\ext
+    ECHO Decompressing Boost %DSN_TMP_BOOST_VERSION% to "%TOP_DIR%\ext"
+    CALL %bin_dir%\7z.exe x "%TOP_DIR%\ext\%DSN_TMP_BOOST_PACKAGE_NAME%" -y -o"%TOP_DIR%\ext" > nul
 )
+SET DSN_TMP_BOOST_VERSION=
+SET DSN_TMP_BOOST_PACKAGE_NAME=
 
-IF NOT EXIST "%TOP_DIR%\ext\cmake-3.2.2" (
-    CALL %bin_dir%\wget.exe --no-check-certificate http://github.com/imzhenyu/packages/blob/master/windows/cmake-3.2.2.7z?raw=true
-    CALL %bin_dir%\7z.exe x cmake-3.2.2.7z -y -o"%TOP_DIR%\ext\" > nul
+SET DSN_TMP_CMAKE_VERSION=3.9.0
+SET DSN_TMP_CMAKE_PACKAGE_NAME=cmake-%DSN_TMP_CMAKE_VERSION%.7z
+IF NOT EXIST "%TOP_DIR%\ext\cmake-%DSN_TMP_CMAKE_VERSION%" (
+    IF NOT EXIST "%TOP_DIR%\ext\%DSN_TMP_CMAKE_PACKAGE_NAME%" CALL %bin_dir%\wget.exe --no-check-certificate http://github.com/imzhenyu/packages/blob/master/windows/%DSN_TMP_CMAKE_PACKAGE_NAME%?raw=true -P %TOP_DIR%\ext
+    ECHO Decompressing cmake %DSN_TMP_CMAKE_VERSION% to "%TOP_DIR%\ext"
+    CALL %bin_dir%\7z.exe x "%TOP_DIR%\ext\%DSN_TMP_CMAKE_PACKAGE_NAME%" -y -o"%TOP_DIR%\ext" > nul
 )
+SET DSN_TMP_CMAKE_VERSION=
+SET DSN_TMP_CMAKE_PACKAGE_NAME=

--- a/bin/Windows/start_zk.cmd
+++ b/bin/Windows/start_zk.cmd
@@ -24,7 +24,7 @@ IF NOT EXIST %INSTALL_DIR%\%zk% (
     IF NOT EXIST %zk%.tar.gz (
         CALL %bin_dir%\echoc.exe 4 download zookeeper package failed from  https://github.com/shengofsun/packages/raw/master/%zk%.tar.gz?raw=true
         popd
-        exit /b 1
+        exit /B 1
     ) 
     
     CALL %bin_dir%\7z.exe x %zk%.tar.gz -y -o"%INSTALL_DIR%"
@@ -65,4 +65,4 @@ GOTO exit
     GOTO:EOF
     
 :exit
-    exit /b 0
+    exit /B 0

--- a/bin/Windows/test.cmd
+++ b/bin/Windows/test.cmd
@@ -57,7 +57,7 @@ goto exit
 
 :error
     CALL %bin_dir%\echoc.exe 4  "Usage: run.cmd test build_type(Debug|Release|RelWithDebInfo|MinSizeRel) build_dir"
-    exit -1
+    exit /B -1
 
 :exit
-    exit /b 0
+    exit /B 0

--- a/bin/Windows/test.cmd
+++ b/bin/Windows/test.cmd
@@ -57,7 +57,7 @@ goto exit
 
 :error
     CALL %bin_dir%\echoc.exe 4  "Usage: run.cmd test build_type(Debug|Release|RelWithDebInfo|MinSizeRel) build_dir"
-    exit /B -1
+    exit /B 1
 
 :exit
     exit /B 0

--- a/bin/dsn.run.cmd
+++ b/bin/dsn.run.cmd
@@ -14,7 +14,7 @@ IF "%DSN_ROOT%" EQU "" SET DSN_ROOT=%TOP_DIR%\install
 @mkdir "%DSN_ROOT%"
 IF "%DSN_ROOT%" NEQ "" IF exist "%DSN_ROOT%" GOTO install_env
 CALL %bin_dir%\echoc.exe 4 %DSN_ROOT% does not exist
-exit /b 1
+exit /B 1
 
 :usage
     CALL %bin_dir%\echoc.exe 4  "Usage: run.cmd setup-env|pre-require|build|install|test|publish|republish|deploy|start|stop|cleanup|scds(stop-cleanup-deploy-start)|start_zk|stop_zk|onecluster"
@@ -42,12 +42,12 @@ CALL %bin_dir%\echoc.exe 2 DSN_ROOT\lib and DSN_ROOT\bin are added to PATH env.
 CALL :%1 %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 IF ERRORLEVEL 1 (
-    CALL %bin_dir%\echoc.exe 4 unknow command '%1'
+    CALL %bin_dir%\echoc.exe 4 unknown command '%1'
     CALL :usage
-    exit /b 1
+    exit /B 1
 )
 
-exit /b 0
+exit /B 0
 
 :pre-require
 :build


### PR DESCRIPTION
1. Users need to run 'x64 Native Tools Command Prompt' before building, testing rDSN because they may install both VS 2015 and 2017.
2. Upgrade cmake to 3.9.0 .
3. Upgrade boost to 1.64.0. The single package contains both VS 2015 and 2017 libraries, so the downloading size may be a little bigger (about 35MB).
4. Fix an issue that batch script errors exit the whole cmd.exe .