### PR TITLE
Suppress external dependency warnings

### DIFF
--- a/ext/protobuf/CMakeLists.txt
+++ b/ext/protobuf/CMakeLists.txt
@@ -23,7 +23,7 @@ endif ()
 set(PROTOBUF_CXX_FLAGS "")
 
 if (NOT WIN32)
-    set(PROTOBUF_CXX_FLAGS "${PROTOBUF_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-deprecated-declarations")
+    set(PROTOBUF_CXX_FLAGS "${PROTOBUF_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unused-private-field -Wno-deprecated-declarations")
 endif ()
 
 if(PROTOBUF_CXX_FLAGS)

--- a/ext/protobuf/CMakeLists.txt
+++ b/ext/protobuf/CMakeLists.txt
@@ -20,6 +20,11 @@ if (WIN32)
     list (APPEND PROTOBUF_CMAKE_ARGS "-DWITH_CSHARP=ON;")
 endif ()
 
+# Suppress macOS SDK deprecation warnings from protobuf's legacy OSAtomic usage.
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    list (APPEND PROTOBUF_CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations;")
+endif ()
+
 ExternalProject_Add(protobuf
     GIT_REPOSITORY ${target_url}
     GIT_TAG ${git_tag}

--- a/ext/protobuf/CMakeLists.txt
+++ b/ext/protobuf/CMakeLists.txt
@@ -22,9 +22,8 @@ endif ()
 
 set(PROTOBUF_CXX_FLAGS "")
 
-# Suppress macOS SDK warnings for deprecated functions such as OSAtomicAdd32Barrier.
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(PROTOBUF_CXX_FLAGS "${PROTOBUF_CXX_FLAGS} -Wno-deprecated-declarations")
+if (NOT WIN32)
+    set(PROTOBUF_CXX_FLAGS "${PROTOBUF_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-deprecated-declarations")
 endif ()
 
 if(PROTOBUF_CXX_FLAGS)

--- a/ext/protobuf/CMakeLists.txt
+++ b/ext/protobuf/CMakeLists.txt
@@ -20,9 +20,15 @@ if (WIN32)
     list (APPEND PROTOBUF_CMAKE_ARGS "-DWITH_CSHARP=ON;")
 endif ()
 
-# Suppress macOS SDK deprecation warnings from protobuf's legacy OSAtomic usage.
+set(PROTOBUF_CXX_FLAGS "")
+
+# Suppress macOS SDK warnings for deprecated functions such as OSAtomicAdd32Barrier.
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    list (APPEND PROTOBUF_CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations;")
+    set(PROTOBUF_CXX_FLAGS "${PROTOBUF_CXX_FLAGS} -Wno-deprecated-declarations")
+endif ()
+
+if(PROTOBUF_CXX_FLAGS)
+    list (APPEND PROTOBUF_CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${PROTOBUF_CXX_FLAGS};")
 endif ()
 
 ExternalProject_Add(protobuf

--- a/ext/protobuf/CMakeLists.txt
+++ b/ext/protobuf/CMakeLists.txt
@@ -23,7 +23,10 @@ endif ()
 set(PROTOBUF_CXX_FLAGS "")
 
 if (NOT WIN32)
-    set(PROTOBUF_CXX_FLAGS "${PROTOBUF_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unused-private-field -Wno-deprecated-declarations")
+    set(PROTOBUF_CXX_FLAGS "${PROTOBUF_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-deprecated-declarations")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(PROTOBUF_CXX_FLAGS "${PROTOBUF_CXX_FLAGS} -Wno-unused-private-field")
+    endif()
 endif ()
 
 if(PROTOBUF_CXX_FLAGS)

--- a/ext/thrift/CMakeLists.txt
+++ b/ext/thrift/CMakeLists.txt
@@ -33,7 +33,10 @@ endif()
 set(THRIFT_CXX_FLAGS "")
 
 if (NOT WIN32)
-    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unused-private-field -Wno-deprecated-declarations")
+    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-deprecated-declarations")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -Wno-unused-private-field")
+    endif()
 endif()
 
 if(DEFINED DSN_BOOST_HEADER_ONLY AND DSN_BOOST_HEADER_ONLY)

--- a/ext/thrift/CMakeLists.txt
+++ b/ext/thrift/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 set(THRIFT_CXX_FLAGS "")
 
 if(DEFINED DSN_BOOST_HEADER_ONLY AND DSN_BOOST_HEADER_ONLY)
-    list(APPEND THRIFT_CMAKE_ARGS "-DBOOST_ERROR_CODE_HEADER_ONLY;")
+    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -DBOOST_ERROR_CODE_HEADER_ONLY")
 endif()
 
 # Suppress macOS SDK warnings for deprecated functions such as sprintf.

--- a/ext/thrift/CMakeLists.txt
+++ b/ext/thrift/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 set(THRIFT_CXX_FLAGS "")
 
 if (NOT WIN32)
-    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-deprecated-declarations")
+    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unused-private-field -Wno-deprecated-declarations")
 endif()
 
 if(DEFINED DSN_BOOST_HEADER_ONLY AND DSN_BOOST_HEADER_ONLY)

--- a/ext/thrift/CMakeLists.txt
+++ b/ext/thrift/CMakeLists.txt
@@ -32,13 +32,12 @@ endif()
 
 set(THRIFT_CXX_FLAGS "")
 
-if(DEFINED DSN_BOOST_HEADER_ONLY AND DSN_BOOST_HEADER_ONLY)
-    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -DBOOST_ERROR_CODE_HEADER_ONLY")
+if (NOT WIN32)
+    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-deprecated-declarations")
 endif()
 
-# Suppress macOS SDK warnings for deprecated functions such as sprintf.
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -Wno-deprecated-declarations")
+if(DEFINED DSN_BOOST_HEADER_ONLY AND DSN_BOOST_HEADER_ONLY)
+    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -DBOOST_ERROR_CODE_HEADER_ONLY")
 endif()
 
 if(WIN32)

--- a/ext/thrift/CMakeLists.txt
+++ b/ext/thrift/CMakeLists.txt
@@ -29,8 +29,16 @@ set(THRIFT_CMAKE_ARGS
 if(DEFINED BOOST_ROOT)
     list(APPEND THRIFT_CMAKE_ARGS "-DBOOST_ROOT=${BOOST_ROOT};")
 endif()
+
+set(THRIFT_CXX_FLAGS "")
+
 if(DEFINED DSN_BOOST_HEADER_ONLY AND DSN_BOOST_HEADER_ONLY)
-    list(APPEND THRIFT_CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -DBOOST_ERROR_CODE_HEADER_ONLY;")
+    list(APPEND THRIFT_CMAKE_ARGS "-DBOOST_ERROR_CODE_HEADER_ONLY;")
+endif()
+
+# Suppress macOS SDK warnings for deprecated functions such as sprintf.
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(THRIFT_CXX_FLAGS "${THRIFT_CXX_FLAGS} -Wno-deprecated-declarations")
 endif()
 
 if(WIN32)
@@ -47,6 +55,10 @@ else()
         "-DBUILD_COMPILER=ON;"
         "-DWITH_STATIC_LIB=OFF;"
     )
+endif()
+
+if(THRIFT_CXX_FLAGS)
+    list(APPEND THRIFT_CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${THRIFT_CXX_FLAGS};")
 endif()
 
 ExternalProject_Add(thrift


### PR DESCRIPTION
## Summary

Suppress noisy compiler warnings from the protobuf and thrift external builds, especially on macOS with newer Xcode SDKs.

## Changes

- Pass additional non-Windows CXX warning suppressions to protobuf and thrift external CMake builds:
  - `-Wno-unused-variable`
  - `-Wno-unused-parameter`
  - `-Wno-unused-but-set-variable`
  - `-Wno-unused-const-variable`
  - `-Wno-unused-private-field`
  - `-Wno-deprecated-declarations`
- Preserve thrift’s `BOOST_ERROR_CODE_HEADER_ONLY` as a compiler definition when `DSN_BOOST_HEADER_ONLY` is enabled.
- Keep warning suppression in rDSN’s external-project CMake wrappers instead of modifying thrift/protobuf source.

## Notes

These warnings come from old third-party dependency code and are harmless. This change only reduces build log noise; it does not change rDSN runtime behavior or generated code.

## Testing

- Verified protobuf and thrift external CMake wrapper configuration locally.