### PR TITLE
Replace Boost lexical casts

### DIFF
--- a/include/dsn/cpp/utils.h
+++ b/include/dsn/cpp/utils.h
@@ -179,12 +179,22 @@ namespace dsn {
                 throw std::invalid_argument("lexical_cast_integer: empty string");
             }
 
+            if (str == "-" || str == "+")
+            {
+                throw std::invalid_argument("lexical_cast_integer: cannot convert \"" + str + "\"");
+            }
+
             std::istringstream iss(str);
             iss >> std::noskipws;
 
             std::intmax_t value = 0;
             if (!(iss >> value) || !iss.eof())
             {
+                if (iss.eof())
+                {
+                    throw std::out_of_range("lexical_cast_integer: out of range \"" + str + "\"");
+                }
+
                 throw std::invalid_argument("lexical_cast_integer: cannot convert \"" + str + "\"");
             }
 
@@ -210,6 +220,11 @@ namespace dsn {
                 throw std::invalid_argument("lexical_cast_integer: empty string");
             }
 
+            if (str == "-" || str == "+")
+            {
+                throw std::invalid_argument("lexical_cast_integer: cannot convert \"" + str + "\"");
+            }
+
             if (str[0] == '-')
             {
                 throw std::out_of_range("lexical_cast_integer: out of range \"" + str + "\"");
@@ -221,6 +236,11 @@ namespace dsn {
             std::uintmax_t value = 0;
             if (!(iss >> value) || !iss.eof())
             {
+                if (iss.eof())
+                {
+                    throw std::out_of_range("lexical_cast_integer: out of range \"" + str + "\"");
+                }
+
                 throw std::invalid_argument("lexical_cast_integer: cannot convert \"" + str + "\"");
             }
 

--- a/include/dsn/cpp/utils.h
+++ b/include/dsn/cpp/utils.h
@@ -38,7 +38,12 @@
 # include <dsn/cpp/auto_codes.h>
 # include <dsn/cpp/callocator.h>
 # include <dsn/cpp/safe_string.h>
+# include <cstdint>
 # include <functional>
+# include <limits>
+# include <sstream>
+# include <stdexcept>
+# include <type_traits>
 
 # ifdef __TITLE__
 # undef __TITLE__
@@ -160,6 +165,133 @@ namespace dsn {
         }
 
         inline int get_invalid_tid() { return -1; }
+
+        template <typename T>
+        inline typename std::enable_if<
+            std::is_integral<T>::value &&
+            std::is_signed<T>::value &&
+            !std::is_same<T, bool>::value,
+            T>::type
+        lexical_cast_integer(const std::string& str)
+        {
+            if (str.empty())
+            {
+                throw std::invalid_argument("lexical_cast_integer: empty string");
+            }
+
+            std::istringstream iss(str);
+            iss >> std::noskipws;
+
+            std::intmax_t value = 0;
+            if (!(iss >> value) || !iss.eof())
+            {
+                throw std::invalid_argument("lexical_cast_integer: cannot convert \"" + str + "\"");
+            }
+
+            if (value < static_cast<std::intmax_t>(std::numeric_limits<T>::min()) ||
+                value > static_cast<std::intmax_t>(std::numeric_limits<T>::max()))
+            {
+                throw std::out_of_range("lexical_cast_integer: out of range \"" + str + "\"");
+            }
+
+            return static_cast<T>(value);
+        }
+
+        template <typename T>
+        inline typename std::enable_if<
+            std::is_integral<T>::value &&
+            std::is_unsigned<T>::value &&
+            !std::is_same<T, bool>::value,
+            T>::type
+        lexical_cast_integer(const std::string& str)
+        {
+            if (str.empty())
+            {
+                throw std::invalid_argument("lexical_cast_integer: empty string");
+            }
+
+            if (str[0] == '-')
+            {
+                throw std::out_of_range("lexical_cast_integer: out of range \"" + str + "\"");
+            }
+
+            std::istringstream iss(str);
+            iss >> std::noskipws;
+
+            std::uintmax_t value = 0;
+            if (!(iss >> value) || !iss.eof())
+            {
+                throw std::invalid_argument("lexical_cast_integer: cannot convert \"" + str + "\"");
+            }
+
+            if (value > static_cast<std::uintmax_t>(std::numeric_limits<T>::max()))
+            {
+                throw std::out_of_range("lexical_cast_integer: out of range \"" + str + "\"");
+            }
+
+            return static_cast<T>(value);
+        }
+
+        inline bool lexical_cast_bool(const std::string& str)
+        {
+            if (str == "0")
+            {
+                return false;
+            }
+            else if (str == "1")
+            {
+                return true;
+            }
+            else
+            {
+                throw std::invalid_argument("lexical_cast_bool: cannot convert \"" + str + "\"");
+            }
+        }
+
+        template <typename T>
+        inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
+        lexical_cast_floating_point(const std::string& str)
+        {
+            if (str.empty())
+            {
+                throw std::invalid_argument("lexical_cast_floating_point: empty string");
+            }
+
+            std::istringstream iss(str);
+            iss >> std::noskipws;
+
+            T value = 0;
+            if (!(iss >> value) || !iss.eof())
+            {
+                throw std::invalid_argument("lexical_cast_floating_point: cannot convert \"" + str + "\"");
+            }
+
+            return value;
+        }
+
+        template <typename T>
+        inline typename std::enable_if<
+            std::is_integral<T>::value &&
+            !std::is_same<T, bool>::value,
+            T>::type
+        lexical_cast(const std::string& str)
+        {
+            return lexical_cast_integer<T>(str);
+        }
+
+        template <typename T>
+        inline typename std::enable_if<std::is_same<T, bool>::value, bool>::type
+        lexical_cast(const std::string& str)
+        {
+            return lexical_cast_bool(str);
+        }
+
+        template <typename T>
+        inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
+        lexical_cast(const std::string& str)
+        {
+            return lexical_cast_floating_point<T>(str);
+        }
 
         namespace filesystem {
 

--- a/src/core/src/aio.perf.test.cpp
+++ b/src/core/src/aio.perf.test.cpp
@@ -36,7 +36,6 @@
 #include <gtest/gtest.h>
 #include <dsn/service_api_cpp.h>
 #include <dsn/cpp/test_utils.h>
-#include <boost/lexical_cast.hpp>
 
 void aio_testcase(uint64_t block_size, size_t concurrency, bool is_write, bool shared)
 {

--- a/src/core/src/rpc.perf.test.cpp
+++ b/src/core/src/rpc.perf.test.cpp
@@ -35,8 +35,6 @@
 #include <gtest/gtest.h>
 #include <dsn/cpp/test_utils.h>
 #include <dsn/service_api_cpp.h>
-#include <boost/lexical_cast.hpp>
-
 
 void rpc_testcase(uint64_t block_size, size_t concurrency)
 {

--- a/src/core/src/rpc.test.cpp
+++ b/src/core/src/rpc.test.cpp
@@ -38,7 +38,6 @@
 #include <dsn/utility/priority_queue.h>
 #include "group_address.h"
 #include <dsn/cpp/test_utils.h>
-#include <boost/lexical_cast.hpp>
 #include <vector>
 #include <string>
 #include <queue>
@@ -66,7 +65,7 @@ static ::dsn::rpc_address dsn_address_from_string(const std::string& str)
     if (pos != std::string::npos)
     {
         std::string host = str.substr(0, pos);
-        uint16_t port = boost::lexical_cast<uint16_t>(str.substr(pos + 1));
+        uint16_t port = ::dsn::utils::lexical_cast<uint16_t>(str.substr(pos + 1));
         return ::dsn::rpc_address(host.c_str(), port);
     }
     else

--- a/src/core/src/rpc_message.corrupt.test.cpp
+++ b/src/core/src/rpc_message.corrupt.test.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include <dsn/service_api_cpp.h>
-#include <boost/lexical_cast.hpp>
 #include <iostream>
 #include <vector>
 #include <string>

--- a/src/core/src/task_queue.perf.test.cpp
+++ b/src/core/src/task_queue.perf.test.cpp
@@ -35,7 +35,6 @@
 #include <gtest/gtest.h>
 #include <dsn/service_api_cpp.h>
 #include <dsn/utility/priority_queue.h>
-#include <boost/lexical_cast.hpp>
 #include <dsn/cpp/test_utils.h>
 #include <mutex>
 #include <condition_variable>

--- a/src/core/src/utils.test.cpp
+++ b/src/core/src/utils.test.cpp
@@ -40,6 +40,7 @@
 # include <dsn/utility/autoref_ptr.h>
 # include <gtest/gtest.h>
 # include <limits>
+# include <sstream>
 # include <string>
 # ifdef _WIN32
 # include <BaseTsd.h>
@@ -49,6 +50,20 @@
 
 using namespace ::dsn;
 using namespace ::dsn::utils;
+
+static std::string signed_integer_to_string(std::intmax_t value)
+{
+    std::ostringstream oss;
+    oss << value;
+    return oss.str();
+}
+
+static std::string unsigned_integer_to_string(std::uintmax_t value)
+{
+    std::ostringstream oss;
+    oss << value;
+    return oss.str();
+}
 
 TEST(core, get_last_component)
 {
@@ -192,28 +207,78 @@ TEST(core, trim_string)
 
 TEST(core, lexical_cast_integer_accepts_valid_values)
 {
-    EXPECT_EQ(-128, static_cast<int>(lexical_cast<int8_t>("-128")));
-    EXPECT_EQ(127, static_cast<int>(lexical_cast<int8_t>("127")));
-    EXPECT_EQ(255, static_cast<int>(lexical_cast<uint8_t>("255")));
+    EXPECT_EQ(static_cast<int>(std::numeric_limits<int8_t>::min()),
+              static_cast<int>(lexical_cast<int8_t>(
+                  signed_integer_to_string(std::numeric_limits<int8_t>::min()))));
+    EXPECT_EQ(static_cast<int>(std::numeric_limits<int8_t>::max()),
+              static_cast<int>(lexical_cast<int8_t>(
+                  signed_integer_to_string(std::numeric_limits<int8_t>::max()))));
+    EXPECT_EQ(static_cast<int>(std::numeric_limits<uint8_t>::min()),
+              static_cast<int>(lexical_cast<uint8_t>(
+                  unsigned_integer_to_string(std::numeric_limits<uint8_t>::min()))));
+    EXPECT_EQ(static_cast<int>(std::numeric_limits<uint8_t>::max()),
+              static_cast<int>(lexical_cast<uint8_t>(
+                  unsigned_integer_to_string(std::numeric_limits<uint8_t>::max()))));
 
-    EXPECT_EQ((int16_t)-32768, lexical_cast<int16_t>("-32768"));
-    EXPECT_EQ((uint16_t)65535, lexical_cast<uint16_t>("65535"));
+    EXPECT_EQ(std::numeric_limits<int16_t>::min(),
+              lexical_cast<int16_t>(
+                  signed_integer_to_string(std::numeric_limits<int16_t>::min())));
+    EXPECT_EQ(std::numeric_limits<int16_t>::max(),
+              lexical_cast<int16_t>(
+                  signed_integer_to_string(std::numeric_limits<int16_t>::max())));
+    EXPECT_EQ(std::numeric_limits<uint16_t>::min(),
+              lexical_cast<uint16_t>(
+                  unsigned_integer_to_string(std::numeric_limits<uint16_t>::min())));
+    EXPECT_EQ(std::numeric_limits<uint16_t>::max(),
+              lexical_cast<uint16_t>(
+                  unsigned_integer_to_string(std::numeric_limits<uint16_t>::max())));
 
-    EXPECT_EQ((int32_t)-2147483647 - 1, lexical_cast<int32_t>("-2147483648"));
-    EXPECT_EQ((uint32_t)4294967295u, lexical_cast<uint32_t>("4294967295"));
+    EXPECT_EQ(std::numeric_limits<int32_t>::min(),
+              lexical_cast<int32_t>(
+                  signed_integer_to_string(std::numeric_limits<int32_t>::min())));
+    EXPECT_EQ(std::numeric_limits<int32_t>::max(),
+              lexical_cast<int32_t>(
+                  signed_integer_to_string(std::numeric_limits<int32_t>::max())));
+    EXPECT_EQ(std::numeric_limits<uint32_t>::min(),
+              lexical_cast<uint32_t>(
+                  unsigned_integer_to_string(std::numeric_limits<uint32_t>::min())));
+    EXPECT_EQ(std::numeric_limits<uint32_t>::max(),
+              lexical_cast<uint32_t>(
+                  unsigned_integer_to_string(std::numeric_limits<uint32_t>::max())));
 
-    EXPECT_EQ((int64_t)std::numeric_limits<int64_t>::min(),
-              lexical_cast<int64_t>("-9223372036854775808"));
-    EXPECT_EQ((uint64_t)std::numeric_limits<uint64_t>::max(),
-              lexical_cast<uint64_t>("18446744073709551615"));
+    EXPECT_EQ(std::numeric_limits<int64_t>::min(),
+              lexical_cast<int64_t>(
+                  signed_integer_to_string(std::numeric_limits<int64_t>::min())));
+    EXPECT_EQ(std::numeric_limits<int64_t>::max(),
+              lexical_cast<int64_t>(
+                  signed_integer_to_string(std::numeric_limits<int64_t>::max())));
+    EXPECT_EQ(std::numeric_limits<uint64_t>::min(),
+              lexical_cast<uint64_t>(
+                  unsigned_integer_to_string(std::numeric_limits<uint64_t>::min())));
+    EXPECT_EQ(std::numeric_limits<uint64_t>::max(),
+              lexical_cast<uint64_t>(
+                  unsigned_integer_to_string(std::numeric_limits<uint64_t>::max())));
 
-    EXPECT_EQ((size_t)42, lexical_cast<size_t>("42"));
+    EXPECT_EQ(std::numeric_limits<size_t>::min(),
+              lexical_cast<size_t>(
+                  unsigned_integer_to_string(std::numeric_limits<size_t>::min())));
+    EXPECT_EQ(std::numeric_limits<size_t>::max(),
+              lexical_cast<size_t>(
+                  unsigned_integer_to_string(std::numeric_limits<size_t>::max())));
 # ifdef _WIN32
-    EXPECT_EQ((SSIZE_T)-42, lexical_cast<SSIZE_T>("-42"));
-    EXPECT_EQ((SSIZE_T)42, lexical_cast<SSIZE_T>("42"));
+    EXPECT_EQ(std::numeric_limits<SSIZE_T>::min(),
+              lexical_cast<SSIZE_T>(
+                  signed_integer_to_string(std::numeric_limits<SSIZE_T>::min())));
+    EXPECT_EQ(std::numeric_limits<SSIZE_T>::max(),
+              lexical_cast<SSIZE_T>(
+                  signed_integer_to_string(std::numeric_limits<SSIZE_T>::max())));
 # else
-    EXPECT_EQ((ssize_t)-42, lexical_cast<ssize_t>("-42"));
-    EXPECT_EQ((ssize_t)42, lexical_cast<ssize_t>("42"));
+    EXPECT_EQ(std::numeric_limits<ssize_t>::min(),
+              lexical_cast<ssize_t>(
+                  signed_integer_to_string(std::numeric_limits<ssize_t>::min())));
+    EXPECT_EQ(std::numeric_limits<ssize_t>::max(),
+              lexical_cast<ssize_t>(
+                  signed_integer_to_string(std::numeric_limits<ssize_t>::max())));
 # endif
     EXPECT_EQ(123, lexical_cast<int>("+123"));
 }
@@ -226,19 +291,50 @@ TEST(core, lexical_cast_integer_rejects_invalid_values)
     EXPECT_THROW(lexical_cast<int>("12 3"), std::invalid_argument);
     EXPECT_THROW(lexical_cast<int>("123abc"), std::invalid_argument);
     EXPECT_THROW(lexical_cast<int>("--12"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int>("-"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int>("+"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<unsigned int>("-"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<unsigned int>("+"), std::invalid_argument);
 
     EXPECT_THROW(lexical_cast<int8_t>("-129"), std::out_of_range);
     EXPECT_THROW(lexical_cast<int8_t>("128"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<uint8_t>("-1"), std::out_of_range);
     EXPECT_THROW(lexical_cast<uint8_t>("256"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<int16_t>("-32769"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<int16_t>("32768"), std::out_of_range);
     EXPECT_THROW(lexical_cast<uint16_t>("65536"), std::out_of_range);
     EXPECT_THROW(lexical_cast<uint16_t>("-1"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<int32_t>("-2147483649"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<int32_t>("2147483648"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<uint32_t>("-1"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<uint32_t>("4294967296"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<int64_t>("-9223372036854775809"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<int64_t>("9223372036854775808"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<uint64_t>("18446744073709551616"), std::out_of_range);
     EXPECT_THROW(lexical_cast<size_t>("-1"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<size_t>("18446744073709551616"), std::out_of_range);
     EXPECT_THROW(lexical_cast<uint64_t>("-1"), std::out_of_range);
 # ifdef _WIN32
+    EXPECT_THROW(lexical_cast<SSIZE_T>("-9223372036854775809"), std::out_of_range);
     EXPECT_THROW(lexical_cast<SSIZE_T>("9223372036854775808"), std::out_of_range);
 # else
+    EXPECT_THROW(lexical_cast<ssize_t>("-9223372036854775809"), std::out_of_range);
     EXPECT_THROW(lexical_cast<ssize_t>("9223372036854775808"), std::out_of_range);
 # endif
+
+    EXPECT_THROW(lexical_cast<int64_t>("9223372036854775808 "), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int64_t>(" 9223372036854775808"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int64_t>("9223372036854775808ab"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int64_t>("9223372036854775808 ab"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int64_t>("-9223372036854775809 "), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<uint64_t>("18446744073709551616 "), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<uint64_t>("18446744073709551616ab"), std::invalid_argument);
+
+    EXPECT_THROW(lexical_cast<int64_t>("9223372036854775807 "), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int64_t>(" 9223372036854775807"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int64_t>("9223372036854775807ab"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<uint64_t>("18446744073709551615 "), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<uint64_t>("18446744073709551615ab"), std::invalid_argument);
 }
 
 TEST(core, lexical_cast_bool_accepts_valid_values)

--- a/src/core/src/utils.test.cpp
+++ b/src/core/src/utils.test.cpp
@@ -51,20 +51,6 @@
 using namespace ::dsn;
 using namespace ::dsn::utils;
 
-static std::string signed_integer_to_string(std::intmax_t value)
-{
-    std::ostringstream oss;
-    oss << value;
-    return oss.str();
-}
-
-static std::string unsigned_integer_to_string(std::uintmax_t value)
-{
-    std::ostringstream oss;
-    oss << value;
-    return oss.str();
-}
-
 TEST(core, get_last_component)
 {
     ASSERT_EQ("a", get_last_component("a", "/"));
@@ -205,8 +191,45 @@ TEST(core, trim_string)
     EXPECT_EQ(std::string(r), "x x x x");
 }
 
+static std::string signed_integer_to_string(std::intmax_t value)
+{
+    std::ostringstream oss;
+    oss << value;
+    return oss.str();
+}
+
+static std::string unsigned_integer_to_string(std::uintmax_t value)
+{
+    std::ostringstream oss;
+    oss << value;
+    return oss.str();
+}
+
 TEST(core, lexical_cast_integer_accepts_valid_values)
 {
+    EXPECT_EQ(-12, static_cast<int>(lexical_cast<int8_t>("-12")));
+    EXPECT_EQ(12, static_cast<int>(lexical_cast<int8_t>("12")));
+    EXPECT_EQ(123, static_cast<int>(lexical_cast<uint8_t>("123")));
+
+    EXPECT_EQ((int16_t)-12345, lexical_cast<int16_t>("-12345"));
+    EXPECT_EQ((uint16_t)12345, lexical_cast<uint16_t>("12345"));
+
+    EXPECT_EQ((int32_t)-123456789, lexical_cast<int32_t>("-123456789"));
+    EXPECT_EQ((uint32_t)123456789u, lexical_cast<uint32_t>("123456789"));
+
+    EXPECT_EQ((int64_t)-123456789012345LL, lexical_cast<int64_t>("-123456789012345"));
+    EXPECT_EQ((uint64_t)123456789012345ULL, lexical_cast<uint64_t>("123456789012345"));
+
+    EXPECT_EQ((size_t)42, lexical_cast<size_t>("42"));
+# ifdef _WIN32
+    EXPECT_EQ((SSIZE_T)-42, lexical_cast<SSIZE_T>("-42"));
+    EXPECT_EQ((SSIZE_T)42, lexical_cast<SSIZE_T>("42"));
+# else
+    EXPECT_EQ((ssize_t)-42, lexical_cast<ssize_t>("-42"));
+    EXPECT_EQ((ssize_t)42, lexical_cast<ssize_t>("42"));
+# endif
+    EXPECT_EQ(123, lexical_cast<int>("+123"));
+
     EXPECT_EQ(static_cast<int>(std::numeric_limits<int8_t>::min()),
               static_cast<int>(lexical_cast<int8_t>(
                   signed_integer_to_string(std::numeric_limits<int8_t>::min()))));
@@ -280,7 +303,6 @@ TEST(core, lexical_cast_integer_accepts_valid_values)
               lexical_cast<ssize_t>(
                   signed_integer_to_string(std::numeric_limits<ssize_t>::max())));
 # endif
-    EXPECT_EQ(123, lexical_cast<int>("+123"));
 }
 
 TEST(core, lexical_cast_integer_rejects_invalid_values)

--- a/src/core/src/utils.test.cpp
+++ b/src/core/src/utils.test.cpp
@@ -39,6 +39,13 @@
 # include <dsn/utility/link.h>
 # include <dsn/utility/autoref_ptr.h>
 # include <gtest/gtest.h>
+# include <limits>
+# include <string>
+# ifdef _WIN32
+# include <BaseTsd.h>
+# else
+# include <sys/types.h>
+# endif
 
 using namespace ::dsn;
 using namespace ::dsn::utils;
@@ -183,6 +190,91 @@ TEST(core, trim_string)
     EXPECT_EQ(std::string(r), "x x x x");
 }
 
+TEST(core, lexical_cast_integer_accepts_valid_values)
+{
+    EXPECT_EQ(-128, static_cast<int>(lexical_cast<int8_t>("-128")));
+    EXPECT_EQ(127, static_cast<int>(lexical_cast<int8_t>("127")));
+    EXPECT_EQ(255, static_cast<int>(lexical_cast<uint8_t>("255")));
+
+    EXPECT_EQ((int16_t)-32768, lexical_cast<int16_t>("-32768"));
+    EXPECT_EQ((uint16_t)65535, lexical_cast<uint16_t>("65535"));
+
+    EXPECT_EQ((int32_t)-2147483647 - 1, lexical_cast<int32_t>("-2147483648"));
+    EXPECT_EQ((uint32_t)4294967295u, lexical_cast<uint32_t>("4294967295"));
+
+    EXPECT_EQ((int64_t)std::numeric_limits<int64_t>::min(),
+              lexical_cast<int64_t>("-9223372036854775808"));
+    EXPECT_EQ((uint64_t)std::numeric_limits<uint64_t>::max(),
+              lexical_cast<uint64_t>("18446744073709551615"));
+
+    EXPECT_EQ((size_t)42, lexical_cast<size_t>("42"));
+# ifdef _WIN32
+    EXPECT_EQ((SSIZE_T)-42, lexical_cast<SSIZE_T>("-42"));
+    EXPECT_EQ((SSIZE_T)42, lexical_cast<SSIZE_T>("42"));
+# else
+    EXPECT_EQ((ssize_t)-42, lexical_cast<ssize_t>("-42"));
+    EXPECT_EQ((ssize_t)42, lexical_cast<ssize_t>("42"));
+# endif
+    EXPECT_EQ(123, lexical_cast<int>("+123"));
+}
+
+TEST(core, lexical_cast_integer_rejects_invalid_values)
+{
+    EXPECT_THROW(lexical_cast<int>(""), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int>(" 123"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int>("123 "), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int>("12 3"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int>("123abc"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<int>("--12"), std::invalid_argument);
+
+    EXPECT_THROW(lexical_cast<int8_t>("-129"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<int8_t>("128"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<uint8_t>("256"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<uint16_t>("65536"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<uint16_t>("-1"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<size_t>("-1"), std::out_of_range);
+    EXPECT_THROW(lexical_cast<uint64_t>("-1"), std::out_of_range);
+# ifdef _WIN32
+    EXPECT_THROW(lexical_cast<SSIZE_T>("9223372036854775808"), std::out_of_range);
+# else
+    EXPECT_THROW(lexical_cast<ssize_t>("9223372036854775808"), std::out_of_range);
+# endif
+}
+
+TEST(core, lexical_cast_bool_accepts_valid_values)
+{
+    EXPECT_FALSE(lexical_cast<bool>("0"));
+    EXPECT_TRUE(lexical_cast<bool>("1"));
+}
+
+TEST(core, lexical_cast_bool_rejects_invalid_values)
+{
+    EXPECT_THROW(lexical_cast<bool>(""), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<bool>("2"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<bool>("true"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<bool>("false"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<bool>("False"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<bool>(" 1"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<bool>("1 "), std::invalid_argument);
+}
+
+TEST(core, lexical_cast_floating_point_accepts_valid_values)
+{
+    EXPECT_FLOAT_EQ(1.25f, lexical_cast<float>("1.25"));
+    EXPECT_DOUBLE_EQ(-0.03125, lexical_cast<double>("-3.125e-2"));
+    EXPECT_EQ((long double)0.125, lexical_cast<long double>("0.125"));
+    EXPECT_DOUBLE_EQ(123.0, lexical_cast<double>("+123"));
+}
+
+TEST(core, lexical_cast_floating_point_rejects_invalid_values)
+{
+    EXPECT_THROW(lexical_cast<float>(""), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<float>(" 1.25"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<float>("1.25 "), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<double>("1.2.3"), std::invalid_argument);
+    EXPECT_THROW(lexical_cast<double>("abc"), std::invalid_argument);
+}
+
 TEST(core, dlink)
 {
     dlink links[10];
@@ -293,5 +385,3 @@ TEST(core, ref_ptr)
     z = std::move(foo_ptr());
     EXPECT_TRUE(count == 0);
 }
-
-


### PR DESCRIPTION
Add dsn::utils::lexical_cast helpers for numeric and bool parsing, cover them in utils tests, remove obsolete Boost lexical_cast includes from core tests, and sync the external dist service module.