### PR TITLE
Fix abort hang on Windows.

### DIFF
--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -63,7 +63,6 @@
 # include <unistd.h>
 # else
 # include <TlHelp32.h>
-# include <cstdlib>
 # endif
 
 # ifdef __TITLE__
@@ -288,12 +287,11 @@ bool run(
 )
 {
 # ifdef _WIN32
-    // On Windows, abort() (e.g. triggered by dassert/dsn_coredump) pops up a modal
-    // "Abort, Retry, Ignore" message box in "Debug" builds. This blocks waiting for
-    // user input and hangs unattended/automated testing. Clear the abort message and
-    // Windows Error Reporting flags so abort() terminates the process directly.
-    // See https://github.com/Microsoft/rDSN/issues/218
-    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    // On Windows, abort() (e.g. triggered by dassert/dsn_coredump) pops up a modal "Abort, Retry, Ignore" message box in "Debug" builds.
+    // This blocks waiting for user input and hangs unattended/automated testing.
+    // Clear the abort message and Windows Error Reporting flags so abort() terminates the process directly.
+    // See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/abort
+    ::_set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
 # endif
 
     ::dsn::task::set_tls_dsn_context(nullptr, nullptr, nullptr);

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -63,6 +63,7 @@
 # include <unistd.h>
 # else
 # include <TlHelp32.h>
+# include <cstdlib>
 # endif
 
 # ifdef __TITLE__
@@ -286,6 +287,15 @@ bool run(
     std::string& app_list
 )
 {
+# ifdef _WIN32
+    // On Windows, abort() (e.g. triggered by dassert/dsn_coredump) pops up a modal
+    // "Abort, Retry, Ignore" message box in "Debug" builds. This blocks waiting for
+    // user input and hangs unattended/automated testing. Clear the abort message and
+    // Windows Error Reporting flags so abort() terminates the process directly.
+    // See https://github.com/Microsoft/rDSN/issues/218
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+# endif
+
     ::dsn::task::set_tls_dsn_context(nullptr, nullptr, nullptr);
 
     dsn_all.engine_ready = false;


### PR DESCRIPTION
## Problem

Fixes #218.

On Windows, `abort()` — reached in rDSN via `dassert` → `dsn_coredump()` → `::abort()` — pops up a modal **"Abort, Retry, Ignore"** message box in `"Debug"` builds (the CRT `_WRITE_ABORT_MSG` behavior). During unattended/automated testing there is no one to dismiss the dialog, so the process hangs indefinitely.

## Fix

Call `_set_abort_behavior()` at rDSN startup (top of `run()` in `src/core/src/main.cpp`) to clear the `_WRITE_ABORT_MSG` and `_CALL_REPORTFAULT` flags. With these cleared, `abort()` terminates the process directly instead of showing a modal dialog or invoking Windows Error Reporting. rDSN already writes its own coredump (`coredump::write()`) before aborting, so the WER dump is redundant.

The call is placed at the very beginning of `run()`, before config loading and before any unit tests execute, so it covers every abort path (`dsn_coredump`, `configuration.cpp`, etc.). It is guarded by `# ifdef _WIN32` and has no effect on non-Windows builds.

## Notes

- `_set_abort_behavior` is part of the Microsoft CRT and is available in both Debug and Release, so the guard is `_WIN32` rather than `_DEBUG`.
- This is a Windows-only code path; it cannot be exercised by a build on the non-Windows CI host, but the snippet was syntax-checked against the documented `_set_abort_behavior(unsigned, unsigned)` signature.