### PR TITLE
Fix Windows header and build style inconsistencies

### DIFF
--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -622,6 +622,10 @@ function(dsn_setup_packages)
         set(DSN_SYSTEM_LIBS ${DSN_SYSTEM_LIBS} ${DSN_LIB_UTIL})
     endif()
 
+    if(WIN32)
+        list(APPEND DSN_SYSTEM_LIBS ws2_32 psapi)
+    endif()
+
     set(DSN_SYSTEM_LIBS
         ${DSN_SYSTEM_LIBS}
         ${CMAKE_THREAD_LIBS_INIT}

--- a/include/dsn/utility/module_init.cpp.h
+++ b/include/dsn/utility/module_init.cpp.h
@@ -63,12 +63,12 @@ extern void dsn_module_init();
 
 # define MODULE_INIT_END }
 
-# ifdef _WIN32
+# if defined(_WIN32)
 # include <windows.h>
 
-#ifdef _MANAGED
-#pragma managed(push, off)
-#endif
+# if defined(_MANAGED)
+# pragma managed(push, off)
+# endif
 
 bool APIENTRY DllMain(HMODULE hModule,
     DWORD  ul_reason_for_call,
@@ -89,8 +89,8 @@ bool APIENTRY DllMain(HMODULE hModule,
     return TRUE;
 }
 
-#ifdef _MANAGED
-#pragma managed(pop)
-#endif
+# if defined(_MANAGED)
+# pragma managed(pop)
+# endif
 
 # endif

--- a/include/dsn/utility/module_init.cpp.h
+++ b/include/dsn/utility/module_init.cpp.h
@@ -64,7 +64,7 @@ extern void dsn_module_init();
 # define MODULE_INIT_END }
 
 # ifdef _WIN32
-# include <Windows.h>
+# include <windows.h>
 
 #ifdef _MANAGED
 #pragma managed(push, off)
@@ -94,4 +94,3 @@ bool APIENTRY DllMain(HMODULE hModule,
 #endif
 
 # endif
-

--- a/include/dsn/utility/ports.h
+++ b/include/dsn/utility/ports.h
@@ -37,7 +37,7 @@
 
 #if defined(_WIN32)
 
-# include <Windows.h>
+# include <windows.h>
 
 __pragma(warning(disable:4127))
 
@@ -113,7 +113,7 @@ __pragma(warning(disable:4127))
 
 # ifdef _WIN32
 
-// make sure to include <Winsock2.h> before the usage
+// make sure to include <winsock2.h> before the usage
 
 # ifndef be16toh
 # define be16toh(x) ntohs(x)
@@ -123,15 +123,15 @@ __pragma(warning(disable:4127))
 # define htobe16(x) htons(x)
 # endif
 
-static_assert (sizeof(int32_t) == sizeof(long),
-    "sizeof(int32_t) == sizeof(u_long) for use of ntohl");
+static_assert (sizeof(uint32_t) == sizeof(u_long),
+    "sizeof(uint32_t) == sizeof(u_long) for use of ntohl");
 
 # ifndef be32toh
-# define be32toh(x) ntohl(x)
+# define be32toh(x) static_cast<uint32_t>(ntohl(static_cast<u_long>(x)))
 # endif
 
 # ifndef htobe32
-# define htobe32(x) htonl(x)
+# define htobe32(x) static_cast<uint32_t>(htonl(static_cast<u_long>(x)))
 # endif
 
 # ifndef be64toh

--- a/include/dsn/utility/ports.h
+++ b/include/dsn/utility/ports.h
@@ -35,7 +35,7 @@
 
 # pragma once
 
-#if defined(_WIN32)
+# if defined(_WIN32)
 
 # include <windows.h>
 
@@ -50,14 +50,14 @@ __pragma(warning(disable:4127))
 
 # define __selectany __attribute__((weak)) extern 
 
-# ifndef O_BINARY
+# if !defined(O_BINARY)
 # define O_BINARY 0
-#endif
+# endif
 
-#else
+# else
 
-#error "unsupported platform"
-#endif
+# error "unsupported platform"
+# endif
 
 // stl headers
 # include <string>
@@ -85,25 +85,25 @@ __pragma(warning(disable:4127))
 # include <atomic>
 
 // common macros and data structures
-# ifndef FIELD_OFFSET
+# if !defined(FIELD_OFFSET)
 # define FIELD_OFFSET(s, field)  (((size_t)&((s *)(10))->field) - 10)
 # endif
 
-# ifndef CONTAINING_RECORD 
+# if !defined(CONTAINING_RECORD)
 # define CONTAINING_RECORD(address, type, field) \
     ((type *)((char*)(address)-FIELD_OFFSET(type, field)))
 # endif
 
-# ifndef MAX_COMPUTERNAME_LENGTH
+# if !defined(MAX_COMPUTERNAME_LENGTH)
 # define MAX_COMPUTERNAME_LENGTH 32
 # endif
 
-# ifndef ARRAYSIZE
+# if !defined(ARRAYSIZE)
 # define ARRAYSIZE(a) \
     ((sizeof(a) / sizeof(*(a))) / static_cast<size_t>(!(sizeof(a) % sizeof(*(a)))))
 # endif
 
-# ifndef snprintf_p
+# if !defined(snprintf_p)
 # if defined(_WIN32)
 # define snprintf_p sprintf_s
 # else
@@ -111,30 +111,30 @@ __pragma(warning(disable:4127))
 # endif
 # endif
 
-# ifdef _WIN32
+# if defined(_WIN32)
 
 // make sure to include <winsock2.h> before the usage
 
-# ifndef be16toh
+# if !defined(be16toh)
 # define be16toh(x) ntohs(x)
 # endif
 
-# ifndef htobe16
+# if !defined(htobe16)
 # define htobe16(x) htons(x)
 # endif
 
 static_assert (sizeof(uint32_t) == sizeof(u_long),
     "sizeof(uint32_t) == sizeof(u_long) for use of ntohl");
 
-# ifndef be32toh
+# if !defined(be32toh)
 # define be32toh(x) static_cast<uint32_t>(ntohl(static_cast<u_long>(x)))
 # endif
 
-# ifndef htobe32
+# if !defined(htobe32)
 # define htobe32(x) static_cast<uint32_t>(htonl(static_cast<u_long>(x)))
 # endif
 
-# ifndef be64toh
+# if !defined(be64toh)
 # define be64toh(x) ( (be32toh((x)>>32)&0xffffffff) | ( be32toh( (x)&0xffffffff ) << 32 ) )
 # endif
 
@@ -145,27 +145,27 @@ static_assert (sizeof(uint32_t) == sizeof(u_long),
 
 # include <libkern/OSByteOrder.h>
 
-# ifndef be16toh
+# if !defined(be16toh)
 # define be16toh(x) OSSwapBigToHostInt16(x)
 # endif
 
-# ifndef htobe16
+# if !defined(htobe16)
 # define htobe16(x) OSSwapHostToBigInt16(x)
 # endif
 
-# ifndef be32toh
+# if !defined(be32toh)
 # define be32toh(x) OSSwapBigToHostInt32(x)
 # endif
 
-# ifndef htobe32
+# if !defined(htobe32)
 # define htobe32(x) OSSwapHostToBigInt32(x)
 # endif
 
-# ifndef be64toh
+# if !defined(be64toh)
 # define be64toh(x) OSSwapBigToHostInt64(x)
 # endif
 
-# ifndef htobe64
+# if !defined(htobe64)
 # define htobe64(x) OSSwapHostToBigInt64(x)
 # endif
 

--- a/src/core/src/address.cpp
+++ b/src/core/src/address.cpp
@@ -34,7 +34,7 @@
  */
 
 
-# ifdef _WIN32
+# if defined(_WIN32)
 
 # define _WINSOCK_DEPRECATED_NO_WARNINGS 1
 
@@ -70,7 +70,7 @@ namespace dsn
     const rpc_address rpc_group_address::_invalid;
 }
 
-#ifdef _WIN32
+# if defined(_WIN32)
 static void net_init()
 {
     static std::once_flag flag;
@@ -85,7 +85,7 @@ static void net_init()
         });
     }
 }
-#endif
+# endif
 
 // name to ip etc.
 DSN_API uint32_t dsn_ipv4_from_host(const char* name)
@@ -98,7 +98,7 @@ DSN_API uint32_t dsn_ipv4_from_host(const char* name)
     {
         hostent* hp = ::gethostbyname(name);
         int err =
-# ifdef _WIN32
+# if defined(_WIN32)
             (int)::WSAGetLastError()
 # else
             h_errno
@@ -138,7 +138,7 @@ DSN_API uint32_t dsn_ipv4_local(const char* network_interface)
 {
     uint32_t ret = 0;
 
-# ifndef _WIN32
+# if !defined(_WIN32)
     static const char loopback[4] = { 127, 0, 0, 1 };
     struct ifaddrs* ifa = nullptr;
     if (getifaddrs(&ifa) == 0)
@@ -200,7 +200,7 @@ DSN_API uint32_t dsn_ipv4_local(const char* network_interface)
             freeifaddrs(ifa);
         }
     }
-#endif
+# endif
 
     return ret;
 }
@@ -210,7 +210,7 @@ DSN_API const char*   dsn_address_to_string(dsn_address_t addr)
     char* p = dsn::tls_dsn.scratch_next();
     auto sz = sizeof(dsn::tls_dsn.scratch_buffer[0]);
     struct in_addr net_addr;
-# ifdef _WIN32
+# if defined(_WIN32)
     char* ip_str;
 # else
     int ip_len;
@@ -220,7 +220,7 @@ DSN_API const char*   dsn_address_to_string(dsn_address_t addr)
     {
     case HOST_TYPE_IPV4:
         net_addr.s_addr = htonl((uint32_t)addr.u.v4.ip);
-# ifdef _WIN32
+# if defined(_WIN32)
         ip_str = inet_ntoa(net_addr);
         snprintf_p(p, sz, "%s:%hu", ip_str, (uint16_t)addr.u.v4.port);
 # else

--- a/src/core/src/address.cpp
+++ b/src/core/src/address.cpp
@@ -38,10 +38,9 @@
 
 # define _WINSOCK_DEPRECATED_NO_WARNINGS 1
 
-# include <Winsock2.h>
+# include <winsock2.h>
 # include <ws2tcpip.h>
-# include <Windows.h>
-# pragma comment(lib, "ws2_32.lib")
+# include <windows.h>
 
 # else
 # include <sys/socket.h>

--- a/src/core/src/coredump.win.cpp
+++ b/src/core/src/coredump.win.cpp
@@ -36,7 +36,7 @@
 # include <dsn/tool_api.h>
 # include "coredump.h"
 
-#ifdef _WIN32
+# if defined(_WIN32)
 
 # include <windows.h>
 # include <dbghelp.h>
@@ -44,7 +44,7 @@
 # include <ctime>
 # include <psapi.h>
 
-# ifdef __TITLE__
+# if defined(__TITLE__)
 # undef __TITLE__
 # endif
 # define __TITLE__ "coredump"

--- a/src/core/src/coredump.win.cpp
+++ b/src/core/src/coredump.win.cpp
@@ -38,12 +38,11 @@
 
 #ifdef _WIN32
 
-# include <Windows.h>
-# include <DbgHelp.h>
+# include <windows.h>
+# include <dbghelp.h>
 # include <cstdlib>
 # include <ctime>
-# include <PsApi.h>
-# pragma comment(lib, "PsApi.lib")
+# include <psapi.h>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -58,14 +58,14 @@
 # include "library_utils.h"
 # include <fstream>
 
-# ifndef _WIN32
+# if !defined(_WIN32)
 # include <signal.h>
 # include <unistd.h>
 # else
 # include <tlhelp32.h>
 # endif
 
-# ifdef __TITLE__
+# if defined(__TITLE__)
 # undef __TITLE__
 # endif
 # define __TITLE__ "service_api_main"
@@ -238,7 +238,7 @@ static void load_all_modules(::dsn::configuration_ptr config)
         }
 
 // attribute(contructor) is not reliable on *nix
-#ifndef  _WIN32
+# if !defined(_WIN32)
         typedef void(*dsn_module_init_fn)();
         dsn_module_init_fn init_fn = (dsn_module_init_fn)::dsn::utils::load_symbol(hmod, "dsn_module_init");
         dassert(init_fn != nullptr,
@@ -246,7 +246,7 @@ static void load_all_modules(::dsn::configuration_ptr config)
             m.first.c_str()
         );
         init_fn();
-#endif // ! _WIN32
+# endif // ! _WIN32
         
         // have dmodule_bridge_arguments?
         if (m.second.length() > 0)
@@ -286,7 +286,7 @@ bool run(
     std::string& app_list
 )
 {
-# ifdef _WIN32
+# if defined(_WIN32)
     // On Windows, abort() (e.g. triggered by dassert/dsn_coredump) pops up a modal "Abort, Retry, Ignore" message box in "Debug" builds.
     // This blocks waiting for user input and hangs unattended/automated testing.
     // Clear the abort message and Windows Error Reporting flags so abort() terminates the process directly.
@@ -315,11 +315,11 @@ bool run(
     if (dsn_all.config->get_value<bool>("core", "pause_on_start", false,
         "whether to pause at startup time for easier debugging"))
     {
-#if defined(_WIN32)
+# if defined(_WIN32)
         printf("\nPause for debugging (pid = %d)...\n", static_cast<int>(::GetCurrentProcessId()));
-#else
+# else
         printf("\nPause for debugging (pid = %d)...\n", static_cast<int>(getpid()));
-#endif
+# endif
         getchar();
     }
 

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -62,7 +62,7 @@
 # include <signal.h>
 # include <unistd.h>
 # else
-# include <TlHelp32.h>
+# include <tlhelp32.h>
 # endif
 
 # ifdef __TITLE__

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -58,11 +58,11 @@
 # include "library_utils.h"
 # include <fstream>
 
-# if !defined(_WIN32)
+# if defined(_WIN32)
+# include <tlhelp32.h>
+# else
 # include <signal.h>
 # include <unistd.h>
-# else
-# include <tlhelp32.h>
 # endif
 
 # if defined(__TITLE__)

--- a/src/core/src/network.cpp
+++ b/src/core/src/network.cpp
@@ -33,7 +33,7 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
-# ifdef _WIN32
+# if defined(_WIN32)
 # include <winsock2.h>
 # include <windows.h>
 # endif
@@ -42,7 +42,7 @@
 # include "message_parser_manager.h"
 # include "rpc_engine.h"
 
-# ifdef __TITLE__
+# if defined(__TITLE__)
 # undef __TITLE__
 # endif
 # define __TITLE__ "network"

--- a/src/core/src/network.cpp
+++ b/src/core/src/network.cpp
@@ -34,7 +34,8 @@
  */
 
 # ifdef _WIN32
-# include <Winsock2.h>
+# include <winsock2.h>
+# include <windows.h>
 # endif
 # include <dsn/tool-api/network.h>
 # include <dsn/utility/factory_store.h>

--- a/src/core/src/rpc_engine.cpp
+++ b/src/core/src/rpc_engine.cpp
@@ -33,7 +33,7 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
-# ifdef _WIN32
+# if defined(_WIN32)
 # include <winsock2.h>
 # include <windows.h>
 # else
@@ -55,7 +55,7 @@
 # include <set>
 # include <dsn/cpp/layer2_handler.h>
 
-# ifdef __TITLE__
+# if defined(__TITLE__)
 # undef __TITLE__
 # endif
 # define __TITLE__ "rpc.engine"

--- a/src/core/src/rpc_engine.cpp
+++ b/src/core/src/rpc_engine.cpp
@@ -34,7 +34,8 @@
  */
 
 # ifdef _WIN32
-# include <WinSock2.h>
+# include <winsock2.h>
+# include <windows.h>
 # else
 # include <sys/socket.h>
 # include <netdb.h>

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -59,11 +59,11 @@
 # include "library_utils.h"
 # include <fstream>
 
-# if !defined(_WIN32)
+# if defined(_WIN32)
+# include <tlhelp32.h>
+# else
 # include <signal.h>
 # include <unistd.h>
-# else
-# include <tlhelp32.h>
 # endif
 
 # if defined(__TITLE__)

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -63,7 +63,7 @@
 # include <signal.h>
 # include <unistd.h>
 # else
-# include <TlHelp32.h>
+# include <tlhelp32.h>
 # endif
 
 # ifdef __TITLE__

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -59,14 +59,14 @@
 # include "library_utils.h"
 # include <fstream>
 
-# ifndef _WIN32
+# if !defined(_WIN32)
 # include <signal.h>
 # include <unistd.h>
 # else
 # include <tlhelp32.h>
 # endif
 
-# ifdef __TITLE__
+# if defined(__TITLE__)
 # undef __TITLE__
 # endif
 # define __TITLE__ "service_api_c"
@@ -845,7 +845,7 @@ DSN_API uint64_t dsn_random64(uint64_t min, uint64_t max) // [min, max]
 //
 //------------------------------------------------------------------------------
 
-# ifdef _WIN32
+# if defined(_WIN32)
 static BOOL SuspendAllThreads()
 {
     std::map<uint32_t, HANDLE> threads;
@@ -902,7 +902,7 @@ err:
     ::CloseHandle(hSnapshot);
     return FALSE;
 }
-#endif
+# endif
 
 NORETURN DSN_API void dsn_exit(int code)
 {

--- a/src/core/src/utils.test.cpp
+++ b/src/core/src/utils.test.cpp
@@ -42,7 +42,7 @@
 # include <limits>
 # include <sstream>
 # include <string>
-# ifdef _WIN32
+# if defined(_WIN32)
 # include <basetsd.h>
 # else
 # include <sys/types.h>
@@ -228,7 +228,7 @@ TEST(core, lexical_cast_integer_accepts_valid_values)
     EXPECT_EQ((uint64_t)123456789012345ULL, lexical_cast<uint64_t>("123456789012345"));
 
     EXPECT_EQ((size_t)42, lexical_cast<size_t>("42"));
-# ifdef _WIN32
+# if defined(_WIN32)
     EXPECT_EQ((SSIZE_T)-42, lexical_cast<SSIZE_T>("-42"));
     EXPECT_EQ((SSIZE_T)42, lexical_cast<SSIZE_T>("42"));
 # else
@@ -295,7 +295,7 @@ TEST(core, lexical_cast_integer_accepts_valid_values)
     EXPECT_EQ(std::numeric_limits<size_t>::max(),
               lexical_cast<size_t>(
                   unsigned_integer_to_string(std::numeric_limits<size_t>::max())));
-# ifdef _WIN32
+# if defined(_WIN32)
     EXPECT_EQ(std::numeric_limits<SSIZE_T>::min(),
               lexical_cast<SSIZE_T>(
                   signed_integer_to_string(std::numeric_limits<SSIZE_T>::min())));
@@ -343,7 +343,7 @@ TEST(core, lexical_cast_integer_rejects_invalid_values)
     EXPECT_THROW(lexical_cast<size_t>("-1"), std::out_of_range);
     EXPECT_THROW(lexical_cast<size_t>("18446744073709551616"), std::out_of_range);
     EXPECT_THROW(lexical_cast<uint64_t>("-1"), std::out_of_range);
-# ifdef _WIN32
+# if defined(_WIN32)
     EXPECT_THROW(lexical_cast<SSIZE_T>("-9223372036854775809"), std::out_of_range);
     EXPECT_THROW(lexical_cast<SSIZE_T>("9223372036854775808"), std::out_of_range);
 # else

--- a/src/core/src/utils.test.cpp
+++ b/src/core/src/utils.test.cpp
@@ -43,7 +43,7 @@
 # include <sstream>
 # include <string>
 # ifdef _WIN32
-# include <BaseTsd.h>
+# include <basetsd.h>
 # else
 # include <sys/types.h>
 # endif

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -34,7 +34,8 @@
  */
 
 # if defined(_WIN32)
-# include <WinSock2.h>
+# include <winsock2.h>
+# include <windows.h>
 # else
 # include <unistd.h>
 # endif

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -50,9 +50,9 @@
 # include <sys/stat.h>
 # include <random>
 
-#ifdef DSN_USE_THRIFT_SERIALIZATION
+# if defined(DSN_USE_THRIFT_SERIALIZATION)
 # include <dsn/cpp/serialization_helper/thrift_helper.h>
-#endif
+# endif
 
 # if defined(__linux__)
 # include <sys/syscall.h>
@@ -62,7 +62,7 @@
 # include <pthread.h>
 # endif
 
-# ifdef __TITLE__
+# if defined(__TITLE__)
 # undef __TITLE__
 # endif
 # define __TITLE__ "dsn.utils"
@@ -277,12 +277,12 @@ namespace dsn {
         void time_ms_to_string(uint64_t ts_ms, char* str)
         {
             auto t = (time_t)(ts_ms / 1000);
-#if defined(_WIN32)
+# if defined(_WIN32)
             auto ret = localtime(&t);
-#else
+# else
             struct tm tmp;
             auto ret = localtime_r(&t, &tmp);
-#endif
+# endif
             auto ms = static_cast<uint32_t>(ts_ms % 1000);
 
             snprintf(str, 13, "%02d:%02d:%02d.%03u", ret->tm_hour, ret->tm_min, ret->tm_sec, ms);


### PR DESCRIPTION
Updates Windows-specific code style and build configuration:

- Normalize Windows SDK header casing to lowercase, e.g. <windows.h>, <winsock2.h>, <tlhelp32.h>.
- Ensure Winsock headers are included before <windows.h>.
- Move Windows system library dependencies from source pragmas into CMake via DSN_SYSTEM_LIBS.
- Add ws2_32 and psapi for Windows builds.
- Fix the ntohl/htonl helper type check in ports.h to use u_long.
- Normalize Windows conditional include ordering in main.cpp and service_api_c.cpp.