### PR TITLE
Replace Boost usage.

### DIFF
--- a/include/dsn/cpp/utils.h
+++ b/include/dsn/cpp/utils.h
@@ -313,6 +313,10 @@ namespace dsn {
             return lexical_cast_floating_point<T>(str);
         }
 
+        namespace asio {
+            extern std::string host_name();
+        }
+
         namespace filesystem {
 
             extern bool get_absolute_path(const std::string& path1, std::string& path2);

--- a/src/core/src/utils.test.cpp
+++ b/src/core/src/utils.test.cpp
@@ -191,6 +191,13 @@ TEST(core, trim_string)
     EXPECT_EQ(std::string(r), "x x x x");
 }
 
+TEST(core, host_name)
+{
+    auto hostname = asio::host_name();
+    EXPECT_FALSE(hostname.empty());
+    EXPECT_EQ(std::string::npos, hostname.find('\0'));
+}
+
 static std::string signed_integer_to_string(std::intmax_t value)
 {
     std::ostringstream oss;

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -33,11 +33,18 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
+# if defined(_WIN32)
+# include <WinSock2.h>
+# else
+# include <unistd.h>
+# endif
 # include <dsn/cpp/utils.h>
 # include <dsn/cpp/blob.h>
 # include <dsn/cpp/address.h>
 # include <dsn/cpp/auto_codes.h>
 # include <dsn/utility/singleton.h>
+# include <cerrno>
+# include <cstring>
 # include <sys/types.h>
 # include <sys/stat.h>
 # include <random>
@@ -282,7 +289,30 @@ namespace dsn {
     }
 }
 
-namespace  dsn 
+namespace dsn
+{
+    namespace utils
+    {
+        namespace asio
+        {
+            std::string host_name()
+            {
+                char name[1024];
+
+                int result = ::gethostname(name, sizeof(name));
+                if (result != 0)
+                {
+                    derror("gethostname failed, err = %s", strerror(errno));
+                    return std::string();
+                }
+                name[sizeof(name) - 1] = '\0';
+                return std::string(name);
+            }
+        }
+    }
+}
+
+namespace dsn
 {
     binary_reader::binary_reader(const blob& blob)
     {
@@ -642,7 +672,3 @@ namespace  dsn
         return true;
     }
 } // end namespace dsn
-
-
-
-

--- a/src/plugins/tools.common/simple_perf_counter.cpp
+++ b/src/plugins/tools.common/simple_perf_counter.cpp
@@ -201,7 +201,7 @@ namespace dsn {
             };
 
         private:
-            inline void insert_calc_queue(boost::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
+            inline void insert_calc_queue(std::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
             {
                 calc_tail++;
                 ctx->calc_queue[calc_tail][_LEFT] = left;
@@ -211,7 +211,7 @@ namespace dsn {
                 return;
             }
 
-            uint64_t find_mid(boost::shared_ptr<compute_context>& ctx, int left, int right)
+            uint64_t find_mid(std::shared_ptr<compute_context>& ctx, int left, int right)
             {
                 if (left == right)
                     return ctx->mid_tmp[left];
@@ -234,7 +234,7 @@ namespace dsn {
                 return find_mid(ctx, 0, (right - left - 1) / 5);
             }
 
-            inline void select(boost::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
+            inline void select(std::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
             {
                 int i, j, index, now;
                 uint64_t mid;
@@ -281,7 +281,7 @@ namespace dsn {
                 return;
             }
 
-            void   calc(boost::shared_ptr<compute_context>& ctx)
+            void   calc(std::shared_ptr<compute_context>& ctx)
             {
                 if (_tail == 0)
                     return;
@@ -315,7 +315,7 @@ namespace dsn {
                     // only when others also hold the reference
                     if (this->get_count() > 1)
                     {
-                        boost::shared_ptr<compute_context> ctx(new compute_context());
+                        std::shared_ptr<compute_context> ctx(new compute_context());
                         calc(ctx);
 
                         timer->expires_from_now(boost::posix_time::seconds(_counter_computation_interval_seconds));

--- a/src/plugins/tools.common/simple_perf_counter_v2_atomic.cpp
+++ b/src/plugins/tools.common/simple_perf_counter_v2_atomic.cpp
@@ -269,7 +269,7 @@ namespace dsn {
                 int      calc_queue[MAX_QUEUE_LENGTH][4];
             };
 
-            inline void insert_calc_queue(boost::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
+            inline void insert_calc_queue(std::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
             {
                 calc_tail++;
                 ctx->calc_queue[calc_tail][_LEFT] = left;
@@ -279,7 +279,7 @@ namespace dsn {
                 return;
             }
 
-            uint64_t find_mid(boost::shared_ptr<compute_context>& ctx, int left, int right)
+            uint64_t find_mid(std::shared_ptr<compute_context>& ctx, int left, int right)
             {
                 if (left == right)
                     return ctx->mid_tmp[left];
@@ -301,7 +301,7 @@ namespace dsn {
                 return find_mid(ctx, 0, (right - left - 1) / 5);
             }
 
-            inline void select(boost::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
+            inline void select(std::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
             {
                 int i, j, index, now;
                 uint64_t mid;
@@ -348,7 +348,7 @@ namespace dsn {
                 return;
             }
 
-            void   calc(boost::shared_ptr<compute_context>& ctx)
+            void   calc(std::shared_ptr<compute_context>& ctx)
             {
                 int _num = _tail > MAX_QUEUE_LENGTH ? MAX_QUEUE_LENGTH : _tail;
 
@@ -382,7 +382,7 @@ namespace dsn {
                     // only when others also hold the reference
                     if (this->get_count() > 1)
                     {
-                        boost::shared_ptr<compute_context> ctx(new compute_context());
+                        std::shared_ptr<compute_context> ctx(new compute_context());
                         calc(ctx);
 
                         timer->expires_from_now(boost::posix_time::seconds(_counter_computation_interval_seconds));

--- a/src/plugins/tools.common/simple_perf_counter_v2_fast.cpp
+++ b/src/plugins/tools.common/simple_perf_counter_v2_fast.cpp
@@ -269,7 +269,7 @@ namespace dsn {
                 int      calc_queue[MAX_QUEUE_LENGTH][4];
             };
 
-            inline void insert_calc_queue(boost::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
+            inline void insert_calc_queue(std::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
             {
                 calc_tail++;
                 ctx->calc_queue[calc_tail][_LEFT] = left;
@@ -279,7 +279,7 @@ namespace dsn {
                 return;
             }
 
-            uint64_t find_mid(boost::shared_ptr<compute_context>& ctx, int left, int right)
+            uint64_t find_mid(std::shared_ptr<compute_context>& ctx, int left, int right)
             {
                 if (left == right)
                     return ctx->mid_tmp[left];
@@ -301,7 +301,7 @@ namespace dsn {
                 return find_mid(ctx, 0, (right - left - 1) / 5);
             }
 
-            inline void select(boost::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
+            inline void select(std::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
             {
                 int i, j, index, now;
                 uint64_t mid;
@@ -348,7 +348,7 @@ namespace dsn {
                 return;
             }
 
-            void   calc(boost::shared_ptr<compute_context>& ctx)
+            void   calc(std::shared_ptr<compute_context>& ctx)
             {
                 int _num = _tail > MAX_QUEUE_LENGTH ? MAX_QUEUE_LENGTH : _tail;
 
@@ -382,7 +382,7 @@ namespace dsn {
                     // only when others also hold the reference
                     if (this->get_count() > 1)
                     {
-                        boost::shared_ptr<compute_context> ctx(new compute_context());
+                        std::shared_ptr<compute_context> ctx(new compute_context());
                         calc(ctx);
 
                         timer->expires_from_now(boost::posix_time::seconds(_counter_computation_interval_seconds));

--- a/src/plugins/tools.emulator/network.sim.cpp
+++ b/src/plugins/tools.emulator/network.sim.cpp
@@ -180,7 +180,8 @@ namespace dsn { namespace tools {
         dassert(channel == RPC_CHANNEL_TCP || channel == RPC_CHANNEL_UDP, "invalid given channel %s", channel.to_string());
 
         _address = ::dsn::rpc_address("localhost", port);
-        auto hostname = boost::asio::ip::host_name();
+        auto hostname = ::dsn::utils::asio::host_name();
+        dassert(!hostname.empty(), "fail to get local hostname");
         if (!client_only)
         {
             for (int i = NET_HDR_INVALID + 1; i <= network_header_format::max_value(); i++)


### PR DESCRIPTION
1. Use std::shared_ptr in perf counters.
2. Add non-Boost hostname helper.