### PR TITLE
Fix -Woverloaded-virtual warnings.

### DIFF
--- a/include/dsn/tool-api/task.h
+++ b/include/dsn/tool-api/task.h
@@ -409,6 +409,7 @@ public:
         );
     DSN_API ~aio_task();
 
+    using task::enqueue;
     DSN_API void    enqueue(error_code err, size_t transferred_size);
     size_t          get_transferred_size() const { return _transferred_size; }
     disk_aio*       aio() { return _aio; }

--- a/include/dsn/utility/priority_queue.h
+++ b/include/dsn/utility/priority_queue.h
@@ -128,6 +128,7 @@ public:
         return r;
     }
 
+    using priority_queue<T, priority_count, TQueue>::dequeue;
     virtual T dequeue(/*out*/ long& ct, int millieseconds = 0xffffffff)
     {
         if (!_sema.wait(millieseconds))


### PR DESCRIPTION
Fix -Woverloaded-virtual warnings caused by hidden base class virtual functions.