### PR TITLE
Fix ubuntu build

### DIFF
--- a/src/plugins/tools.emulator/scheduler.cpp
+++ b/src/plugins/tools.emulator/scheduler.cpp
@@ -38,6 +38,7 @@
 # include <dsn/tool-api/node_scoper.h>
 # include "scheduler.h"
 # include "env.sim.h"
+# include <algorithm>
 # include <set>
 
 # ifdef __TITLE__
@@ -291,7 +292,19 @@ void scheduler::schedule()
             }
 
             // randomize the events, and see
+# if 0
             std::random_shuffle(events->begin(), events->end(), [](int n) { return dsn_random32(0, n - 1); });
+# endif
+            auto n = events->size();
+            if (n > 1)
+            {
+                auto first = events->begin();
+                for (auto i = n - 1; i > 0; --i)
+                {
+                    auto j = static_cast<decltype(n)>(dsn_random32(0, static_cast<uint32_t>(i)));
+                    std::iter_swap(first + i, first + j);
+                }
+            }
 
             for (auto e : *events)
             {


### PR DESCRIPTION
1. Fix deprecated scheduler shuffle
Replace the deprecated std::random_shuffle call with an explicit Fisher-Yates shuffle that keeps using dsn_random32 for bounded random indices. Keep the original line disabled for reference.

2. Fix pessimizing move in hpc tail logger
Return the stringstream result directly instead of applying std::move to the temporary string. This avoids GCC 14's -Wpessimizing-move warning, which fails Ubuntu 24.04 builds under -Werror, while preserving behavior on older compilers.