### PR TITLE
Fix cross-platform build and test issues

### DIFF
--- a/bin/Linux/build.sh
+++ b/bin/Linux/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # !!! This script should be run in dsn project root directory (../../).
 #
 # Shell Options:
@@ -13,8 +13,8 @@
 #    BOOST_DIR      <dir>|""
 #
 # CMake options:
-#    -DCMAKE_C_COMPILER=gcc
-#    -DCMAKE_CXX_COMPILER=g++
+#    -DCMAKE_C_COMPILER=<c compiler>
+#    -DCMAKE_CXX_COMPILER=<c++ compiler>
 #    [-DCMAKE_BUILD_TYPE=Debug]
 #    [-DDSN_GIT_SOURCE=github]
 #    [-DWARNING_ALL=TRUE]
@@ -34,7 +34,9 @@ GCOV_DIR="$ROOT/gcov_report"
 GCOV_TMP="$ROOT/.gcov_tmp"
 GCOV_PATTERN=`find $ROOT/include $ROOT/src -name '*.h' -o -name '*.cpp'`
 TIME=`date '+%Y-%m-%d %H:%M:%S%z'`
-CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
+CMAKE_C_COMPILER="${CC:-cc}"
+CMAKE_CXX_COMPILER="${CXX:-c++}"
+CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER=$CMAKE_C_COMPILER -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER"
 MAKE_OPTIONS="$MAKE_OPTIONS -j$JOB_NUM"
 
 scripts_path=`readlink -f $0`

--- a/bin/Linux/clear_zk.sh
+++ b/bin/Linux/clear_zk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Options:
 #    INSTALL_DIR    <dir>

--- a/bin/Linux/deploy.sh
+++ b/bin/Linux/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 os=linux
 scripts_path=`readlink -f "$0"`
 scripts_dir=`dirname "$scripts_path"`

--- a/bin/Linux/deploy/genrcyaml.sh
+++ b/bin/Linux/deploy/genrcyaml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 configtool=./configtool

--- a/bin/Linux/deploy/gensvcyaml.sh
+++ b/bin/Linux/deploy/gensvcyaml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 configtool=./configtool

--- a/bin/Linux/deploy/run.sh
+++ b/bin/Linux/deploy/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PROGRAM=/home/rdsn/{{ placeholder['deploy_name'] }}
 CONFIG=/home/rdsn/config.ini

--- a/bin/Linux/deploy/start.sh
+++ b/bin/Linux/deploy/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 

--- a/bin/Linux/deploy/start_docker.sh
+++ b/bin/Linux/deploy/start_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PREFIX=$(readlink -m $(dirname ${BASH_SOURCE}))
 export LD_LIBRARY_PATH=${PREFIX}

--- a/bin/Linux/deploy/stop.sh
+++ b/bin/Linux/deploy/stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PREFIX=$(readlink -m $(dirname ${BASH_SOURCE}))
 

--- a/bin/Linux/deploy/stop_docker.sh
+++ b/bin/Linux/deploy/stop_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PREFIX=$(readlink -m $(dirname ${BASH_SOURCE}))
 

--- a/bin/Linux/download.sh
+++ b/bin/Linux/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function download_file()
 {

--- a/bin/Linux/format.sh
+++ b/bin/Linux/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is to check format of the project, including:
 #   - not use 'TAB' in codes, instead using spaces.
 

--- a/bin/Linux/install.sh
+++ b/bin/Linux/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # !!! This script should be run in dsn project root directory (../../).
 #
 # Options:

--- a/bin/Linux/k8s_deploy.sh
+++ b/bin/Linux/k8s_deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 os=linux
 scripts_path=`readlink -f "$0"`
 export scripts_dir=`dirname "$scripts_path"`

--- a/bin/Linux/onecluster.sh
+++ b/bin/Linux/onecluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Options:
 

--- a/bin/Linux/publish.sh
+++ b/bin/Linux/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 os=linux
 scripts_path=`readlink -f $0`
 export scripts_dir=`dirname $scripts_path`

--- a/bin/Linux/publish.simple_kv.sh
+++ b/bin/Linux/publish.simple_kv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 b_dir=$1
 t_dir=$2

--- a/bin/Linux/publish_docker.simple_kv.sh
+++ b/bin/Linux/publish_docker.simple_kv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/Linux/start_zk.sh
+++ b/bin/Linux/start_zk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Options:
 #    INSTALL_DIR    <dir>

--- a/bin/Linux/stop_zk.sh
+++ b/bin/Linux/stop_zk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Options:
 #    INSTALL_DIR    <dir>

--- a/bin/Linux/stop_zk.sh
+++ b/bin/Linux/stop_zk.sh
@@ -9,7 +9,12 @@ then
     exit -1
 fi
 
-cd $INSTALL_DIR
+if [ ! -d "$INSTALL_DIR" ]
+then
+    exit 0
+fi
+
+cd "$INSTALL_DIR"
 
 ZOOKEEPER_HOME=`pwd`/zookeeper-3.4.6
 

--- a/bin/Linux/test.sh
+++ b/bin/Linux/test.sh
@@ -104,7 +104,7 @@ do
     if [ -f "$dir/gtests" ]
     then
         pushd "$dir" >/dev/null
-        cat $dir/gtests | while read -r line || [ -n "$line" ]; do
+        while read -r line || [ -n "$line" ]; do
             echo "============ run unit tests in $dir with $line ============"
             rm -fr ./data
             $SVC_HOST $dir/$line
@@ -124,7 +124,7 @@ do
                 popd >/dev/null
                 exit -1
             fi
-        done
+        done < "$dir/gtests"
         popd >/dev/null
     fi    
 done

--- a/bin/Linux/test.sh
+++ b/bin/Linux/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # !!! This script should be run in dsn project root directory (../../).
 #
 # Shell Options:
@@ -17,7 +17,9 @@ GCOV_DIR="$ROOT/gcov_report"
 GCOV_TMP="$ROOT/.gcov_tmp"
 GCOV_PATTERN=`find $ROOT/include $ROOT/src -name '*.h' -o -name '*.cpp'`
 TIME=`date '+%Y-%m-%d %H:%M:%S%z'`
-CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++"
+CMAKE_C_COMPILER="${CC:-cc}"
+CMAKE_CXX_COMPILER="${CXX:-c++}"
+CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER=$CMAKE_C_COMPILER -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER"
 MAKE_OPTIONS="$MAKE_OPTIONS -j$JOB_NUM"
 
 CBIN_DIR=$(dirname "$0")

--- a/bin/Windows/pre-require.cmd
+++ b/bin/Windows/pre-require.cmd
@@ -119,7 +119,9 @@ IF NOT DEFINED DSN_TMP_CMAKE_EXE (
 )
 
 SET DSN_TMP_CMAKE_FOUND_VERSION=
-FOR /F "tokens=3" %%i IN ('"%DSN_TMP_CMAKE_EXE%" --version 2^>nul ^| findstr /B /C:"cmake version"') DO SET DSN_TMP_CMAKE_FOUND_VERSION=%%i
+FOR /F "tokens=1,2,3" %%i IN ('CALL "%DSN_TMP_CMAKE_EXE%" --version 2^>nul') DO (
+    IF /I "%%i %%j"=="cmake version" SET DSN_TMP_CMAKE_FOUND_VERSION=%%k
+)
 IF NOT DEFINED DSN_TMP_CMAKE_FOUND_VERSION (
     CALL "%bin_dir%\echoc.exe" 4 "failed to detect CMake version from %DSN_TMP_CMAKE_EXE%"
     GOTO error

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -507,6 +507,8 @@ function(dsn_setup_compiler_flags)
         add_definitions(-D_WIN32_WINNT=0x0600)
         add_definitions(-D_UNICODE)
         add_definitions(-DUNICODE)
+        # Boost may not recognize newer MSVC versions yet, such as VS 2026.
+        add_definitions(-DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
         add_compile_options(-MP)
         if(DEFINED DSN_PEDANTIC)
             add_compile_options(-WX)

--- a/bin/dsn.cmake
+++ b/bin/dsn.cmake
@@ -373,6 +373,11 @@ function(dsn_add_project)
     
     dsn_setup_serialization()
 
+    list(FIND MY_PROJ_LIBS gtest DSN_GTEST_LIB_INDEX)
+    if((NOT DSN_GTEST_LIB_INDEX EQUAL -1) AND DEFINED GTEST_LIB_DIR AND NOT "${GTEST_LIB_DIR}" STREQUAL "")
+        list(APPEND MY_PROJ_LIB_PATH ${GTEST_LIB_DIR})
+    endif()
+
     if(MY_PROJ_LANG STREQUAL "CXX")
         set(MY_BOOST_LIBS "")
         if(NOT (MY_BOOST_PACKAGES STREQUAL ""))

--- a/bin/dsn.run.sh
+++ b/bin/dsn.run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 scripts_path=`readlink -f $0`
 scripts_dir=`dirname $scripts_path`/Linux

--- a/ext/gtest/CMakeLists.txt
+++ b/ext/gtest/CMakeLists.txt
@@ -2,8 +2,10 @@ set(project_name googletest)
 
 set(target_url ${GTEST_GIT_SOURCE})
 set(git_tag ${GTEST_GIT_TAG})
+set(target_bin_subdir src)
+set(gtest_lib_dir "${PROJECT_BINARY_DIR}/${project_name}/${target_bin_subdir}")
 
-set(my_cmake_args "-Wno-dev;-DCMAKE_SUPPRESS_DEVELOPER_WARNINGS=ON;-Dgtest_force_shared_crt=OFF;-DBUILD_SHARED_LIBS=ON;")
+set(my_cmake_args "-Wno-dev;-DCMAKE_SUPPRESS_DEVELOPER_WARNINGS=ON;-Dgtest_force_shared_crt=OFF;-DBUILD_SHARED_LIBS=ON;-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${gtest_lib_dir};-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${gtest_lib_dir};")
 
 if(WIN32)
     set(target_binaries gtest.lib gtest_main.lib gtest.dll gtest_main.dll)
@@ -21,4 +23,4 @@ install(DIRECTORY ${my_source_dir}/include/gtest
 )
 
 set(GTEST_INCLUDE_DIR ${my_source_dir}/include PARENT_SCOPE)
-set(GTEST_LIB_DIR ${my_binary_dir} PARENT_SCOPE)
+set(GTEST_LIB_DIR ${my_binary_dir}/${target_bin_subdir} PARENT_SCOPE)

--- a/ext/rapidjson/CMakeLists.txt
+++ b/ext/rapidjson/CMakeLists.txt
@@ -3,17 +3,13 @@ include(ExternalProject)
 set(target_url ${RAPIDJSON_GIT_SOURCE})
 set(git_tag ${RAPIDJSON_GIT_TAG})
 
-set (RAPIDJSON_CMAKE_ARGS
-    "-Wno-dev;"
-    "-DCMAKE_SUPPRESS_DEVELOPER_WARNINGS=ON;"
-)
-
 ExternalProject_Add(rapidjson_header
     GIT_REPOSITORY ${target_url}
     GIT_TAG ${git_tag}
     GIT_SHALLOW TRUE
     GIT_PROGRESS FALSE
-    CMAKE_ARGS ${RAPIDJSON_CMAKE_ARGS}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
     INSTALL_COMMAND ""
 )
 

--- a/include/dsn/utility/ports.h
+++ b/include/dsn/utility/ports.h
@@ -135,7 +135,7 @@ static_assert (sizeof(uint32_t) == sizeof(unsigned long),
 # endif
 
 # if !defined(be64toh)
-# define be64toh(x) ( (be32toh((x)>>32)&0xffffffff) | ( be32toh( (x)&0xffffffff ) << 32 ) )
+# define be64toh(x) ( static_cast<uint64_t>(be32toh(static_cast<uint32_t>((x) >> 32))) | ( static_cast<uint64_t>(be32toh(static_cast<uint32_t>(x))) << 32 ) )
 # endif
 
 

--- a/include/dsn/utility/ports.h
+++ b/include/dsn/utility/ports.h
@@ -115,27 +115,57 @@ __pragma(warning(disable:4127))
 
 // make sure to include <winsock2.h> before the usage
 
+# if !defined(_WINSOCK2API_)
+template <typename TResult, typename TArg>
+inline TResult require_winsock2_for_byte_order(TArg)
+{
+    static_assert(sizeof(TArg) == 0,
+        "include <winsock2.h> before using Windows byte-order macros");
+    return TResult();
+}
+# endif
+
 # if !defined(be16toh)
+# if defined(_WINSOCK2API_)
 # define be16toh(x) ntohs(x)
+# else
+# define be16toh(x) ::require_winsock2_for_byte_order<uint16_t>(x)
+# endif
 # endif
 
 # if !defined(htobe16)
+# if defined(_WINSOCK2API_)
 # define htobe16(x) htons(x)
+# else
+# define htobe16(x) ::require_winsock2_for_byte_order<uint16_t>(x)
+# endif
 # endif
 
 static_assert (sizeof(uint32_t) == sizeof(unsigned long),
     "sizeof(uint32_t) == sizeof(unsigned long) for use of ntohl");
 
 # if !defined(be32toh)
+# if defined(_WINSOCK2API_)
 # define be32toh(x) static_cast<uint32_t>(ntohl(static_cast<unsigned long>(x)))
+# else
+# define be32toh(x) ::require_winsock2_for_byte_order<uint32_t>(x)
+# endif
 # endif
 
 # if !defined(htobe32)
+# if defined(_WINSOCK2API_)
 # define htobe32(x) static_cast<uint32_t>(htonl(static_cast<unsigned long>(x)))
+# else
+# define htobe32(x) ::require_winsock2_for_byte_order<uint32_t>(x)
+# endif
 # endif
 
 # if !defined(be64toh)
+# if defined(_WINSOCK2API_)
 # define be64toh(x) ( static_cast<uint64_t>(be32toh(static_cast<uint32_t>((x) >> 32))) | ( static_cast<uint64_t>(be32toh(static_cast<uint32_t>(x))) << 32 ) )
+# else
+# define be64toh(x) ::require_winsock2_for_byte_order<uint64_t>(x)
+# endif
 # endif
 
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 local_path=`readlink -f $0`
 local_dir=`dirname $local_path`
 echo "run $0 in $local_dir"

--- a/src/core/src/address.cpp
+++ b/src/core/src/address.cpp
@@ -133,9 +133,48 @@ DSN_API uint32_t dsn_ipv4_from_host(const char* name)
     return (uint32_t)ntohl(addr.sin_addr.s_addr);
 }
 
-// If network_interface is "", this only returns the first "eth" prefixed non-loopback IPv4 address.
-// This Linux-centric default misses common macOS and FreeBSD interface names,
-// such as "en0", "em0", "vtnet0", "igb0", and "re0";
+static bool interface_has_prefix(const char* network_interface, const char* prefix)
+{
+    return strncmp(network_interface, prefix, strlen(prefix)) == 0;
+}
+
+# if !defined(_WIN32)
+static bool is_default_interface(const struct ifaddrs* ifa)
+{
+    if ((ifa->ifa_flags & IFF_UP) == 0 ||
+        (ifa->ifa_flags & IFF_LOOPBACK) != 0 ||
+        ifa->ifa_addr->sa_family != AF_INET)
+    {
+        return false;
+    }
+
+# if defined(__APPLE__)
+    return interface_has_prefix(ifa->ifa_name, "en");
+# elif defined(__FreeBSD__)
+    return interface_has_prefix(ifa->ifa_name, "em") ||
+           interface_has_prefix(ifa->ifa_name, "igb") ||
+           interface_has_prefix(ifa->ifa_name, "ix") ||
+           interface_has_prefix(ifa->ifa_name, "re") ||
+           interface_has_prefix(ifa->ifa_name, "bge") ||
+           interface_has_prefix(ifa->ifa_name, "vtnet") ||
+           interface_has_prefix(ifa->ifa_name, "vmx") ||
+           interface_has_prefix(ifa->ifa_name, "iwn") ||
+           interface_has_prefix(ifa->ifa_name, "iwm") ||
+           interface_has_prefix(ifa->ifa_name, "urtwn");
+# else
+    return interface_has_prefix(ifa->ifa_name, "eth") ||
+           interface_has_prefix(ifa->ifa_name, "en") ||
+           interface_has_prefix(ifa->ifa_name, "wl") ||
+           interface_has_prefix(ifa->ifa_name, "ww") ||
+           interface_has_prefix(ifa->ifa_name, "ib") ||
+           interface_has_prefix(ifa->ifa_name, "sl");
+# endif
+}
+# endif
+
+// If network_interface is empty, this returns the first hinted non-loopback IPv4 address.
+// The original Linux-centric "eth" prefix misses modern Linux names and common
+// macOS and FreeBSD interface names, such as "en0", "em0", "vtnet0", "igb0", and "re0";
 // callers may then fall back to hostname resolution, which can choose
 // an address that is inconsistent with localhost-based tests.
 DSN_API uint32_t dsn_ipv4_local(const char* network_interface)
@@ -143,6 +182,7 @@ DSN_API uint32_t dsn_ipv4_local(const char* network_interface)
     uint32_t ret = 0;
 
 # if !defined(_WIN32)
+    const bool use_default_interface = network_interface == nullptr || network_interface[0] == '\0';
     static const char loopback[4] = { 127, 0, 0, 1 };
     struct ifaddrs* ifa = nullptr;
     if (getifaddrs(&ifa) == 0)
@@ -154,12 +194,13 @@ DSN_API uint32_t dsn_ipv4_local(const char* network_interface)
                 i->ifa_addr != nullptr 
                 )
             {
-                if (strcmp(i->ifa_name, network_interface) == 0 ||
-                    (network_interface[0] == '\0' && strncmp(i->ifa_name, "eth", 3) == 0)
-                   )
+                if ((!use_default_interface && strcmp(i->ifa_name, network_interface) == 0) ||
+                    (use_default_interface && is_default_interface(i)))
                 {
+                    // Existing loopback detection checks IPv4 address bytes; IFF_LOOPBACK
+                    // would be a better signal for interface-level loopback status.
                     if (i->ifa_addr->sa_family == AF_INET && 
-                        (network_interface[0] != '\0' || strncmp((const char*)&((struct sockaddr_in *)i->ifa_addr)->sin_addr.s_addr, loopback, 4) != 0))
+                        (!use_default_interface || strncmp((const char*)&((struct sockaddr_in *)i->ifa_addr)->sin_addr.s_addr, loopback, 4) != 0))
                     {
                         ret = (uint32_t)ntohl(((struct sockaddr_in *)i->ifa_addr)->sin_addr.s_addr);
                         break;
@@ -182,7 +223,7 @@ DSN_API uint32_t dsn_ipv4_local(const char* network_interface)
                         auto err = ioctl(fd, SIOCGIFADDR, &ifr);
                         close(fd);
                         if (err == 0 &&
-                            (network_interface[0] != '\0' || strncmp((const char*)&((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr.s_addr, loopback, 4) != 0))
+                            (!use_default_interface || strncmp((const char*)&((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr.s_addr, loopback, 4) != 0))
                         {
                             ret = (uint32_t)ntohl(((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr.s_addr);
                             break;

--- a/src/core/src/address.test.cpp
+++ b/src/core/src/address.test.cpp
@@ -80,7 +80,7 @@ TEST(core, dsn_ipv4_local)
 {
 #ifndef _WIN32
     const char* loopback_interface =
-# if defined(__APPLE__)
+# if defined(__APPLE__) || defined(__FreeBSD__)
         "lo0"
 # else
         "lo"

--- a/src/core/src/disk_engine.cpp
+++ b/src/core/src/disk_engine.cpp
@@ -377,6 +377,8 @@ void disk_engine::process_write(aio_task* aio, uint32_t sz)
 
 void disk_engine::complete_io(aio_task* aio, error_code err, uint32_t bytes, int delay_milliseconds)
 {
+    // TODO: ERR_TRY_AGAIN from an AIO provider means the request was not queued
+    // and could be retried here before completing the user's aio task.
     if (err != ERR_OK)
     {
         dinfo(

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -235,7 +235,7 @@ static void load_all_modules(::dsn::configuration_ptr config)
         }
         else
         {
-            dwarn("load shared library '%s' successfully", m.first.c_str());
+            dinfo("load shared library '%s' successfully", m.first.c_str());
         }
 
 // attribute(contructor) is not reliable on *nix

--- a/src/core/src/network.cpp
+++ b/src/core/src/network.cpp
@@ -558,7 +558,7 @@ namespace dsn
 
         static const char* inteface = dsn_config_get_value_string(
             "network", "primary_interface",
-            "", "network interface name used to init primary ipv4 address, if empty, means using the first \"eth\" prefixed non-loopback ipv4 address");
+            "", "network interface name used to init primary ipv4 address, if empty, means using the first hinted non-loopback ipv4 address");
 
         uint32_t ip = 0;
 

--- a/src/core/src/rpc_engine.cpp
+++ b/src/core/src/rpc_engine.cpp
@@ -721,7 +721,7 @@ namespace dsn {
 
             if (ctx.queue)
             {
-                dwarn("[%s.%s] network server started at port %u, channel = %s, ...",
+                dinfo("[%s.%s] network server started at port %u, channel = %s, ...",
                     node()->name(),
                     ctx.queue->get_name().c_str(),
                     (uint32_t)(port + ctx.port_shift_value),
@@ -730,7 +730,7 @@ namespace dsn {
             }
             else
             {
-                dwarn("[%s] network server started at port %u, channel = %s, ...",
+                dinfo("[%s] network server started at port %u, channel = %s, ...",
                     node()->name(),
                     (uint32_t)(port + ctx.port_shift_value),
                     sp.second.channel.to_string()

--- a/src/core/src/task_worker.cpp
+++ b/src/core/src/task_worker.cpp
@@ -43,6 +43,10 @@
 # else
 # include <pthread.h>
 
+# ifdef __linux__
+# include <sys/resource.h>
+# endif
+
 # ifdef __FreeBSD__
 # include <pthread_np.h>
 # endif
@@ -217,7 +221,12 @@ void task_worker::set_priority(worker_priority_t pri)
 # ifdef _WIN32
     succ = (::SetThreadPriority(::GetCurrentThread(), prio) == TRUE);
 # elif defined(__linux__)
-    if ((nice(prio) == -1) && (errno != 0))
+    if (prio == 0)
+    {
+        return;
+    }
+
+    if (setpriority(PRIO_PROCESS, 0, prio) != 0)
     {
         succ = false;
     }

--- a/src/dev/cpp/file_utils.cpp
+++ b/src/dev/cpp/file_utils.cpp
@@ -70,8 +70,7 @@
 
 # if defined(__FreeBSD__)
 # include <sys/types.h>
-# include <sys/user.h>
-# include <libutil.h>
+# include <sys/sysctl.h>
 # endif
 
 # if defined(__APPLE__)
@@ -1073,25 +1072,24 @@ out_error:
                 tls_path_buffer[err] = 0;
                 path = tls_path_buffer;
 # elif defined(__FreeBSD__)
-                struct kinfo_proc* proc;
-
                 if (pid == -1)
                 {
                     pid = (int)getpid();
                 }
 
-                proc = kinfo_getproc(pid);
-                if (proc == nullptr)
+                int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, pid };
+                size_t path_len = TLS_PATH_BUFFER_SIZE;
+                if (::sysctl(mib, 4, tls_path_buffer, &path_len, nullptr, 0) != 0 || (path_len == 0))
                 {
                     return ERR_PATH_NOT_FOUND;
                 }
 
-                // proc->ki_comm is the command name instead of the full name.
-                if (!dsn::utils::filesystem::get_absolute_path(proc->ki_comm, path))
+                if (path_len >= TLS_PATH_BUFFER_SIZE)
                 {
-                    return ERR_PATH_NOT_FOUND;
+                    path_len = TLS_PATH_BUFFER_SIZE - 1;
                 }
-                free(proc);
+                tls_path_buffer[path_len] = '\0';
+                path = tls_path_buffer;
 # elif defined(__APPLE__)
                 if (pid == -1)
                 {

--- a/src/plugins/tools.common/asio_rpc_session.cpp
+++ b/src/plugins/tools.common/asio_rpc_session.cpp
@@ -106,7 +106,14 @@ namespace dsn {
             {
                 if (!!ec)
                 {
-                    derror("asio read from %s failed: %s", _remote_addr.to_string(), ec.message().c_str());
+                    if (ec == boost::asio::error::eof)
+                    {
+                        ddebug("asio read from %s ended: %s", _remote_addr.to_string(), ec.message().c_str());
+                    }
+                    else
+                    {
+                        derror("asio read from %s failed: %s", _remote_addr.to_string(), ec.message().c_str());
+                    }
                     on_failure();
                 }
                 else

--- a/src/plugins/tools.common/native_aio_provider.posix.cpp
+++ b/src/plugins/tools.common/native_aio_provider.posix.cpp
@@ -248,6 +248,8 @@ namespace dsn {
                 if (async)
                 {
 # if defined(__APPLE__)
+                    // TODO: Replace the per-request wait thread with a bounded/shared
+                    // macOS AIO completion mechanism such as dispatch_io.
                     std::thread(wait_aio_completed, aio).detach();
 # endif
                     return ERR_IO_PENDING;

--- a/src/plugins/tools.common/native_aio_provider.posix.cpp
+++ b/src/plugins/tools.common/native_aio_provider.posix.cpp
@@ -224,19 +224,20 @@ namespace dsn {
 
             if (r != 0)
             {
+                const error_code err = (errno == EAGAIN) ? ERR_TRY_AGAIN : ERR_FILE_OPERATION_FAILED;
                 derror("file op failed, err = %d (%s). On FreeBSD, you may need to load"
                        " aio kernel module by running 'sudo kldload aio'.", errno, strerror(errno));
 
                 if (async)
                 {
-                    complete_io(aio_tsk, ERR_FILE_OPERATION_FAILED, 0);
+                    complete_io(aio_tsk, err, 0);
                 }
                 else
                 {
                     delete aio->evt;
                     aio->evt = nullptr;
                 }
-                return ERR_FILE_OPERATION_FAILED;
+                return err;
             }
             else 
             {

--- a/src/plugins/tools.common/native_aio_provider.posix.cpp
+++ b/src/plugins/tools.common/native_aio_provider.posix.cpp
@@ -119,7 +119,11 @@ namespace dsn {
 
         void native_posix_aio_provider::aio(aio_task* aio_tsk)
         {
-            aio_internal(aio_tsk, true);
+            auto err = aio_internal(aio_tsk, true);
+            if (err == ERR_IO_PENDING)
+            {
+                err.end_tracking();
+            }
         }
 
         void aio_completed(sigval sigval)

--- a/src/plugins/tools.common/thrift_message_parser.cpp
+++ b/src/plugins/tools.common/thrift_message_parser.cpp
@@ -33,6 +33,10 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
+# if defined(_WIN32)
+# include <winsock2.h>
+# endif
+
 # include "thrift_message_parser.h"
 # include <dsn/service_api_c.h>
 # include <dsn/cpp/serialization_helper/thrift_helper.h>


### PR DESCRIPTION
## Summary

This PR fixes cross-platform build/test issues found while validating rDSN on macOS, Ubuntu, FreeBSD, and Windows.

## Changes

- Skip the unnecessary RapidJSON header-only configure step.
- Fix gtest build/install path handling.
- Improve shell script portability across Unix platforms.
- Fix `test.sh` so gtest failures stop the parent script instead of only exiting a pipeline subshell.
- Improve default network interface detection.
- Add FreeBSD and Windows portability fixes.
- Fix transient POSIX AIO submit handling and consume expected `ERR_IO_PENDING` tracking.
- Avoid redundant Linux thread priority changes.
- Reduce normal startup and TCP EOF log noise.
- Update external submodules, including `rDSN.dist.service` fixes for macOS daemon path lookup, pending meta response tracking, and daemon shutdown avoiding `dsn.svchost` self-kill.

## Notes

Some remaining log messages are expected negative-test output, such as config parser failures and transient daemon startup connection refusals.