### PR TITLE
Harden public API parameter validation

### DIFF
--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -846,11 +846,15 @@ extern DSN_API void*         dsn_rpc_unregiser_handler(
                                 dsn_gpid gpid DEFAULT(dsn_gpid())
                                 );
 
-/*! reply with a response which is created using dsn_msg_create_response */
-extern DSN_API void          dsn_rpc_reply(dsn_message_t response, dsn_error_t err DEFAULT(0));
+/*! reply with a response which is created using dsn_msg_create_response.
+    \return ERR_OK if the reply is submitted, otherwise the submission error code.
+ */
+extern DSN_API dsn_error_t   dsn_rpc_reply(dsn_message_t response, dsn_error_t err DEFAULT(0));
 
-/*! forward the request to another server instead */
-extern DSN_API void          dsn_rpc_forward(dsn_message_t request, dsn_address_t addr);
+/*! forward the request to another server instead.
+    \return ERR_OK if the forward request is submitted, otherwise the submission error code.
+ */
+extern DSN_API dsn_error_t   dsn_rpc_forward(dsn_message_t request, dsn_address_t addr);
 
 
 /*@}*/
@@ -906,8 +910,10 @@ extern DSN_API dsn_task_t    dsn_rpc_create_response_task_ex(
                                 dsn_task_tracker_t tracker DEFAULT(nullptr)
                                 );
 
-/*! client invokes the RPC call */
-extern DSN_API void          dsn_rpc_call(
+/*! client invokes the RPC call.
+    \return ERR_OK if the call is submitted, otherwise the submission error code.
+ */
+extern DSN_API dsn_error_t   dsn_rpc_call(
                                 dsn_address_t server,
                                 dsn_task_t rpc_call
                                 );
@@ -921,8 +927,10 @@ extern DSN_API dsn_message_t dsn_rpc_call_wait(
                                 dsn_message_t request
                                 );
 
-/*! one-way RPC from client, no rpc response is expected */
-extern DSN_API void          dsn_rpc_call_one_way(
+/*! one-way RPC from client, no rpc response is expected.
+    \return ERR_OK if the call is submitted, otherwise the submission error code.
+ */
+extern DSN_API dsn_error_t   dsn_rpc_call_one_way(
                                 dsn_address_t server, 
                                 dsn_message_t request
                                 );
@@ -933,10 +941,12 @@ extern DSN_API void          dsn_rpc_call_one_way(
 */
 extern DSN_API dsn_message_t dsn_rpc_get_response(dsn_task_t rpc_call);
 
-/*! this is to mimic a response is received when no real rpc is called */
-extern DSN_API void          dsn_rpc_enqueue_response(
-                                dsn_task_t rpc_call, 
-                                dsn_error_t err, 
+/*! enqueue an RPC response task.
+    \return ERR_OK if the response is enqueued, otherwise the submission error code.
+ */
+extern DSN_API dsn_error_t   dsn_rpc_enqueue_response(
+                                dsn_task_t rpc_call,
+                                dsn_error_t err,
                                 dsn_message_t response
                                 );
 
@@ -1044,8 +1054,9 @@ extern DSN_API dsn_task_t   dsn_file_create_aio_task_ex(
  \param count  byte size of the read buffer
  \param offset offset in the file to start reading
  \param cb     callback aio task to be executed on completion
+ \return ERR_OK if the read request is submitted, otherwise the submission error code.
  */
-extern DSN_API void         dsn_file_read(
+extern DSN_API dsn_error_t  dsn_file_read(
                                 dsn_handle_t file, 
                                 char* buffer, 
                                 int count, 
@@ -1061,8 +1072,9 @@ extern DSN_API void         dsn_file_read(
  \param count  byte size of the to-be-written content
  \param offset offset in the file to start write
  \param cb     callback aio task to be executed on completion
+ \return ERR_OK if the write request is submitted, otherwise the submission error code.
  */
-extern DSN_API void         dsn_file_write(
+extern DSN_API dsn_error_t  dsn_file_write(
                                 dsn_handle_t file, 
                                 const char* buffer, 
                                 int count, 
@@ -1078,8 +1090,9 @@ extern DSN_API void         dsn_file_write(
  \param buffer_count  number of write buffers
  \param offset        offset in the file to start write
  \param cb            callback aio task to be executed on completion
+ \return ERR_OK if the write request is submitted, otherwise the submission error code.
  */
-extern DSN_API void         dsn_file_write_vector(
+extern DSN_API dsn_error_t  dsn_file_write_vector(
                                 dsn_handle_t file,
                                 const dsn_file_buffer_t* buffers,
                                 int buffer_count,
@@ -1095,8 +1108,9 @@ extern DSN_API void         dsn_file_write_vector(
  \param dest_dir   destination dir on local server
  \param overwrite  true to overwrite, false to preserve.
  \param cb         callback aio task to be executed on completion
+ \return ERR_OK if the copy request is submitted, otherwise the submission error code.
  */
-extern DSN_API void         dsn_file_copy_remote_directory(
+extern DSN_API dsn_error_t  dsn_file_copy_remote_directory(
                                 dsn_address_t remote, 
                                 const char* source_dir, 
                                 const char* dest_dir,
@@ -1114,8 +1128,9 @@ extern DSN_API void         dsn_file_copy_remote_directory(
  \param dest_dir     destination dir on local server
  \param overwrite    true to overwrite, false to preserve.
  \param cb           callback aio task to be executed on completion
+ \return ERR_OK if the copy request is submitted, otherwise the submission error code.
  */
-extern DSN_API void         dsn_file_copy_remote_files(
+extern DSN_API dsn_error_t  dsn_file_copy_remote_files(
                                 dsn_address_t remote,
                                 const char* source_dir, 
                                 const char** source_files, 
@@ -1127,8 +1142,10 @@ extern DSN_API void         dsn_file_copy_remote_files(
 /*! get read/written io size for the given aio task */
 extern DSN_API size_t       dsn_file_get_io_size(dsn_task_t cb_task);
 
-/*! mimic io completion when no io operation is really issued */
-extern DSN_API void         dsn_file_task_enqueue(
+/*! mimic io completion when no io operation is really issued.
+    \return ERR_OK if the aio task is enqueued, otherwise the submission error code.
+ */
+extern DSN_API dsn_error_t  dsn_file_task_enqueue(
                                 dsn_task_t cb_task, 
                                 dsn_error_t err, 
                                 size_t size

--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -234,8 +234,9 @@ extern DSN_API bool        dsn_task_cancel(dsn_task_t task, bool wait_until_fini
 
  \param task                the task handle
  \param delay_ms            the delay milliseconds for a task
+ \return true if the delay is set, false if the parameters are invalid.
  */
-extern DSN_API void        dsn_task_set_delay(dsn_task_t task, int delay_ms);
+extern DSN_API bool        dsn_task_set_delay(dsn_task_t task, int delay_ms);
 
 /*!
  cancel a task
@@ -432,8 +433,9 @@ extern DSN_API dsn_task_t  dsn_task_create_timer_ex(
 
  \param task                the task handle
  \param delay_milliseconds  delay time before its execution
+ \return true if the task is enqueued, false if the parameters are invalid.
  */
-extern DSN_API void        dsn_task_call(
+extern DSN_API bool        dsn_task_call(
                             dsn_task_t task,                                 
                             int delay_milliseconds DEFAULT(0)
                             );
@@ -733,8 +735,9 @@ inline void dsn_address_size_checker()
  \param msg  the message handle
  \param opts options to be set in the message
  \param mask the mask composed using e.g., DSN_MSGM_TIMEOUT above to specify what to set
+ \return true if the options are set, false if the parameters are invalid.
  */
-extern DSN_API void          dsn_msg_set_options(
+extern DSN_API bool          dsn_msg_set_options(
                                 dsn_message_t msg,
                                 dsn_msg_options_t *opts,
                                 uint32_t mask
@@ -745,13 +748,17 @@ extern DSN_API void          dsn_msg_set_options(
 
  \param msg  the message handle
  \param opts options to be get
+ \return true if the options are returned, false if the parameters are invalid.
  */
-extern DSN_API void         dsn_msg_get_options(
+extern DSN_API bool         dsn_msg_get_options(
                                 dsn_message_t msg,
                                 /*out*/ dsn_msg_options_t* opts
                                 );
 
-DSN_API void dsn_msg_set_serailize_format(dsn_message_t msg, dsn_msg_serialize_format fmt);
+/*! set the message serialization format.
+    \return true if the format is set, false if the parameters are invalid.
+ */
+DSN_API bool dsn_msg_set_serailize_format(dsn_message_t msg, dsn_msg_serialize_format fmt);
 
 DSN_API dsn_msg_serialize_format dsn_msg_get_serialize_format(dsn_message_t msg);
 
@@ -780,16 +787,19 @@ extern DSN_API dsn_task_code_t dsn_msg_task_code(dsn_message_t msg);
  \param ptr      *ptr returns the writable memory pointer
  \param size     *size returns the writable memory buffer size
  \param min_size *size must >= min_size
+ \return true if a write buffer is returned, false if the parameters are invalid.
  */
-extern DSN_API void          dsn_msg_write_next(
+extern DSN_API bool          dsn_msg_write_next(
                                 dsn_message_t msg, 
                                 /*out*/ void** ptr, 
                                 /*out*/ size_t* size, 
                                 size_t min_size
                                 );
 
-/*! commit the write buffer after the message content is written with the real written size */
-extern DSN_API void          dsn_msg_write_commit(dsn_message_t msg, size_t size);
+/*! commit the write buffer after the message content is written with the real written size.
+    \return true if the buffer is committed, false if the parameters are invalid.
+ */
+extern DSN_API bool          dsn_msg_write_commit(dsn_message_t msg, size_t size);
 
 /*!
  get message read buffer
@@ -808,8 +818,9 @@ extern DSN_API bool          dsn_msg_read_next(
 
 /*! commit the read buffer after the message content is read with the real read size,
     it is possible to use a different size to allow duplicated or skipped read in the message.
+    \return true if the buffer is committed, false if the parameters are invalid.
  */
-extern DSN_API void          dsn_msg_read_commit(dsn_message_t msg, size_t size);
+extern DSN_API bool          dsn_msg_read_commit(dsn_message_t msg, size_t size);
 
 /*@}*/
 

--- a/include/dsn/c/api_layer2.h
+++ b/include/dsn/c/api_layer2.h
@@ -92,8 +92,9 @@ send an RPC request to a local application and execute
 \param app_context_for_downcalls see \ref dsn_hosted_app_create
 \param msg the RPC request
 \param exec_inline whether to execute the RPC handler within this call or not
+\return ERR_OK if the request is dispatched, otherwise the submission error code.
 */
-extern DSN_API void        dsn_hosted_app_commit_rpc_request(void* app_context_for_downcalls, dsn_message_t msg, bool exec_inline);
+extern DSN_API dsn_error_t dsn_hosted_app_commit_rpc_request(void* app_context_for_downcalls, dsn_message_t msg, bool exec_inline);
 
 /*@}*/
 

--- a/include/dsn/c/app_model.h
+++ b/include/dsn/c/app_model.h
@@ -59,8 +59,8 @@ extern "C" {
   int main(int argc, char** argv)
   {
     // register all app types
-    dsn::register_app<test_client>("test");
-    dsn::register_app<test_server>("server");
+    dassert(dsn::register_app<test_client>("test"), "register test app failed");
+    dassert(dsn::register_app<test_server>("server"), "register server app failed");
 
     // run rDSN
     dsn_run(argc, argv, true);

--- a/include/dsn/c/app_tools.h
+++ b/include/dsn/c/app_tools.h
@@ -71,7 +71,7 @@ typedef void(*dsn_checker_apply)(
  \param create callback to create the checker
  \param apply  callback to execute the checker
  */
-extern DSN_API void      dsn_register_app_checker(
+extern DSN_API bool      dsn_register_app_checker(
     const char* name,
     dsn_checker_create create,
     dsn_checker_apply apply

--- a/include/dsn/cpp/address.h
+++ b/include/dsn/cpp/address.h
@@ -143,6 +143,13 @@ namespace dsn
     inline void rpc_address::assign_ipv4(const char* host, uint16_t port)
     {
         clear();
+        if (host == nullptr || host[0] == '\0')
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.address", "rpc_address::assign_ipv4 got invalid host");
+            _addr.u.v4.type = HOST_TYPE_INVALID;
+            return;
+        }
+
         _addr.u.v4.type = HOST_TYPE_IPV4;
         _addr.u.v4.ip = dsn_ipv4_from_host(host);
         _addr.u.v4.port = port;
@@ -151,6 +158,13 @@ namespace dsn
     inline void rpc_address::assign_ipv4_local_address(const char* network_interface, uint16_t port)
     {
         clear();
+        if (network_interface == nullptr || network_interface[0] == '\0')
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.address", "rpc_address::assign_ipv4_local_address got invalid network_interface");
+            _addr.u.v4.type = HOST_TYPE_INVALID;
+            return;
+        }
+
         _addr.u.v4.type = HOST_TYPE_IPV4;
         _addr.u.v4.ip = dsn_ipv4_local(network_interface);
         _addr.u.v4.port = port;
@@ -159,6 +173,13 @@ namespace dsn
     inline void rpc_address::assign_uri(dsn_uri_t uri)
     {
         clear();
+        if (uri == nullptr)
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.address", "rpc_address::assign_uri got null uri");
+            _addr.u.v4.type = HOST_TYPE_INVALID;
+            return;
+        }
+
         _addr.u.v4.type = HOST_TYPE_URI;
         _addr.u.uri.uri = (uint64_t)uri;
     }
@@ -166,6 +187,13 @@ namespace dsn
     inline void rpc_address::assign_group(dsn_group_t g)
     {
         clear();
+        if (g == nullptr)
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.address", "rpc_address::assign_group got null group");
+            _addr.u.v4.type = HOST_TYPE_INVALID;
+            return;
+        }
+
         _addr.u.v4.type = HOST_TYPE_GROUP;
         _addr.u.group.group = (uint64_t)g;
     }
@@ -250,10 +278,18 @@ namespace dsn
 
     inline bool rpc_address::from_string_ipv4(const char* s)
     {
+        if (s == nullptr || s[0] == '\0')
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.address", "rpc_address::from_string_ipv4 got invalid string");
+            return false;
+        }
+
         std::string str = std::string(s);
         auto pos = str.find_last_of(':');
         if (pos == std::string::npos)
+        {
             return false;
+        }
         else
         {
             auto host = str.substr(0, pos);
@@ -265,6 +301,13 @@ namespace dsn
 
     inline url_host_address::url_host_address(const char* url_or_host_port)
     {
+        if (url_or_host_port == nullptr || url_or_host_port[0] == '\0')
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.address", "url_host_address got invalid url_or_host_port");
+            set_invalid();
+            return;
+        }
+
         std::string s(url_or_host_port);
         auto sp = s.find(':');
         if (sp != std::string::npos)

--- a/include/dsn/cpp/auto_codes.h
+++ b/include/dsn/cpp/auto_codes.h
@@ -305,9 +305,8 @@ namespace dsn
     public:
         error_code(const char* name)
         {
+            dassert(name != nullptr && name[0] != '\0', "name for an error code cannot be null or empty");
             _internal_code = dsn_error_register(name);
-
-            dassert (name, "name for an error code cannot be empty");
     # ifdef TRACK_ERROR_CODE
             _used = true;
     # endif
@@ -482,4 +481,3 @@ namespace dsn
     DEFINE_ERR_CODE(ERR_NETWORK_FAILURE)
 /*@}*/
 } // end namespace
-

--- a/include/dsn/cpp/blob.h
+++ b/include/dsn/cpp/blob.h
@@ -67,15 +67,27 @@ namespace dsn
 
         blob(const std::shared_ptr<char>& buffer, int offset, unsigned int length)
             : _holder(buffer), _buffer(_holder.get()), _data(_holder.get() + offset), _length(length)
-        {}
+        {
+            dassert(buffer != nullptr || (offset == 0 && length == 0),
+                    "blob got null buffer with non-empty range");
+            dassert(offset >= 0, "blob got invalid offset = %d", offset);
+        }
 
         blob(std::shared_ptr<char>&& buffer, int offset, unsigned int length)
             : _holder(std::move(buffer)), _buffer(_holder.get()), _data(_holder.get() + offset), _length(length)
-        {}
+        {
+            dassert(_holder != nullptr || (offset == 0 && length == 0),
+                    "blob got null buffer with non-empty range");
+            dassert(offset >= 0, "blob got invalid offset = %d", offset);
+        }
 
         blob(const char* buffer, int offset, unsigned int length)
             : _buffer(buffer), _data(buffer + offset), _length(length)
-        {}
+        {
+            dassert(buffer != nullptr || (offset == 0 && length == 0),
+                    "blob got null buffer with non-empty range");
+            dassert(offset >= 0, "blob got invalid offset = %d", offset);
+        }
 
         blob(const blob& source)
             : _holder(source._holder), _buffer(source._buffer), _data(source._data), _length(source._length)
@@ -112,6 +124,9 @@ namespace dsn
 
         void assign(const std::shared_ptr<char>& buffer, int offset, unsigned int length)
         {
+            dassert(buffer != nullptr || (offset == 0 && length == 0),
+                    "blob::assign got null buffer with non-empty range");
+            dassert(offset >= 0, "blob::assign got invalid offset = %d", offset);
             _holder = buffer;
             _buffer = _holder.get();
             _data = _holder.get() + offset;
@@ -120,6 +135,9 @@ namespace dsn
 
         void assign(std::shared_ptr<char>&& buffer, int offset, unsigned int length)
         {
+            dassert(buffer != nullptr || (offset == 0 && length == 0),
+                    "blob::assign got null buffer with non-empty range");
+            dassert(offset >= 0, "blob::assign got invalid offset = %d", offset);
             _holder = std::move(buffer);
             _buffer = (_holder.get());
             _data = (_holder.get() + offset);
@@ -128,6 +146,9 @@ namespace dsn
 
         void assign(const char* buffer, int offset, unsigned int length)
         {
+            dassert(buffer != nullptr || (offset == 0 && length == 0),
+                    "blob::assign got null buffer with non-empty range");
+            dassert(offset >= 0, "blob::assign got invalid offset = %d", offset);
             _holder = nullptr;
             _buffer = buffer;
             _data = buffer + offset;
@@ -192,7 +213,7 @@ namespace dsn
         binary_reader(const blob& blob);
 
         // or delayed init
-        binary_reader() {}
+        binary_reader() : _blob(), _size(0), _ptr(nullptr), _remaining_size(0) {}
 
         virtual ~binary_reader() {}
 
@@ -219,7 +240,14 @@ namespace dsn
         bool backup(int count);
 
         blob get_buffer() const { return _blob; }
-        blob get_remaining_buffer() const { return _blob.range(static_cast<int>(_ptr - _blob.data())); }
+        blob get_remaining_buffer() const
+        {
+            if (_ptr == nullptr || _blob.data() == nullptr)
+            {
+                return blob();
+            }
+            return _blob.range(static_cast<int>(_ptr - _blob.data()));
+        }
         bool is_eof() const { return _ptr >= _blob.data() + _size; }
         int  total_size() const { return _size; }
         int  get_remaining_size() const { return _remaining_size; }
@@ -318,6 +346,11 @@ namespace dsn
 
     inline blob binary_writer::get_first_buffer() const
     {
+        if (_buffers.empty())
+        {
+            return blob();
+        }
+
         return _buffers[0];
     }
 

--- a/include/dsn/cpp/clientlet.h
+++ b/include/dsn/cpp/clientlet.h
@@ -145,6 +145,11 @@ namespace dsn
                 tsk,
                 hash,
                 svc ? svc->tracker() : nullptr);
+            if (native_tsk == nullptr)
+            {
+                tsk->release_ref();
+                return nullptr;
+            }
             tsk->set_task_info(native_tsk);
             return tsk;
         }
@@ -168,6 +173,11 @@ namespace dsn
                 hash,
                 static_cast<int>(timer_interval.count()),
                 svc ? svc->tracker() : nullptr);
+            if (native_tsk == nullptr)
+            {
+                tsk->release_ref();
+                return nullptr;
+            }
             tsk->set_task_info(native_tsk);
             return tsk;
         }
@@ -181,6 +191,10 @@ namespace dsn
             std::chrono::milliseconds delay = std::chrono::milliseconds(0))
         {
             auto tsk = create_task(evt, svc, std::forward<TCallback>(callback), hash);
+            if (tsk == nullptr)
+            {
+                return nullptr;
+            }
             tsk->enqueue(delay);
             return tsk;
         }
@@ -195,6 +209,10 @@ namespace dsn
             std::chrono::milliseconds delay = std::chrono::milliseconds(0))
         {
             auto tsk = create_timer_task(evt, svc, std::forward<TCallback>(callback), timer_interval, hash);
+            if (tsk == nullptr)
+            {
+                return nullptr;
+            }
             tsk->enqueue(delay);
             return tsk;
         }
@@ -213,6 +231,11 @@ namespace dsn
                 safe_late_task<THandler>::exec,
                 safe_late_task<THandler>::on_cancel,
                 tsk, hash, svc ? svc->tracker() : nullptr);
+            if (t == nullptr)
+            {
+                tsk->release_ref();
+                return nullptr;
+            }
 
             tsk->set_task_info(t);
             return tsk;
@@ -252,6 +275,11 @@ namespace dsn
                 reply_thread_hash,
                 svc ? svc->tracker() : nullptr
                 );
+            if (t == nullptr)
+            {
+                tsk->release_ref();
+                return nullptr;
+            }
             tsk->set_task_info(t);
             return tsk;
         }
@@ -289,6 +317,10 @@ namespace dsn
             )
         {
             task_ptr t = create_rpc_response_task(request, svc, std::forward<TCallback>(callback), reply_thread_hash);
+            if (t == nullptr)
+            {
+                return nullptr;
+            }
             auto err = dsn_rpc_call(server.c_addr(), t->native_handle());
             if (err != ERR_OK)
             {
@@ -311,6 +343,10 @@ namespace dsn
             )
         {
             dsn_message_t msg = dsn_msg_create_request(code, static_cast<int>(timeout.count()), thread_hash, partition_hash);
+            if (msg == nullptr)
+            {
+                return nullptr;
+            }
             ::dsn::marshall(msg, std::forward<TRequest>(req));
             return call(server, msg, owner, std::forward<TCallback>(callback), reply_thread_hash);
         }
@@ -342,6 +378,10 @@ namespace dsn
             )
         {
             dsn_message_t msg = dsn_msg_create_request(code, static_cast<int>(timeout.count()), thread_hash, partition_hash);
+            if (msg == nullptr)
+            {
+                return rpc_message_helper(nullptr);
+            }
             ::dsn::marshall(msg, std::forward<TRequest>(req));
             return rpc_message_helper(msg);
         }
@@ -367,14 +407,25 @@ namespace dsn
             )
         {
             dsn_message_t msg = dsn_msg_create_request(code, 0, thread_hash, partition_hash);
+            if (msg == nullptr)
+            {
+                return;
+            }
             ::dsn::marshall(msg, req);
             auto err = dsn_rpc_call_one_way(server.c_addr(), msg);
-            dassert(err == ERR_OK, "dsn_rpc_call_one_way failed: %s", error_code(err).to_string());
+            if (err != ERR_OK)
+            {
+                derror("dsn_rpc_call_one_way failed: %s", error_code(err).to_string());
+            }
         }
         
         template<typename TResponse>
         std::pair< ::dsn::error_code, TResponse> wait_and_unwrap(safe_task_handle* task)
         {
+            if (task == nullptr)
+            {
+                return std::make_pair(::dsn::ERR_INVALID_PARAMETERS, TResponse{});
+            }
             task->wait();
             std::pair< ::dsn::error_code, TResponse> result;
             result.first = task->error();
@@ -429,6 +480,11 @@ namespace dsn
                 transient_safe_task<callback_storage_t>::on_cancel,
                 tsk, hash, svc ? svc->tracker() : nullptr
                 );
+            if (t == nullptr)
+            {
+                tsk->release_ref();
+                return nullptr;
+            }
 
             tsk->set_task_info(t);
             return tsk;
@@ -447,6 +503,10 @@ namespace dsn
             )
         {
             auto tsk = create_aio_task(callback_code, svc, std::forward<TCallback>(callback), hash);
+            if (tsk == nullptr)
+            {
+                return nullptr;
+            }
             auto err = dsn_file_read(fh, buffer, count, offset, tsk->native_handle());
             if (err != ERR_OK)
             {
@@ -468,6 +528,10 @@ namespace dsn
             )
         {
             auto tsk = create_aio_task(callback_code, svc, std::forward<TCallback>(callback), hash);
+            if (tsk == nullptr)
+            {
+                return nullptr;
+            }
             auto err = dsn_file_write(fh, buffer, count, offset, tsk->native_handle());
             if (err != ERR_OK)
             {
@@ -489,6 +553,10 @@ namespace dsn
             )
         {
             auto tsk = create_aio_task(callback_code, svc, std::forward<TCallback>(callback), hash);
+            if (tsk == nullptr)
+            {
+                return nullptr;
+            }
             auto err = dsn_file_write_vector(fh, buffers, buffer_count, offset, tsk->native_handle());
             if (err != ERR_OK)
             {
@@ -520,6 +588,10 @@ namespace dsn
             )
         {
             auto tsk = create_aio_task(callback_code, svc, std::forward<TCallback>(callback), hash);
+            if (tsk == nullptr)
+            {
+                return nullptr;
+            }
             auto err = copy_remote_files_impl(remote, source_dir, files, dest_dir, overwrite, tsk->native_handle());
             if (err != ERR_OK)
             {

--- a/include/dsn/cpp/clientlet.h
+++ b/include/dsn/cpp/clientlet.h
@@ -289,7 +289,11 @@ namespace dsn
             )
         {
             task_ptr t = create_rpc_response_task(request, svc, std::forward<TCallback>(callback), reply_thread_hash);
-            dsn_rpc_call(server.c_addr(), t->native_handle());
+            auto err = dsn_rpc_call(server.c_addr(), t->native_handle());
+            if (err != ERR_OK)
+            {
+                t->enqueue_rpc_response(error_code(err), nullptr);
+            }
             return t;
         }
 
@@ -364,7 +368,8 @@ namespace dsn
         {
             dsn_message_t msg = dsn_msg_create_request(code, 0, thread_hash, partition_hash);
             ::dsn::marshall(msg, req);
-            dsn_rpc_call_one_way(server.c_addr(), msg);
+            auto err = dsn_rpc_call_one_way(server.c_addr(), msg);
+            dassert(err == ERR_OK, "dsn_rpc_call_one_way failed: %s", error_code(err).to_string());
         }
         
         template<typename TResponse>
@@ -442,7 +447,11 @@ namespace dsn
             )
         {
             auto tsk = create_aio_task(callback_code, svc, std::forward<TCallback>(callback), hash);
-            dsn_file_read(fh, buffer, count, offset, tsk->native_handle());
+            auto err = dsn_file_read(fh, buffer, count, offset, tsk->native_handle());
+            if (err != ERR_OK)
+            {
+                tsk->enqueue_aio(error_code(err), 0);
+            }
             return tsk;
         }
 
@@ -459,7 +468,11 @@ namespace dsn
             )
         {
             auto tsk = create_aio_task(callback_code, svc, std::forward<TCallback>(callback), hash);
-            dsn_file_write(fh, buffer, count, offset, tsk->native_handle());
+            auto err = dsn_file_write(fh, buffer, count, offset, tsk->native_handle());
+            if (err != ERR_OK)
+            {
+                tsk->enqueue_aio(error_code(err), 0);
+            }
             return tsk;
         }
 
@@ -476,11 +489,15 @@ namespace dsn
             )
         {
             auto tsk = create_aio_task(callback_code, svc, std::forward<TCallback>(callback), hash);
-            dsn_file_write_vector(fh, buffers, buffer_count, offset, tsk->native_handle());
+            auto err = dsn_file_write_vector(fh, buffers, buffer_count, offset, tsk->native_handle());
+            if (err != ERR_OK)
+            {
+                tsk->enqueue_aio(error_code(err), 0);
+            }
             return tsk;
         }
 
-        void copy_remote_files_impl(
+        error_code copy_remote_files_impl(
             ::dsn::rpc_address remote,
             const std::string& source_dir,
             const std::vector<std::string>& files,  // empty for all
@@ -503,7 +520,11 @@ namespace dsn
             )
         {
             auto tsk = create_aio_task(callback_code, svc, std::forward<TCallback>(callback), hash);
-            copy_remote_files_impl(remote, source_dir, files, dest_dir, overwrite, tsk->native_handle());
+            auto err = copy_remote_files_impl(remote, source_dir, files, dest_dir, overwrite, tsk->native_handle());
+            if (err != ERR_OK)
+            {
+                tsk->enqueue_aio(err, 0);
+            }
             return tsk;
         }
 

--- a/include/dsn/cpp/layer2_handler.h
+++ b/include/dsn/cpp/layer2_handler.h
@@ -64,14 +64,25 @@ namespace dsn
         static void on_layer2_rpc_request(void* app, dsn_gpid gpid, bool is_write, dsn_message_t msg)
         {
             auto sapp = (layer2_handler*)app;
-            return sapp->on_request(gpid, is_write, msg);
+            if (sapp == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.layer2_handler", "on_layer2_rpc_request got null app");
+                return;
+            }
+            sapp->on_request(gpid, is_write, msg);
         }
     };
 
     /*! C++ wrapper of the \ref dsn_register_app function for layer 2 frameworks */
     template<typename TServiceApp>
-    void register_layer2_framework(const char* type_name, uint64_t framework_mask)
+    bool register_layer2_framework(const char* type_name, uint64_t framework_mask)
     {
+        if (type_name == nullptr || type_name[0] == '\0')
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.layer2_handler", "register_layer2_framework got invalid type_name");
+            return false;
+        }
+
         dsn_app app;
         memset(&app, 0, sizeof(app));
         app.mask = framework_mask;
@@ -82,6 +93,6 @@ namespace dsn
 
         app.layer2.frameworks.on_rpc_request = layer2_handler::on_layer2_rpc_request;
 
-        dsn_register_app(&app);
+        return dsn_register_app(&app);
     }
 }

--- a/include/dsn/cpp/replicated_service_app.h
+++ b/include/dsn/cpp/replicated_service_app.h
@@ -100,6 +100,15 @@ namespace dsn
 
             ::dsn::error_code to_c_state(dsn_app_learn_state& state, int state_capacity)
             {
+                if (state_capacity < 0)
+                {
+                    return ERR_INVALID_PARAMETERS;
+                }
+                if (state_capacity < static_cast<int>(sizeof(dsn_app_learn_state)))
+                {
+                    return ERR_INVALID_PARAMETERS;
+                }
+
                 bool succ = true;
 
                 state.from_decree_excluded = from_decree_excluded;
@@ -197,31 +206,95 @@ namespace dsn
     public:
         static void app_on_batched_write_requests(void* app, int64_t decree, dsn_message_t* requests, int count)
         {
+            if (app == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR,
+                     "cpp.replicated_service_app",
+                     "app_on_batched_write_requests got null app");
+                return;
+            }
+            if (count < 0)
+            {
+                dlog(LOG_LEVEL_ERROR,
+                     "cpp.replicated_service_app",
+                     "app_on_batched_write_requests got invalid count = %d",
+                     count);
+                return;
+            }
+            if (count > 0 && requests == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR,
+                     "cpp.replicated_service_app",
+                     "app_on_batched_write_requests got null requests");
+                return;
+            }
+
             reinterpret_cast<replicated_service_app_type_1*>(app)->on_batched_write_requests(decree, requests, count);
         }
 
         static int app_get_physical_error(void* app)
         {
+            if (app == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_get_physical_error got null app");
+                return ERR_INVALID_PARAMETERS;
+            }
+
             return reinterpret_cast<replicated_service_app_type_1*>(app)->get_physical_error();
         }
 
         static dsn_error_t app_sync_checkpoint(void* app, int64_t last_commit)
         {
+            if (app == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_sync_checkpoint got null app");
+                return ERR_INVALID_PARAMETERS;
+            }
+
             return reinterpret_cast<replicated_service_app_type_1*>(app)->sync_checkpoint(last_commit);
         }
 
         static dsn_error_t app_async_checkpoint(void* app, int64_t last_commit)
         {
+            if (app == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_async_checkpoint got null app");
+                return ERR_INVALID_PARAMETERS;
+            }
+
             return reinterpret_cast<replicated_service_app_type_1*>(app)->async_checkpoint(last_commit);
         }
 
         static int64_t app_get_last_checkpoint_decree(void* app)
         {
+            if (app == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR,
+                     "cpp.replicated_service_app",
+                     "app_get_last_checkpoint_decree got null app");
+                return -1;
+            }
+
             return reinterpret_cast<replicated_service_app_type_1*>(app)->get_last_checkpoint_decree();
         }
 
         static dsn_error_t app_prepare_get_checkpoint(void* app, void* buffer, int capacity, int* occupied)
         {
+            if (app == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR,
+                     "cpp.replicated_service_app",
+                     "app_prepare_get_checkpoint got null app");
+                return ERR_INVALID_PARAMETERS;
+            }
+            if (occupied == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR,
+                     "cpp.replicated_service_app",
+                     "app_prepare_get_checkpoint got null occupied");
+                return ERR_INVALID_PARAMETERS;
+            }
+
             return reinterpret_cast<replicated_service_app_type_1*>(app)->prepare_get_checkpoint(buffer, capacity, occupied);
         }
         
@@ -235,6 +308,33 @@ namespace dsn
             int state_capacity
             )
         {
+            if (app == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_get_checkpoint got null app");
+                return ERR_INVALID_PARAMETERS;
+            }
+            if (state == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_get_checkpoint got null state");
+                return ERR_INVALID_PARAMETERS;
+            }
+            if (state_capacity < 0)
+            {
+                dlog(LOG_LEVEL_ERROR,
+                     "cpp.replicated_service_app",
+                     "app_get_checkpoint got invalid state_capacity = %d",
+                     state_capacity);
+                return ERR_INVALID_PARAMETERS;
+            }
+            if (state_capacity < static_cast<int>(sizeof(dsn_app_learn_state)))
+            {
+                dlog(LOG_LEVEL_ERROR,
+                     "cpp.replicated_service_app",
+                     "app_get_checkpoint got invalid state_capacity = %d",
+                     state_capacity);
+                return ERR_INVALID_PARAMETERS;
+            }
+
             app_learn_state cpp_state;
             auto err = reinterpret_cast<replicated_service_app_type_1*>(app)->get_checkpoint(
                     learn_start, local_commit, learn_request, learn_request_size, cpp_state);
@@ -248,14 +348,33 @@ namespace dsn
             const dsn_app_learn_state* state
             )
         {
+            if (app == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_apply_checkpoint got null app");
+                return ERR_INVALID_PARAMETERS;
+            }
+            if (state == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_apply_checkpoint got null state");
+                return ERR_INVALID_PARAMETERS;
+            }
+
             return reinterpret_cast<replicated_service_app_type_1*>(app)->apply_checkpoint(mode, local_commit, *state);
         }
     };
 
     /*! C++ wrapper of the \ref dsn_register_app function for framework hosted apps */
     template<typename TServiceApp>
-    void register_app_with_type_1_replication_support(const char* type_name)
+    bool register_app_with_type_1_replication_support(const char* type_name)
     {
+        if (type_name == nullptr || type_name[0] == '\0')
+        {
+            dlog(LOG_LEVEL_ERROR,
+                 "cpp.replicated_service_app",
+                 "register_app_with_type_1_replication_support got invalid type_name");
+            return false;
+        }
+
         dsn_app app;
         memset(&app, 0, sizeof(app));
         app.mask = DSN_APP_MASK_FRAMEWORK;
@@ -278,7 +397,7 @@ namespace dsn
         else
             app.layer2.apps.calls.on_batched_write_requests = replicated_service_app_type_1::app_on_batched_write_requests;
 
-        dsn_register_app(&app);
+        return dsn_register_app(&app);
     }
 
     /*@}*/

--- a/include/dsn/cpp/replicated_service_app.h
+++ b/include/dsn/cpp/replicated_service_app.h
@@ -237,7 +237,7 @@ namespace dsn
             if (app == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_get_physical_error got null app");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
 
             return reinterpret_cast<replicated_service_app_type_1*>(app)->get_physical_error();
@@ -248,10 +248,10 @@ namespace dsn
             if (app == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_sync_checkpoint got null app");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
 
-            return reinterpret_cast<replicated_service_app_type_1*>(app)->sync_checkpoint(last_commit);
+            return reinterpret_cast<replicated_service_app_type_1*>(app)->sync_checkpoint(last_commit).get();
         }
 
         static dsn_error_t app_async_checkpoint(void* app, int64_t last_commit)
@@ -259,10 +259,10 @@ namespace dsn
             if (app == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_async_checkpoint got null app");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
 
-            return reinterpret_cast<replicated_service_app_type_1*>(app)->async_checkpoint(last_commit);
+            return reinterpret_cast<replicated_service_app_type_1*>(app)->async_checkpoint(last_commit).get();
         }
 
         static int64_t app_get_last_checkpoint_decree(void* app)
@@ -285,17 +285,19 @@ namespace dsn
                 dlog(LOG_LEVEL_ERROR,
                      "cpp.replicated_service_app",
                      "app_prepare_get_checkpoint got null app");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
             if (occupied == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR,
                      "cpp.replicated_service_app",
                      "app_prepare_get_checkpoint got null occupied");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
 
-            return reinterpret_cast<replicated_service_app_type_1*>(app)->prepare_get_checkpoint(buffer, capacity, occupied);
+            return reinterpret_cast<replicated_service_app_type_1*>(app)
+                ->prepare_get_checkpoint(buffer, capacity, occupied)
+                .get();
         }
         
         static dsn_error_t app_get_checkpoint(
@@ -311,12 +313,12 @@ namespace dsn
             if (app == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_get_checkpoint got null app");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
             if (state == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_get_checkpoint got null state");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
             if (state_capacity < 0)
             {
@@ -324,7 +326,7 @@ namespace dsn
                      "cpp.replicated_service_app",
                      "app_get_checkpoint got invalid state_capacity = %d",
                      state_capacity);
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
             if (state_capacity < static_cast<int>(sizeof(dsn_app_learn_state)))
             {
@@ -332,13 +334,13 @@ namespace dsn
                      "cpp.replicated_service_app",
                      "app_get_checkpoint got invalid state_capacity = %d",
                      state_capacity);
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
 
             app_learn_state cpp_state;
             auto err = reinterpret_cast<replicated_service_app_type_1*>(app)->get_checkpoint(
                     learn_start, local_commit, learn_request, learn_request_size, cpp_state);
-            return err == ERR_OK ? cpp_state.to_c_state(*state, state_capacity) : err;
+            return err == ERR_OK ? cpp_state.to_c_state(*state, state_capacity).get() : err.get();
         }
         
         static dsn_error_t app_apply_checkpoint(
@@ -351,15 +353,17 @@ namespace dsn
             if (app == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_apply_checkpoint got null app");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
             if (state == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.replicated_service_app", "app_apply_checkpoint got null state");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
 
-            return reinterpret_cast<replicated_service_app_type_1*>(app)->apply_checkpoint(mode, local_commit, *state);
+            return reinterpret_cast<replicated_service_app_type_1*>(app)
+                ->apply_checkpoint(mode, local_commit, *state)
+                .get();
         }
     };
 

--- a/include/dsn/cpp/rpc_stream.h
+++ b/include/dsn/cpp/rpc_stream.h
@@ -117,7 +117,8 @@ namespace dsn
         {
             if (!_last_write_next_committed)
             {
-                dsn_msg_write_commit(native_handle(), (size_t)(total_size() - _last_write_next_total_size));
+                dassert(dsn_msg_write_commit(native_handle(), (size_t)(total_size() - _last_write_next_total_size)),
+                        "dsn_msg_write_commit failed");
                 _last_write_next_committed = true;
             }
         }
@@ -140,8 +141,8 @@ namespace dsn
 
             void* ptr;
             size_t sz;
-            dsn_msg_write_next(native_handle(), &ptr, &sz, size);
-            dbg_dassert(sz >= size, "allocated buffer size must be not less than the required size");
+            dassert(dsn_msg_write_next(native_handle(), &ptr, &sz, size), "dsn_msg_write_next failed");
+            dassert(sz >= size, "allocated buffer size must be not less than the required size");
             bb.assign((const char*)ptr, 0, (int)sz);
 
             _last_write_next_total_size = total_size();

--- a/include/dsn/cpp/rpc_stream.h
+++ b/include/dsn/cpp/rpc_stream.h
@@ -66,6 +66,8 @@ namespace dsn
 
         void set_read_msg(dsn_message_t msg)
         {
+            dassert(msg != nullptr, "rpc_read_stream::set_read_msg got null message");
+
             assign(msg, false);
 
             void* ptr;
@@ -95,6 +97,7 @@ namespace dsn
         rpc_write_stream(dsn_message_t msg)
             : safe_handle<dsn_msg_release_ref>(msg, false)
         {
+            dassert(msg != nullptr, "rpc_write_stream got null response message");
             _last_write_next_committed = true;
             _last_write_next_total_size = 0;
         }
@@ -103,6 +106,7 @@ namespace dsn
         rpc_write_stream(task_code code, int timeout_ms = 0, int thread_hash = 0, uint64_t partition_hash = 0)
             : safe_handle<dsn_msg_release_ref>(dsn_msg_create_request(code, timeout_ms, thread_hash, partition_hash), false)
         {
+            dassert(native_handle() != nullptr, "rpc_write_stream failed to create request message");
             _last_write_next_committed = true;
             _last_write_next_total_size = 0;
         }

--- a/include/dsn/cpp/serialization.h
+++ b/include/dsn/cpp/serialization.h
@@ -135,6 +135,8 @@ namespace dsn
     template<typename T>
     inline void marshall(dsn_message_t msg, const T& val)
     {
+        dassert(msg != nullptr, "marshall got null message");
+
         ::dsn::rpc_write_stream writer(msg);
         marshall(writer, val, dsn_msg_get_serialize_format(msg));
     }
@@ -142,6 +144,8 @@ namespace dsn
     template<typename T>
     inline void marshall(dsn_message_t msg, const T& val, dsn_msg_serialize_format fmt)
     {
+        dassert(msg != nullptr, "marshall got null message");
+
         ::dsn::rpc_write_stream writer(msg);
         marshall(writer, val, fmt);
     }
@@ -149,6 +153,8 @@ namespace dsn
     template<typename T>
     inline void unmarshall(dsn_message_t msg, /*out*/ T& val)
     {
+        dassert(msg != nullptr, "unmarshall got null message");
+
         ::dsn::rpc_read_stream reader(msg);
         unmarshall(reader, val, dsn_msg_get_serialize_format(msg));
     }

--- a/include/dsn/cpp/serverlet.h
+++ b/include/dsn/cpp/serverlet.h
@@ -74,7 +74,8 @@ namespace dsn
             if (_response != nullptr)
             {
                 ::dsn::marshall(_response, resp);
-                dsn_rpc_reply(_response);
+                auto err = dsn_rpc_reply(_response);
+                dassert(err == ERR_OK, "dsn_rpc_reply failed: %s", error_code(err).to_string());
             }
         }
 
@@ -234,7 +235,8 @@ namespace dsn
     {
         auto msg = dsn_msg_create_response(request);
         ::dsn::marshall(msg, resp);
-        dsn_rpc_reply(msg);
+        auto err = dsn_rpc_reply(msg);
+        dassert(err == ERR_OK, "dsn_rpc_reply failed: %s", error_code(err).to_string());
     }
     /*@}*/
 } // end namespace

--- a/include/dsn/cpp/serverlet.h
+++ b/include/dsn/cpp/serverlet.h
@@ -129,7 +129,7 @@ namespace dsn
     // ------------- inline implementation ----------------
     template<typename T>
     inline serverlet<T>::serverlet(const char* nm, int task_bucket_count)
-        : clientlet(task_bucket_count), _name(nm)
+        : clientlet(task_bucket_count), _name(nm == nullptr ? "" : nm)
     {
     }
 
@@ -141,6 +141,12 @@ namespace dsn
     template<typename T> template<typename TRequest>
     inline bool serverlet<T>::register_rpc_handler(dsn_task_code_t rpc_code, const char* rpc_name_, void (T::*handler)(const TRequest&), dsn_gpid gpid)
     {
+        if (handler == nullptr)
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.serverlet", "register_rpc_handler got null handler");
+            return false;
+        }
+
         typedef handler_context<void (T::*)(const TRequest&)> hc_type1;
         auto hc = (hc_type1*)malloc(sizeof(hc_type1));
         hc->this_ = (T*)this;
@@ -155,12 +161,23 @@ namespace dsn
             ((hc2->this_)->*(hc2->cb))(req);
         };
 
-        return dsn_rpc_register_handler(rpc_code, rpc_name_, cb, hc, gpid);
+        if (!dsn_rpc_register_handler(rpc_code, rpc_name_, cb, hc, gpid))
+        {
+            free(hc);
+            return false;
+        }
+        return true;
     }
 
     template<typename T> template<typename TRequest, typename TResponse>
     inline bool serverlet<T>::register_rpc_handler(dsn_task_code_t rpc_code, const char* rpc_name_, void (T::*handler)(const TRequest&, TResponse&), dsn_gpid gpid)
     {
+        if (handler == nullptr)
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.serverlet", "register_rpc_handler got null handler");
+            return false;
+        }
+
         typedef handler_context<void (T::*)(const TRequest&, TResponse&)> hc_type2;
         auto hc = (hc_type2*)malloc(sizeof(hc_type2));
         hc->this_ = (T*)this;
@@ -180,12 +197,23 @@ namespace dsn
             replier(resp);
         };
 
-        return dsn_rpc_register_handler(rpc_code, rpc_name_, cb, hc, gpid);
+        if (!dsn_rpc_register_handler(rpc_code, rpc_name_, cb, hc, gpid))
+        {
+            free(hc);
+            return false;
+        }
+        return true;
     }
 
     template<typename T> template<typename TRequest, typename TResponse>
     inline bool serverlet<T>::register_async_rpc_handler(dsn_task_code_t rpc_code, const char* rpc_name_, void (T::*handler)(const TRequest&, rpc_replier<TResponse>&), dsn_gpid gpid)
     {
+        if (handler == nullptr)
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.serverlet", "register_async_rpc_handler got null handler");
+            return false;
+        }
+
         typedef handler_context<void (T::*)(const TRequest&, rpc_replier<TResponse>&)> hc_type3;
         auto hc = (hc_type3*)malloc(sizeof(hc_type3));
         hc->this_ = (T*)this;
@@ -202,12 +230,23 @@ namespace dsn
             ((hc2->this_)->*(hc2->cb))(req, replier);
         };
 
-        return dsn_rpc_register_handler(rpc_code, rpc_name_, cb, hc, gpid);
+        if (!dsn_rpc_register_handler(rpc_code, rpc_name_, cb, hc, gpid))
+        {
+            free(hc);
+            return false;
+        }
+        return true;
     }
 
     template<typename T>
     inline bool serverlet<T>::register_rpc_handler(dsn_task_code_t rpc_code, const char* rpc_name_, void (T::*handler)(dsn_message_t), dsn_gpid gpid)
     {
+        if (handler == nullptr)
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.serverlet", "register_rpc_handler got null handler");
+            return false;
+        }
+
         typedef handler_context<void (T::*)(dsn_message_t)> hc_type4;
         auto hc = (hc_type4*)malloc(sizeof(hc_type4));
         hc->this_ = (T*)this;
@@ -219,7 +258,12 @@ namespace dsn
             ((hc2->this_)->*(hc2->cb))(request);
         };
 
-        return dsn_rpc_register_handler(rpc_code, rpc_name_, cb, hc, gpid);
+        if (!dsn_rpc_register_handler(rpc_code, rpc_name_, cb, hc, gpid))
+        {
+            free(hc);
+            return false;
+        }
+        return true;
     }
 
     template<typename T>
@@ -234,6 +278,7 @@ namespace dsn
     inline void serverlet<T>::reply(dsn_message_t request, const TResponse& resp)
     {
         auto msg = dsn_msg_create_response(request);
+        dassert(msg != nullptr, "dsn_msg_create_response failed");
         ::dsn::marshall(msg, resp);
         auto err = dsn_rpc_reply(msg);
         dassert(err == ERR_OK, "dsn_rpc_reply failed: %s", error_code(err).to_string());

--- a/include/dsn/cpp/service_app.h
+++ b/include/dsn/cpp/service_app.h
@@ -88,6 +88,30 @@ namespace dsn
         static dsn_error_t app_start(void* app, int argc, char** argv)
         {
             service_app* sapp = (service_app*)app;
+            if (sapp == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_start got null app");
+                return ERR_INVALID_PARAMETERS;
+            }
+            if (argc <= 0)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_start got invalid argc = %d", argc);
+                return ERR_INVALID_PARAMETERS;
+            }
+            if (argv == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_start got null argv");
+                return ERR_INVALID_PARAMETERS;
+            }
+            for (int i = 0; i < argc; ++i)
+            {
+                if (argv[i] == nullptr)
+                {
+                    dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_start got null argv at index = %d", i);
+                    return ERR_INVALID_PARAMETERS;
+                }
+            }
+
             sapp->_address = dsn_primary_address();
             sapp->_name = std::string(argv[0]);
 
@@ -102,6 +126,12 @@ namespace dsn
         static dsn_error_t app_destroy(void* app, bool cleanup)
         {
             service_app* sapp = (service_app*)(app);
+            if (sapp == nullptr)
+            {
+                dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_destroy got null app");
+                return ERR_INVALID_PARAMETERS;
+            }
+
             auto err = sapp->stop(cleanup);
             if (ERR_OK == err) sapp->_started = false;
             return err;
@@ -110,8 +140,14 @@ namespace dsn
 
     /*! C++ wrapper of the \ref dsn_register_app function*/
     template<typename TServiceApp>
-    void register_app(const char* type_name)
+    bool register_app(const char* type_name)
     {
+        if (type_name == nullptr || type_name[0] == '\0')
+        {
+            dlog(LOG_LEVEL_ERROR, "cpp.service_app", "register_app got invalid type_name");
+            return false;
+        }
+
         dsn_app app;
         memset(&app, 0, sizeof(app));
         app.mask = DSN_APP_MASK_APP;
@@ -120,7 +156,7 @@ namespace dsn
         app.layer1.start = service_app::app_start;
         app.layer1.destroy = service_app::app_destroy;
 
-        dsn_register_app(&app);
+        return dsn_register_app(&app);
     }
 
     /*@}*/

--- a/include/dsn/cpp/service_app.h
+++ b/include/dsn/cpp/service_app.h
@@ -91,24 +91,24 @@ namespace dsn
             if (sapp == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_start got null app");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
             if (argc <= 0)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_start got invalid argc = %d", argc);
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
             if (argv == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_start got null argv");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
             for (int i = 0; i < argc; ++i)
             {
                 if (argv[i] == nullptr)
                 {
                     dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_start got null argv at index = %d", i);
-                    return ERR_INVALID_PARAMETERS;
+                    return ERR_INVALID_PARAMETERS.get();
                 }
             }
 
@@ -120,7 +120,7 @@ namespace dsn
             {
                 sapp->_started = true;
             }
-            return r;
+            return r.get();
         }
 
         static dsn_error_t app_destroy(void* app, bool cleanup)
@@ -129,12 +129,12 @@ namespace dsn
             if (sapp == nullptr)
             {
                 dlog(LOG_LEVEL_ERROR, "cpp.service_app", "app_destroy got null app");
-                return ERR_INVALID_PARAMETERS;
+                return ERR_INVALID_PARAMETERS.get();
             }
 
             auto err = sapp->stop(cleanup);
             if (ERR_OK == err) sapp->_started = false;
-            return err;
+            return err.get();
         }
     };
 

--- a/include/dsn/cpp/task_helper.h
+++ b/include/dsn/cpp/task_helper.h
@@ -81,6 +81,8 @@ namespace dsn
 
         void set_task_info(dsn_task_t t)
         {
+            dassert(t != nullptr, "safe_task_handle got null task");
+
             _task = t;
             dsn_task_add_ref(t);
         }

--- a/include/dsn/cpp/task_helper.h
+++ b/include/dsn/cpp/task_helper.h
@@ -95,7 +95,7 @@ namespace dsn
 
         void set_delay(int delay_ms)
         {
-            dsn_task_set_delay(_task, delay_ms);
+            dassert(dsn_task_set_delay(_task, delay_ms), "dsn_task_set_delay failed");
         }
 
         void wait() const
@@ -120,12 +120,13 @@ namespace dsn
 
         void enqueue(std::chrono::milliseconds delay = std::chrono::milliseconds(0)) const
         {
-            dsn_task_call(_task, static_cast<int>(delay.count()));
+            dassert(dsn_task_call(_task, static_cast<int>(delay.count())), "dsn_task_call failed");
         }
             
         void enqueue_aio(error_code err, size_t size) const
         {
-            dsn_file_task_enqueue(_task, err.get(), size);
+            auto submit_error = dsn_file_task_enqueue(_task, err.get(), size);
+            dassert(submit_error == ERR_OK, "dsn_file_task_enqueue failed: %s", error_code(submit_error).to_string());
         }
 
         dsn_message_t response()
@@ -137,7 +138,8 @@ namespace dsn
 
         void enqueue_rpc_response(error_code err, dsn_message_t resp) const
         {
-            dsn_rpc_enqueue_response(_task, err.get(), resp);
+            auto submit_error = dsn_rpc_enqueue_response(_task, err.get(), resp);
+            dassert(submit_error == ERR_OK, "dsn_rpc_enqueue_response failed: %s", error_code(submit_error).to_string());
         }
 
     private:
@@ -279,7 +281,7 @@ namespace dsn
         {
             _bound_handler = binder(_handler);
             _handler = nullptr;
-            dsn_task_call(native_handle(), delay_milliseconds);
+            dassert(dsn_task_call(native_handle(), delay_milliseconds), "dsn_task_call failed");
         }
 
         static void on_cancel(void* task)

--- a/include/dsn/cpp/test_utils.h
+++ b/include/dsn/cpp/test_utils.h
@@ -91,7 +91,8 @@ public:
             if (next_addr.port() != TEST_PORT_END) {
                 next_addr.assign_ipv4(next_addr.ip(), next_addr.port()+1);
                 ddebug("test_client_server, talk_to_others: %s", next_addr.to_std_string().c_str());
-                dsn_rpc_forward(message, next_addr.c_addr());
+                auto err = dsn_rpc_forward(message, next_addr.c_addr());
+                dassert(err == ERR_OK, "dsn_rpc_forward failed: %s", error_code(err).to_string());
             }
             else {
                 ddebug("test_client_server, talk_to_me: %s", next_addr.to_std_string().c_str());

--- a/include/dsn/cpp/utils.h
+++ b/include/dsn/cpp/utils.h
@@ -141,7 +141,7 @@ namespace dsn {
 # endif
         }
 
-        extern void time_ms_to_string(uint64_t ts_ms, char* str);
+        extern void time_ms_to_string(uint64_t ts_ms, char* str, size_t str_size);
 
         extern int get_current_tid_internal();
 

--- a/include/dsn/utility/customizable_id.h
+++ b/include/dsn/utility/customizable_id.h
@@ -144,8 +144,14 @@ template<typename T>
 customized_id<T> customized_id<T>::from_string(const char* name, customized_id invalid_value)
 {
     int id = customized_id_mgr<T>::instance().get_id(name);
-    if (id == -1) return invalid_value;
-    else return customized_id<T>(id);
+    if (id == -1)
+    {
+        return invalid_value;
+    }
+    else
+    {
+        return customized_id<T>(id);
+    }
 }
 
 template<typename T>
@@ -163,25 +169,43 @@ customized_id<T>::customized_id(int code)
 template<typename T>
 int customized_id_mgr<T>::get_id(const char* name) const
 {
+    if (name == nullptr || name[0] == '\0')
+    {
+        return -1;
+    }
+
     auto it = _names.find(std::string(name));
     if (it == _names.end())
+    {
         return -1;
+    }
     else
+    {
         return it->second;
+    }
 }
 
 template<typename T>
 const char* customized_id_mgr<T>::get_name(int id) const
 {
-    if (id < static_cast<int>(_names2.size()))
+    if (id >= 0 && id < static_cast<int>(_names2.size()))
+    {
         return _names2[id].c_str();
+    }
     else
+    {
         return "unknown";
+    }
 }
 
 template<typename T>
 int customized_id_mgr<T>::register_id(const char* name)
 {
+    if (name == nullptr || name[0] == '\0')
+    {
+        return -1;
+    }
+
     int id = get_id(name);
     if (-1 != id)
     {

--- a/include/dsn/utility/singleton_vector_store.h
+++ b/include/dsn/utility/singleton_vector_store.h
@@ -49,7 +49,7 @@ public:
 
     bool contains(int index) const
     {
-        if (index >= static_cast<int>(_contains.size()))
+        if (index < 0 || index >= static_cast<int>(_contains.size()))
             return false;
         else
             return _contains[index];
@@ -57,7 +57,7 @@ public:
 
     T get(int index) const
     {
-        if (index >= static_cast<int>(_contains.size()))
+        if (index < 0 || index >= static_cast<int>(_contains.size()))
             return default_value;
         else
             return _values[index];
@@ -65,6 +65,9 @@ public:
 
     bool put(int index, T value)
     {
+        if (index < 0)
+            return false;
+
         if (index >= static_cast<int>(_contains.size()))
         {
             for (int i = static_cast<int>(_contains.size()); i < index; i++)

--- a/src/core/src/address.cpp
+++ b/src/core/src/address.cpp
@@ -90,6 +90,12 @@ static void net_init()
 // name to ip etc.
 DSN_API uint32_t dsn_ipv4_from_host(const char* name)
 {
+    if (name == nullptr || name[0] == '\0')
+    {
+        derror("dsn_ipv4_from_host got null or empty name");
+        return 0;
+    }
+
     sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
 
@@ -275,10 +281,24 @@ DSN_API const char*   dsn_address_to_string(dsn_address_t addr)
 # endif
         break;
     case HOST_TYPE_URI:
-        p = (char*)(uintptr_t)addr.u.uri.uri;
+        if (addr.u.uri.uri == 0)
+        {
+            p = (char*)"invalid address";
+        }
+        else
+        {
+            p = (char*)(uintptr_t)addr.u.uri.uri;
+        }
         break;
     case HOST_TYPE_GROUP:
-        p = (char*)(((dsn::rpc_group_address*)(uintptr_t)(addr.u.group.group))->name());
+        if (addr.u.group.group == 0)
+        {
+            p = (char*)"invalid address";
+        }
+        else
+        {
+            p = (char*)(((dsn::rpc_group_address*)(uintptr_t)(addr.u.group.group))->name());
+        }
         break;
     default:
         p = (char*)"invalid address";
@@ -293,6 +313,12 @@ DSN_API dsn_address_t dsn_address_build(
     uint16_t port
     )
 {
+    if (host == nullptr)
+    {
+        derror("dsn_address_build got null host");
+        return dsn::rpc_address().c_addr();
+    }
+
     dsn::rpc_address addr(host, port);
     return addr.c_addr();
 }
@@ -310,6 +336,12 @@ DSN_API dsn_address_t dsn_address_build_group(
     dsn_group_t g
     )
 {
+    if (g == nullptr)
+    {
+        derror("dsn_address_build_group got null group");
+        return dsn::rpc_address().c_addr();
+    }
+
     dsn::rpc_address addr;
     addr.assign_group(g);
     return addr.c_addr();
@@ -319,6 +351,12 @@ DSN_API dsn_address_t dsn_address_build_uri(
     dsn_uri_t uri
     )
 {
+    if (uri == nullptr)
+    {
+        derror("dsn_address_build_uri got null uri");
+        return dsn::rpc_address().c_addr();
+    }
+
     dsn::rpc_address addr;
     addr.assign_uri(uri);
     return addr.c_addr();
@@ -326,18 +364,36 @@ DSN_API dsn_address_t dsn_address_build_uri(
 
 DSN_API dsn_group_t dsn_group_build(const char* name) // must be paired with release later
 {
+    if (name == nullptr)
+    {
+        derror("dsn_group_build got null name");
+        return nullptr;
+    }
+
     auto g = new ::dsn::rpc_group_address(name);
     return g;
 }
 
 DSN_API int dsn_group_count(dsn_group_t g)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_count got null group");
+        return 0;
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     return grp->count();
 }
 
 DSN_API bool dsn_group_add(dsn_group_t g, dsn_address_t ep)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_add got null group");
+        return false;
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     ::dsn::rpc_address addr(ep);
     return grp->add(addr);
@@ -345,6 +401,12 @@ DSN_API bool dsn_group_add(dsn_group_t g, dsn_address_t ep)
 
 DSN_API void dsn_group_set_leader(dsn_group_t g, dsn_address_t ep)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_set_leader got null group");
+        return;
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     ::dsn::rpc_address addr(ep);
     grp->set_leader(addr);
@@ -352,30 +414,60 @@ DSN_API void dsn_group_set_leader(dsn_group_t g, dsn_address_t ep)
 
 DSN_API dsn_address_t dsn_group_get_leader(dsn_group_t g)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_get_leader got null group");
+        return dsn::rpc_address().c_addr();
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     return grp->leader().c_addr();
 }
 
 DSN_API bool dsn_group_is_leader(dsn_group_t g, dsn_address_t ep)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_is_leader got null group");
+        return false;
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     return grp->leader() == ep;
 }
 
 DSN_API bool dsn_group_is_update_leader_automatically(dsn_group_t g)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_is_update_leader_automatically got null group");
+        return false;
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     return grp->is_update_leader_automatically();
 }
 
 DSN_API void dsn_group_set_update_leader_automatically(dsn_group_t g, bool v)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_set_update_leader_automatically got null group");
+        return;
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     grp->set_update_leader_automatically(v);
 }
 
 DSN_API dsn_address_t dsn_group_next(dsn_group_t g, dsn_address_t ep)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_next got null group");
+        return dsn::rpc_address().c_addr();
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     ::dsn::rpc_address addr(ep);
     return grp->next(addr).c_addr();
@@ -383,6 +475,12 @@ DSN_API dsn_address_t dsn_group_next(dsn_group_t g, dsn_address_t ep)
 
 DSN_API dsn_address_t dsn_group_forward_leader(dsn_group_t g)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_forward_leader got null group");
+        return dsn::rpc_address().c_addr();
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     grp->leader_forward();
     return grp->leader().c_addr();
@@ -390,6 +488,12 @@ DSN_API dsn_address_t dsn_group_forward_leader(dsn_group_t g)
 
 DSN_API bool dsn_group_remove(dsn_group_t g, dsn_address_t ep)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_remove got null group");
+        return false;
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     ::dsn::rpc_address addr(ep);
     return grp->remove(addr);
@@ -397,16 +501,34 @@ DSN_API bool dsn_group_remove(dsn_group_t g, dsn_address_t ep)
 
 DSN_API void dsn_group_destroy(dsn_group_t g)
 {
+    if (g == nullptr)
+    {
+        derror("dsn_group_destroy got null group");
+        return;
+    }
+
     auto grp = (::dsn::rpc_group_address*)(g);
     delete grp;
 }
 
 DSN_API dsn_uri_t dsn_uri_build(const char* url) // must be paired with destroy later
 {
+    if (url == nullptr)
+    {
+        derror("dsn_uri_build got null url");
+        return nullptr;
+    }
+
     return (dsn_uri_t)new ::dsn::rpc_uri_address(url);
 }
 
 DSN_API void dsn_uri_destroy(dsn_uri_t uri)
 {
+    if (uri == nullptr)
+    {
+        derror("dsn_uri_destroy got null uri");
+        return;
+    }
+
     delete (::dsn::rpc_uri_address*)(uri);
 }

--- a/src/core/src/address.cpp
+++ b/src/core/src/address.cpp
@@ -364,9 +364,9 @@ DSN_API dsn_address_t dsn_address_build_uri(
 
 DSN_API dsn_group_t dsn_group_build(const char* name) // must be paired with release later
 {
-    if (name == nullptr)
+    if (name == nullptr || name[0] == '\0')
     {
-        derror("dsn_group_build got null name");
+        derror("dsn_group_build got null or empty name");
         return nullptr;
     }
 
@@ -513,9 +513,9 @@ DSN_API void dsn_group_destroy(dsn_group_t g)
 
 DSN_API dsn_uri_t dsn_uri_build(const char* url) // must be paired with destroy later
 {
-    if (url == nullptr)
+    if (url == nullptr || url[0] == '\0')
     {
-        derror("dsn_uri_build got null url");
+        derror("dsn_uri_build got null or empty url");
         return nullptr;
     }
 

--- a/src/core/src/address.cpp
+++ b/src/core/src/address.cpp
@@ -313,9 +313,9 @@ DSN_API dsn_address_t dsn_address_build(
     uint16_t port
     )
 {
-    if (host == nullptr)
+    if (host == nullptr || host[0] == '\0')
     {
-        derror("dsn_address_build got null host");
+        derror("dsn_address_build got null or empty host");
         return dsn::rpc_address().c_addr();
     }
 

--- a/src/core/src/address.test.cpp
+++ b/src/core/src/address.test.cpp
@@ -179,6 +179,36 @@ TEST(core, dsn_address_invalid_parameters)
     ASSERT_EQ(invalid_address, dsn_address_build_uri(nullptr));
 }
 
+TEST(core, rpc_address_cpp_invalid_parameters)
+{
+    rpc_address addr(nullptr, 8080);
+    ASSERT_TRUE(addr.is_invalid());
+
+    addr.assign_ipv4("", 8080);
+    ASSERT_TRUE(addr.is_invalid());
+
+    addr.assign_ipv4_local_address(nullptr, 8080);
+    ASSERT_TRUE(addr.is_invalid());
+
+    addr.assign_ipv4_local_address("", 8080);
+    ASSERT_TRUE(addr.is_invalid());
+
+    addr.assign_uri(nullptr);
+    ASSERT_TRUE(addr.is_invalid());
+
+    addr.assign_group(nullptr);
+    ASSERT_TRUE(addr.is_invalid());
+
+    ASSERT_FALSE(addr.from_string_ipv4(nullptr));
+    ASSERT_FALSE(addr.from_string_ipv4(""));
+
+    url_host_address url(nullptr);
+    ASSERT_TRUE(url.is_invalid());
+
+    url_host_address empty_url("");
+    ASSERT_TRUE(empty_url.is_invalid());
+}
+
 TEST(core, rpc_group_address)
 {
     rpc_group_address g("test_group");

--- a/src/core/src/address.test.cpp
+++ b/src/core/src/address.test.cpp
@@ -76,6 +76,12 @@ TEST(core, dsn_ipv4_from_host)
     ASSERT_EQ(host_ipv4(127, 0, 0, 1), dsn_ipv4_from_host("127.0.0.1"));
 }
 
+TEST(core, dsn_ipv4_from_host_invalid_parameters)
+{
+    ASSERT_EQ(0u, dsn_ipv4_from_host(nullptr));
+    ASSERT_EQ(0u, dsn_ipv4_from_host(""));
+}
+
 TEST(core, dsn_ipv4_local)
 {
 #ifndef _WIN32
@@ -161,6 +167,16 @@ TEST(core, dsn_address_build)
         ASSERT_EQ(addr, dsn_address_build_group(g));
         dsn_group_destroy(g);
     }
+}
+
+TEST(core, dsn_address_invalid_parameters)
+{
+    const dsn_address_t invalid_address = {};
+
+    ASSERT_EQ(invalid_address, dsn_address_build(nullptr, 8080));
+    ASSERT_EQ(invalid_address, dsn_address_build("", 8080));
+    ASSERT_EQ(invalid_address, dsn_address_build_group(nullptr));
+    ASSERT_EQ(invalid_address, dsn_address_build_uri(nullptr));
 }
 
 TEST(core, rpc_group_address)
@@ -285,4 +301,30 @@ TEST(core, dsn_group)
     ASSERT_EQ(uri_addr.c_addr(), dsn_group_next(g, addr.c_addr()));
 
     dsn_group_destroy(g);
+}
+
+TEST(core, dsn_group_invalid_parameters)
+{
+    const dsn_address_t invalid_address = {};
+
+    ASSERT_EQ(nullptr, dsn_group_build(nullptr));
+    ASSERT_EQ(nullptr, dsn_group_build(""));
+    ASSERT_EQ(0, dsn_group_count(nullptr));
+    ASSERT_FALSE(dsn_group_add(nullptr, invalid_address));
+    dsn_group_set_leader(nullptr, invalid_address);
+    ASSERT_EQ(invalid_address, dsn_group_get_leader(nullptr));
+    ASSERT_FALSE(dsn_group_is_leader(nullptr, invalid_address));
+    ASSERT_FALSE(dsn_group_is_update_leader_automatically(nullptr));
+    dsn_group_set_update_leader_automatically(nullptr, true);
+    ASSERT_EQ(invalid_address, dsn_group_next(nullptr, invalid_address));
+    ASSERT_EQ(invalid_address, dsn_group_forward_leader(nullptr));
+    ASSERT_FALSE(dsn_group_remove(nullptr, invalid_address));
+    dsn_group_destroy(nullptr);
+}
+
+TEST(core, dsn_uri_invalid_parameters)
+{
+    ASSERT_EQ(nullptr, dsn_uri_build(nullptr));
+    ASSERT_EQ(nullptr, dsn_uri_build(""));
+    dsn_uri_destroy(nullptr);
 }

--- a/src/core/src/aio.test.cpp
+++ b/src/core/src/aio.test.cpp
@@ -161,6 +161,44 @@ TEST(core, aio_share)
     utils::filesystem::remove_path("tmp");
 }
 
+TEST(core, aio_cpp_invalid_parameters)
+{
+    auto task = ::dsn::file::create_aio_task(TASK_CODE_INVALID, nullptr, dsn::empty_callback, 0);
+    EXPECT_EQ(nullptr, task.get());
+
+    task = ::dsn::file::create_aio_task(
+        TASK_CODE_INVALID, nullptr, [](::dsn::error_code, size_t) {}, 0);
+    EXPECT_EQ(nullptr, task.get());
+
+    char buffer[1] = {};
+    task = ::dsn::file::read(
+        nullptr, buffer, sizeof(buffer), 0, TASK_CODE_INVALID, nullptr, dsn::empty_callback);
+    EXPECT_EQ(nullptr, task.get());
+
+    task = ::dsn::file::write(
+        nullptr, buffer, sizeof(buffer), 0, TASK_CODE_INVALID, nullptr, dsn::empty_callback);
+    EXPECT_EQ(nullptr, task.get());
+
+    dsn_file_buffer_t file_buffer{buffer, sizeof(buffer)};
+    task = ::dsn::file::write_vector(
+        nullptr, &file_buffer, 1, 0, TASK_CODE_INVALID, nullptr, dsn::empty_callback);
+    EXPECT_EQ(nullptr, task.get());
+
+    task = ::dsn::file::copy_remote_files(rpc_address(),
+                                          "",
+                                          {},
+                                          "",
+                                          false,
+                                          TASK_CODE_INVALID,
+                                          nullptr,
+                                          dsn::empty_callback);
+    EXPECT_EQ(nullptr, task.get());
+
+    task = ::dsn::file::copy_remote_directory(
+        rpc_address(), "", "", false, TASK_CODE_INVALID, nullptr, dsn::empty_callback);
+    EXPECT_EQ(nullptr, task.get());
+}
+
 TEST(core, operation_failed)
 {
     // if in dsn_mimic_app() and disk_io_mode == IOE_PER_QUEUE

--- a/src/core/src/app_manager.cpp
+++ b/src/core/src/app_manager.cpp
@@ -149,8 +149,9 @@ DSN_API dsn_error_t dsn_hosted_app_create(
         return ::dsn::ERR_INVALID_STATE.get();
     }
 
-    return node->get_l2_handler().create_app(
-        type, gpid, data_dir, app_context_for_downcalls, app_context_for_callbacks);
+    return node->get_l2_handler()
+        .create_app(type, gpid, data_dir, app_context_for_downcalls, app_context_for_callbacks)
+        .get();
 }
 
 DSN_API dsn_error_t dsn_hosted_app_start(void* app_context, int argc, char** argv)
@@ -189,7 +190,7 @@ DSN_API dsn_error_t dsn_hosted_app_start(void* app_context, int argc, char** arg
         return ::dsn::ERR_INVALID_STATE.get();
     }
 
-    return node->get_l2_handler().start_app(app_context, argc, argv);
+    return node->get_l2_handler().start_app(app_context, argc, argv).get();
 }
 
 DSN_API dsn_error_t dsn_hosted_app_destroy(void* app_context, bool cleanup)
@@ -207,7 +208,7 @@ DSN_API dsn_error_t dsn_hosted_app_destroy(void* app_context, bool cleanup)
         return ::dsn::ERR_INVALID_STATE.get();
     }
 
-    return node->get_l2_handler().destroy_app(app_context, cleanup);
+    return node->get_l2_handler().destroy_app(app_context, cleanup).get();
 }
 
 DSN_API dsn_error_t dsn_hosted_app_commit_rpc_request(void* app_context, dsn_message_t msg, bool exec_inline)

--- a/src/core/src/app_manager.cpp
+++ b/src/core/src/app_manager.cpp
@@ -196,32 +196,32 @@ DSN_API dsn_error_t dsn_hosted_app_destroy(void* app_context, bool cleanup)
     return node->get_l2_handler().destroy_app(app_context, cleanup);
 }
 
-DSN_API void dsn_hosted_app_commit_rpc_request(void* app_context, dsn_message_t msg, bool exec_inline)
+DSN_API dsn_error_t dsn_hosted_app_commit_rpc_request(void* app_context, dsn_message_t msg, bool exec_inline)
 {
     if (app_context == nullptr)
     {
         derror("dsn_hosted_app_commit_rpc_request got null app_context");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (msg == nullptr)
     {
         derror("dsn_hosted_app_commit_rpc_request got null message");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto node = ::dsn::task::get_current_node2();
     if (node == nullptr)
     {
         derror("dsn_hosted_app_commit_rpc_request got null current node");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     auto app = (::dsn::app_manager::app_internal*)(app_context);
     if (app == nullptr)
     {
         derror("dsn_hosted_app_commit_rpc_request got null app");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (exec_inline)
@@ -231,13 +231,15 @@ DSN_API void dsn_hosted_app_commit_rpc_request(void* app_context, dsn_message_t 
     else
     {
         auto tsk = app->server_dispatcher.on_request((::dsn::message_ex*)(msg), node);
-        if (tsk)
-            tsk->enqueue();
-        else
+        if (tsk == nullptr)
         {
-            dassert(false, "dsn_hosted_app_commit_rpc_request failed to create request task");
+            derror("dsn_hosted_app_commit_rpc_request failed to create request task");
+            return ::dsn::ERR_INVALID_STATE.get();
         }
+        tsk->enqueue();
     }
+
+    return ::dsn::ERR_OK.get();
 }
 
 

--- a/src/core/src/app_manager.cpp
+++ b/src/core/src/app_manager.cpp
@@ -44,19 +44,33 @@ DSN_API bool dsn_register_app(dsn_app* app_type)
         derror("dsn_register_app got null app_type");
         return false;
     }
+    if (app_type->type_name[0] == '\0')
+    {
+        derror("dsn_register_app got empty app type name");
+        return false;
+    }
+    if (strnlen(app_type->type_name, sizeof(app_type->type_name)) >= sizeof(app_type->type_name))
+    {
+        derror("dsn_register_app got non-null-terminated app type name");
+        return false;
+    }
 
     dsn_app* app;
     auto& store = ::dsn::utils::singleton_store<std::string, dsn_app*>::instance();
     if (store.get(app_type->type_name, app))
     {
-        dassert(false, "app type %s is already registered", app_type->type_name);
+        derror("app type %s is already registered", app_type->type_name);
         return false;
     }
 
     app = new dsn_app();
     *app = *app_type;
     auto r = store.put(app_type->type_name, app);
-    dassert(r, "app type %s is already registered", app_type->type_name);
+    if (!r)
+    {
+        derror("app type %s is already registered", app_type->type_name);
+        delete app;
+    }
     return r;
 }
 

--- a/src/core/src/app_manager.cpp
+++ b/src/core/src/app_manager.cpp
@@ -39,6 +39,12 @@
 
 DSN_API bool dsn_register_app(dsn_app* app_type)
 {
+    if (app_type == nullptr)
+    {
+        derror("dsn_register_app got null app_type");
+        return false;
+    }
+
     dsn_app* app;
     auto& store = ::dsn::utils::singleton_store<std::string, dsn_app*>::instance();
     if (store.get(app_type->type_name, app))
@@ -56,6 +62,18 @@ DSN_API bool dsn_register_app(dsn_app* app_type)
 
 DSN_API bool dsn_get_app_callbacks(const char* name, /* out */ dsn_app_callbacks* callbacks)
 {
+    if (name == nullptr || name[0] == '\0')
+    {
+        derror("dsn_get_app_callbacks got null or empty name");
+        return false;
+    }
+
+    if (callbacks == nullptr)
+    {
+        derror("dsn_get_app_callbacks got null callbacks");
+        return false;
+    }
+
     dsn_app* lapp;
     auto& store = ::dsn::utils::singleton_store<std::string, dsn_app*>::instance();
     if (store.get(name, lapp))
@@ -78,36 +96,146 @@ DSN_API dsn_error_t dsn_hosted_app_create(
     /*out*/void** app_context_for_callbacks
     )
 {
-    return ::dsn::task::get_current_node2()->get_l2_handler().create_app(type, gpid, data_dir,
-        app_context_for_downcalls, app_context_for_callbacks);
+    if (type == nullptr || type[0] == '\0')
+    {
+        derror("dsn_hosted_app_create got null or empty type");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    if (gpid.u.app_id <= 0 || gpid.u.partition_index < 0)
+    {
+        derror("dsn_hosted_app_create got invalid gpid = %d.%d",
+               gpid.u.app_id,
+               gpid.u.partition_index);
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    if (data_dir == nullptr || data_dir[0] == '\0')
+    {
+        derror("dsn_hosted_app_create got null or empty data_dir");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    if (app_context_for_downcalls == nullptr)
+    {
+        derror("dsn_hosted_app_create got null app_context_for_downcalls");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    if (app_context_for_callbacks == nullptr)
+    {
+        derror("dsn_hosted_app_create got null app_context_for_callbacks");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    auto node = ::dsn::task::get_current_node2();
+    if (node == nullptr)
+    {
+        derror("dsn_hosted_app_create got null current node");
+        return ::dsn::ERR_INVALID_STATE.get();
+    }
+
+    return node->get_l2_handler().create_app(
+        type, gpid, data_dir, app_context_for_downcalls, app_context_for_callbacks);
 }
 
 DSN_API dsn_error_t dsn_hosted_app_start(void* app_context, int argc, char** argv)
 {
-    return ::dsn::task::get_current_node2()->get_l2_handler().start_app(app_context, argc, argv);
+    if (app_context == nullptr)
+    {
+        derror("dsn_hosted_app_start got null app_context");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    if (argc < 0)
+    {
+        derror("dsn_hosted_app_start got invalid argc = %d", argc);
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    if (argc > 0 && argv == nullptr)
+    {
+        derror("dsn_hosted_app_start got null argv");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    for (int i = 0; i < argc; ++i)
+    {
+        if (argv[i] == nullptr)
+        {
+            derror("dsn_hosted_app_start got null argv at index = %d", i);
+            return ::dsn::ERR_INVALID_PARAMETERS.get();
+        }
+    }
+
+    auto node = ::dsn::task::get_current_node2();
+    if (node == nullptr)
+    {
+        derror("dsn_hosted_app_start got null current node");
+        return ::dsn::ERR_INVALID_STATE.get();
+    }
+
+    return node->get_l2_handler().start_app(app_context, argc, argv);
 }
 
 DSN_API dsn_error_t dsn_hosted_app_destroy(void* app_context, bool cleanup)
 {
-    return ::dsn::task::get_current_node2()->get_l2_handler().destroy_app(app_context, cleanup);
+    if (app_context == nullptr)
+    {
+        derror("dsn_hosted_app_destroy got null app_context");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    auto node = ::dsn::task::get_current_node2();
+    if (node == nullptr)
+    {
+        derror("dsn_hosted_app_destroy got null current node");
+        return ::dsn::ERR_INVALID_STATE.get();
+    }
+
+    return node->get_l2_handler().destroy_app(app_context, cleanup);
 }
 
 DSN_API void dsn_hosted_app_commit_rpc_request(void* app_context, dsn_message_t msg, bool exec_inline)
 {
+    if (app_context == nullptr)
+    {
+        derror("dsn_hosted_app_commit_rpc_request got null app_context");
+        return;
+    }
+
+    if (msg == nullptr)
+    {
+        derror("dsn_hosted_app_commit_rpc_request got null message");
+        return;
+    }
+
+    auto node = ::dsn::task::get_current_node2();
+    if (node == nullptr)
+    {
+        derror("dsn_hosted_app_commit_rpc_request got null current node");
+        return;
+    }
+
     auto app = (::dsn::app_manager::app_internal*)(app_context);
+    if (app == nullptr)
+    {
+        derror("dsn_hosted_app_commit_rpc_request got null app");
+        return;
+    }
 
     if (exec_inline)
     {
-        app->server_dispatcher.on_request_with_inline_execution((::dsn::message_ex*)(msg), ::dsn::task::get_current_node2());
+        app->server_dispatcher.on_request_with_inline_execution((::dsn::message_ex*)(msg), node);
     }
     else
     {
-        auto tsk = app->server_dispatcher.on_request((::dsn::message_ex*)(msg), ::dsn::task::get_current_node2());
+        auto tsk = app->server_dispatcher.on_request((::dsn::message_ex*)(msg), node);
         if (tsk)
             tsk->enqueue();
         else
         {
-            dassert(false, "to be handled");
+            dassert(false, "dsn_hosted_app_commit_rpc_request failed to create request task");
         }
     }
 }

--- a/src/core/src/clientlet.test.cpp
+++ b/src/core/src/clientlet.test.cpp
@@ -34,6 +34,9 @@
  */
 
 #include <dsn/cpp/clientlet.h>
+#include <dsn/cpp/layer2_handler.h>
+#include <dsn/cpp/replicated_service_app.h>
+#include <dsn/cpp/serverlet.h>
 #include <gtest/gtest.h>
 #include <functional>
 #include <chrono>
@@ -95,6 +98,31 @@ TEST(dev_cpp, clientlet_task)
         EXPECT_FALSE( test_tasks[i]->cancel(true) );
 }
 
+TEST(dev_cpp, clientlet_task_invalid_parameters)
+{
+    safe_task_handle invalid_task;
+    EXPECT_FALSE(invalid_task.cancel(false));
+    invalid_task.wait();
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, invalid_task.error());
+    EXPECT_EQ(static_cast<size_t>(-1), invalid_task.io_size());
+    EXPECT_EQ(nullptr, invalid_task.response());
+
+    auto task = tasking::create_task(TASK_CODE_INVALID, nullptr, [] {});
+    EXPECT_EQ(nullptr, task.get());
+
+    task = tasking::create_timer_task(TASK_CODE_INVALID, nullptr, [] {}, std::chrono::milliseconds(1));
+    EXPECT_EQ(nullptr, task.get());
+
+    task = tasking::enqueue(TASK_CODE_INVALID, nullptr, [] {});
+    EXPECT_EQ(nullptr, task.get());
+
+    task = tasking::enqueue_timer(TASK_CODE_INVALID, nullptr, [] {}, std::chrono::milliseconds(1));
+    EXPECT_EQ(nullptr, task.get());
+
+    auto late_task = tasking::create_late_task(TASK_CODE_INVALID, [] {});
+    EXPECT_EQ(nullptr, late_task);
+}
+
 TEST(dev_cpp, clientlet_rpc)
 {
     rpc_address addr("localhost", 20101);
@@ -134,4 +162,227 @@ TEST(dev_cpp, clientlet_rpc)
     task_vec.push_back(t);
     for (int i=0; i!=task_vec.size(); ++i)
         task_vec[i]->wait();
+}
+
+TEST(dev_cpp, clientlet_rpc_invalid_parameters)
+{
+    auto response_task = rpc::create_rpc_response_task(nullptr, nullptr, empty_callback);
+    EXPECT_EQ(nullptr, response_task.get());
+
+    response_task = rpc::create_rpc_response_task(
+        nullptr, nullptr, [](error_code, dsn_message_t, dsn_message_t) {});
+    EXPECT_EQ(nullptr, response_task.get());
+
+    auto call_task = rpc::call(rpc_address(), static_cast<dsn_message_t>(nullptr), nullptr, empty_callback);
+    EXPECT_EQ(nullptr, call_task.get());
+
+    call_task = rpc::call(rpc_address(), TASK_CODE_INVALID, std::string("request"), nullptr, empty_callback);
+    EXPECT_EQ(nullptr, call_task.get());
+
+    call_task = rpc::create_message(TASK_CODE_INVALID, std::string("request"))
+                    .call(rpc_address(), nullptr, empty_callback);
+    EXPECT_EQ(nullptr, call_task.get());
+
+    auto wait_result = rpc::call_wait<std::string>(
+        rpc_address(), TASK_CODE_INVALID, std::string("request"));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, wait_result.first);
+    EXPECT_EQ(std::string(), wait_result.second);
+
+    rpc::call_one_way_typed(rpc_address(), TASK_CODE_INVALID, std::string("request"));
+}
+
+class test_service_app_for_invalid : public service_app
+{
+public:
+    explicit test_service_app_for_invalid(dsn_gpid gpid) : service_app(gpid) {}
+
+    error_code start(int, char**) override { return ERR_OK; }
+    error_code stop(bool) override { return ERR_OK; }
+};
+
+class test_layer2_handler_for_invalid : public layer2_handler
+{
+public:
+    explicit test_layer2_handler_for_invalid(dsn_gpid gpid) : layer2_handler(gpid), request_count(0) {}
+
+    error_code start(int, char**) override { return ERR_OK; }
+    error_code stop(bool) override { return ERR_OK; }
+    void on_request(dsn_gpid, bool, dsn_message_t) override { ++request_count; }
+
+    int request_count;
+};
+
+class test_replicated_service_app_for_invalid : public replicated_service_app_type_1
+{
+public:
+    explicit test_replicated_service_app_for_invalid(dsn_gpid gpid)
+        : replicated_service_app_type_1(gpid)
+    {
+    }
+
+    error_code start(int, char**) override { return ERR_OK; }
+    error_code stop(bool) override { return ERR_OK; }
+    error_code get_checkpoint(int64_t, int64_t, void*, int, app_learn_state&) override
+    {
+        return ERR_OK;
+    }
+    error_code apply_checkpoint(dsn_chkpt_apply_mode, int64_t, const dsn_app_learn_state&) override
+    {
+        return ERR_OK;
+    }
+};
+
+class test_serverlet_for_invalid : public serverlet<test_serverlet_for_invalid>
+{
+public:
+    test_serverlet_for_invalid() : serverlet<test_serverlet_for_invalid>(nullptr) {}
+
+    bool register_raw_public(dsn_task_code_t code,
+                             const char* name,
+                             void (test_serverlet_for_invalid::*handler)(dsn_message_t))
+    {
+        return register_rpc_handler(code, name, handler);
+    }
+
+    bool register_one_public(dsn_task_code_t code,
+                             const char* name,
+                             void (test_serverlet_for_invalid::*handler)(const std::string&))
+    {
+        return register_rpc_handler(code, name, handler);
+    }
+
+    bool register_response_public(
+        dsn_task_code_t code,
+        const char* name,
+        void (test_serverlet_for_invalid::*handler)(const std::string&, std::string&))
+    {
+        return register_rpc_handler(code, name, handler);
+    }
+
+    bool register_async_public(
+        dsn_task_code_t code,
+        const char* name,
+        void (test_serverlet_for_invalid::*handler)(const std::string&, rpc_replier<std::string>&))
+    {
+        return register_async_rpc_handler(code, name, handler);
+    }
+
+    bool unregister_public(dsn_task_code_t code) { return unregister_rpc_handler(code); }
+    void reply_public(dsn_message_t request) { reply(request, std::string("response")); }
+
+    void on_raw(dsn_message_t) {}
+    void on_one(const std::string&) {}
+    void on_response(const std::string&, std::string&) {}
+    void on_async(const std::string&, rpc_replier<std::string>&) {}
+};
+
+TEST(dev_cpp, service_cpp_invalid_parameters)
+{
+    char* argv[] = {const_cast<char*>("test_app")};
+    char* null_argv[] = {nullptr};
+
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, service_app::app_start(nullptr, 1, argv));
+    test_service_app_for_invalid app{dsn_gpid()};
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, service_app::app_start(&app, -1, argv));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, service_app::app_start(&app, 0, nullptr));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, service_app::app_start(&app, 1, nullptr));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, service_app::app_start(&app, 1, null_argv));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, service_app::app_destroy(nullptr, false));
+
+    EXPECT_FALSE(register_app<test_service_app_for_invalid>(nullptr));
+    EXPECT_FALSE(register_app<test_service_app_for_invalid>(""));
+}
+
+TEST(dev_cpp, serverlet_cpp_invalid_parameters)
+{
+    test_serverlet_for_invalid server;
+    EXPECT_TRUE(server.name().empty());
+
+    EXPECT_FALSE(server.register_raw_public(
+        TASK_CODE_INVALID, "invalid_code", &test_serverlet_for_invalid::on_raw));
+    EXPECT_FALSE(server.register_raw_public(
+        RPC_TEST_STRING_COMMAND, nullptr, &test_serverlet_for_invalid::on_raw));
+
+    void (test_serverlet_for_invalid::*raw_handler)(dsn_message_t) = nullptr;
+    EXPECT_FALSE(server.register_raw_public(RPC_TEST_STRING_COMMAND, "null_raw", raw_handler));
+
+    void (test_serverlet_for_invalid::*one_handler)(const std::string&) = nullptr;
+    EXPECT_FALSE(server.register_one_public(RPC_TEST_STRING_COMMAND, "null_one", one_handler));
+
+    void (test_serverlet_for_invalid::*response_handler)(const std::string&, std::string&) =
+        nullptr;
+    EXPECT_FALSE(
+        server.register_response_public(RPC_TEST_STRING_COMMAND, "null_response", response_handler));
+
+    void (test_serverlet_for_invalid::*async_handler)(const std::string&,
+                                                      rpc_replier<std::string>&) = nullptr;
+    EXPECT_FALSE(server.register_async_public(RPC_TEST_STRING_COMMAND, "null_async", async_handler));
+
+    EXPECT_FALSE(server.unregister_public(TASK_CODE_INVALID));
+}
+
+TEST(dev_cpp, layer2_cpp_invalid_parameters)
+{
+    layer2_handler::on_layer2_rpc_request(nullptr, dsn_gpid(), false, nullptr);
+
+    test_layer2_handler_for_invalid handler{dsn_gpid()};
+    layer2_handler::on_layer2_rpc_request(&handler, dsn_gpid(), false, nullptr);
+    EXPECT_EQ(1, handler.request_count);
+
+    EXPECT_FALSE(register_layer2_framework<test_layer2_handler_for_invalid>(nullptr, DSN_APP_MASK_FRAMEWORK));
+    EXPECT_FALSE(register_layer2_framework<test_layer2_handler_for_invalid>("", DSN_APP_MASK_FRAMEWORK));
+}
+
+TEST(dev_cpp, replicated_service_cpp_invalid_parameters)
+{
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, replicated_service_app_type_1::app_get_physical_error(nullptr));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, replicated_service_app_type_1::app_sync_checkpoint(nullptr, 0));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, replicated_service_app_type_1::app_async_checkpoint(nullptr, 0));
+    EXPECT_EQ(-1, replicated_service_app_type_1::app_get_last_checkpoint_decree(nullptr));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_prepare_get_checkpoint(nullptr, nullptr, 0, nullptr));
+
+    dsn_app_learn_state state;
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_get_checkpoint(
+                  nullptr, 0, 0, nullptr, 0, &state, sizeof(state)));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_get_checkpoint(
+                  reinterpret_cast<void*>(1), 0, 0, nullptr, 0, nullptr, sizeof(state)));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_get_checkpoint(
+                  reinterpret_cast<void*>(1), 0, 0, nullptr, 0, &state, -1));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_apply_checkpoint(
+                  nullptr, DSN_CHKPT_LEARN, 0, &state));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_apply_checkpoint(
+                  reinterpret_cast<void*>(1), DSN_CHKPT_LEARN, 0, nullptr));
+    replicated_service_app_type_1::app_on_batched_write_requests(nullptr, 0, nullptr, 0);
+    replicated_service_app_type_1::app_on_batched_write_requests(
+        reinterpret_cast<void*>(1), 0, nullptr, -1);
+    replicated_service_app_type_1::app_on_batched_write_requests(
+        reinterpret_cast<void*>(1), 0, nullptr, 1);
+
+    test_replicated_service_app_for_invalid app{dsn_gpid()};
+    int occupied = 0;
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_prepare_get_checkpoint(
+                  &app, nullptr, 0, nullptr));
+    EXPECT_EQ(ERR_OK,
+              replicated_service_app_type_1::app_prepare_get_checkpoint(
+                  &app, nullptr, 0, &occupied));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_get_checkpoint(
+                  &app, 0, 0, nullptr, 0, &state, 0));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              replicated_service_app_type_1::app_apply_checkpoint(
+                  &app, DSN_CHKPT_LEARN, 0, nullptr));
+
+    replicated_service_app_type_1::app_learn_state cpp_state;
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, cpp_state.to_c_state(state, -1));
+    EXPECT_EQ(ERR_INVALID_PARAMETERS, cpp_state.to_c_state(state, 0));
+
+    EXPECT_FALSE(register_app_with_type_1_replication_support<test_replicated_service_app_for_invalid>(nullptr));
+    EXPECT_FALSE(register_app_with_type_1_replication_support<test_replicated_service_app_for_invalid>(""));
 }

--- a/src/core/src/command_manager.cpp
+++ b/src/core/src/command_manager.cpp
@@ -443,7 +443,8 @@ namespace dsn {
 
         std::string r2 = result.c_str();
         ::dsn::marshall(resp, r2);
-        dsn_rpc_reply(resp);
+        auto err = dsn_rpc_reply(resp);
+        dassert(err == ERR_OK, "dsn_rpc_reply failed: %s", error_code(err).to_string());
     }
 
     void command_manager::set_cli_target_address(dsn_handle_t handle, dsn::rpc_address address)

--- a/src/core/src/command_manager.cpp
+++ b/src/core/src/command_manager.cpp
@@ -52,9 +52,11 @@
 
 DSN_API const char* dsn_cli_run(const char* command_line) // return command output
 {
-    ::dsn::safe_string cmd = command_line;
     ::dsn::safe_string output;
-    dsn::command_manager::instance().run_command(cmd, output);
+    if (!dsn::run_command(command_line, output))
+    {
+        return nullptr;
+    }
 
     char* c_output = (char*)malloc(output.length() + 1);
     if (c_output == nullptr)
@@ -70,6 +72,12 @@ DSN_API const char* dsn_cli_run(const char* command_line) // return command outp
 
 DSN_API void dsn_cli_free(const char* command_output)
 {
+    if (command_output == nullptr)
+    {
+        derror("dsn_cli_free got null command output");
+        return;
+    }
+
     ::free((void*)command_output);
 }
 
@@ -82,6 +90,18 @@ DSN_API dsn_handle_t dsn_cli_register(
     dsn_cli_free_handler output_freer
     )
 {
+    if (cmd_handler == nullptr)
+    {
+        derror("dsn_cli_register got null command handler");
+        return nullptr;
+    }
+
+    if (output_freer == nullptr)
+    {
+        derror("dsn_cli_register got null output freer");
+        return nullptr;
+    }
+
     return dsn::register_command(
         command,
         help_one_line,
@@ -111,6 +131,18 @@ DSN_API dsn_handle_t dsn_cli_app_register(
     dsn_cli_free_handler output_freer
     )
 { 
+    if (command == nullptr || command[0] == '\0')
+    {
+        derror("dsn_cli_app_register got null or empty command");
+        return nullptr;
+    }
+
+    if (help_one_line == nullptr)
+    {
+        derror("dsn_cli_app_register got null help_one_line");
+        return nullptr;
+    }
+
     auto cnode = ::dsn::task::get_current_node2();
     dassert(cnode != nullptr, "tls_dsn not inited properly");
     auto handle = dsn_cli_register(
@@ -121,6 +153,11 @@ DSN_API dsn_handle_t dsn_cli_app_register(
         cmd_handler,
         output_freer
         );
+    if (handle == nullptr)
+    {
+        return nullptr;
+    }
+
     dsn::command_manager::instance().set_cli_target_address(handle, dsn::task::get_current_rpc()->primary_address());
     return handle;
 }
@@ -134,6 +171,12 @@ namespace dsn {
 
     void deregister_command(dsn_handle_t command_handle)
     {
+        if (command_handle == nullptr)
+        {
+            derror("deregister_command got null command handle");
+            return;
+        }
+
         return command_manager::instance().deregister_command(command_handle);
     }
 
@@ -144,6 +187,39 @@ namespace dsn {
         command_handler handler
         )
     {
+        if (commands.empty())
+        {
+            derror("register_command got empty commands");
+            return nullptr;
+        }
+
+        if (help_one_line == nullptr)
+        {
+            derror("register_command got null help_one_line");
+            return nullptr;
+        }
+
+        if (help_long == nullptr)
+        {
+            derror("register_command got null help_long");
+            return nullptr;
+        }
+
+        if (!handler)
+        {
+            derror("register_command got empty handler");
+            return nullptr;
+        }
+
+        for (auto cmd : commands)
+        {
+            if (cmd == nullptr || cmd[0] == '\0')
+            {
+                derror("register_command got null or empty command");
+                return nullptr;
+            }
+        }
+
         return command_manager::instance().register_command(commands, help_one_line, help_long, handler);
     }
 
@@ -154,6 +230,12 @@ namespace dsn {
         command_handler handler
         )
     {
+        if (command == nullptr || command[0] == '\0')
+        {
+            derror("register_command got null or empty command");
+            return nullptr;
+        }
+
         safe_vector<const char*> cmds;
         cmds.push_back(command);
         return register_command(cmds, help_one_line, help_long, handler);
@@ -161,6 +243,12 @@ namespace dsn {
 
     bool run_command(const char* cmd, /* out */ ::dsn::safe_string& output)
     {
+        if (cmd == nullptr || cmd[0] == '\0')
+        {
+            derror("run_command got null or empty command");
+            return false;
+        }
+
         return command_manager::instance().run_command(cmd, output);
     }
 

--- a/src/core/src/command_manager.test.cpp
+++ b/src/core/src/command_manager.test.cpp
@@ -39,6 +39,15 @@
 
 using namespace ::dsn;
 
+namespace
+{
+
+void noop_cli_handler(void*, int, const char**, dsn_cli_reply*) {}
+
+void noop_cli_free(dsn_cli_reply) {}
+
+} // anonymous namespace
+
 void command_manager_module_init()
 {
     register_command("test-cmd",
@@ -58,6 +67,69 @@ void command_manager_module_init()
             return ss.str();
         }
     );
+}
+
+TEST(core, dsn_cli_invalid_parameters)
+{
+    ASSERT_EQ(nullptr, dsn_cli_run(nullptr));
+    ASSERT_EQ(nullptr, dsn_cli_run(""));
+    dsn_cli_free(nullptr);
+
+    ASSERT_EQ(nullptr, dsn_cli_register("invalid-cli",
+                                        "help",
+                                        "help",
+                                        nullptr,
+                                        nullptr,
+                                        noop_cli_free));
+    ASSERT_EQ(nullptr, dsn_cli_register("invalid-cli",
+                                        "help",
+                                        "help",
+                                        nullptr,
+                                        noop_cli_handler,
+                                        nullptr));
+    ASSERT_EQ(nullptr, dsn_cli_register(nullptr,
+                                        "help",
+                                        "help",
+                                        nullptr,
+                                        noop_cli_handler,
+                                        noop_cli_free));
+    ASSERT_EQ(nullptr, dsn_cli_register("",
+                                        "help",
+                                        "help",
+                                        nullptr,
+                                        noop_cli_handler,
+                                        noop_cli_free));
+    ASSERT_EQ(nullptr, dsn_cli_register("invalid-cli",
+                                        nullptr,
+                                        "help",
+                                        nullptr,
+                                        noop_cli_handler,
+                                        noop_cli_free));
+    ASSERT_EQ(nullptr, dsn_cli_register("invalid-cli",
+                                        "help",
+                                        nullptr,
+                                        nullptr,
+                                        noop_cli_handler,
+                                        noop_cli_free));
+
+    ASSERT_EQ(nullptr, dsn_cli_app_register(nullptr,
+                                            "help",
+                                            "help",
+                                            nullptr,
+                                            noop_cli_handler,
+                                            noop_cli_free));
+    ASSERT_EQ(nullptr, dsn_cli_app_register("",
+                                            "help",
+                                            "help",
+                                            nullptr,
+                                            noop_cli_handler,
+                                            noop_cli_free));
+    ASSERT_EQ(nullptr, dsn_cli_app_register("invalid-cli",
+                                            nullptr,
+                                            "help",
+                                            nullptr,
+                                            noop_cli_handler,
+                                            noop_cli_free));
 }
 
 TEST(core, command_manager)
@@ -128,4 +200,3 @@ TEST(core, command_manager)
     std::tie(err, result) = cli.call_sync(rcmd, std::chrono::seconds(10), 0, 0, addr);
     ASSERT_TRUE(err == ERR_TIMEOUT || err == ERR_NETWORK_FAILURE);
 }
-

--- a/src/core/src/global_checkers.cpp
+++ b/src/core/src/global_checkers.cpp
@@ -54,6 +54,24 @@ namespace dsn
 
 DSN_API void dsn_register_app_checker(const char* name, dsn_checker_create create, dsn_checker_apply apply)
 {
+    if (name == nullptr || name[0] == '\0')
+    {
+        derror("dsn_register_app_checker got null or empty name");
+        return;
+    }
+
+    if (create == nullptr)
+    {
+        derror("dsn_register_app_checker got null create callback");
+        return;
+    }
+
+    if (apply == nullptr)
+    {
+        derror("dsn_register_app_checker got null apply callback");
+        return;
+    }
+
     ::dsn::global_checker ck;
     ck.name = name;
     ck.create = create;
@@ -61,4 +79,3 @@ DSN_API void dsn_register_app_checker(const char* name, dsn_checker_create creat
 
     ::dsn::global_checker_store::instance().checkers.push_back(ck);
 }
-

--- a/src/core/src/global_checkers.cpp
+++ b/src/core/src/global_checkers.cpp
@@ -52,24 +52,24 @@ namespace dsn
 }
 
 
-DSN_API void dsn_register_app_checker(const char* name, dsn_checker_create create, dsn_checker_apply apply)
+DSN_API bool dsn_register_app_checker(const char* name, dsn_checker_create create, dsn_checker_apply apply)
 {
     if (name == nullptr || name[0] == '\0')
     {
         derror("dsn_register_app_checker got null or empty name");
-        return;
+        return false;
     }
 
     if (create == nullptr)
     {
         derror("dsn_register_app_checker got null create callback");
-        return;
+        return false;
     }
 
     if (apply == nullptr)
     {
         derror("dsn_register_app_checker got null apply callback");
-        return;
+        return false;
     }
 
     ::dsn::global_checker ck;
@@ -78,4 +78,5 @@ DSN_API void dsn_register_app_checker(const char* name, dsn_checker_create creat
     ck.apply = apply;
 
     ::dsn::global_checker_store::instance().checkers.push_back(ck);
+    return true;
 }

--- a/src/core/src/global_config.cpp
+++ b/src/core/src/global_config.cpp
@@ -374,12 +374,12 @@ static void* mimic_app_create(const char*, dsn_gpid)
 
 static dsn_error_t mimic_app_start(void* ctx, int argc, char** argv)
 {
-    return ::dsn::ERR_OK;
+    return ::dsn::ERR_OK.get();
 }
 
 static dsn_error_t mimic_app_destroy(void* ctx, bool clean_up)
 {
-    return ::dsn::ERR_OK;
+    return ::dsn::ERR_OK.get();
 }
 
 bool service_spec::init_app_specs()

--- a/src/core/src/logging.cpp
+++ b/src/core/src/logging.cpp
@@ -40,6 +40,7 @@
 # include <dsn/tool_api.h>
 # include "service_engine.h"
 # include <dsn/cpp/auto_codes.h>
+# include <cstdio>
 
 DSN_API dsn_log_level_t dsn_log_start_level = dsn_log_level_t::LOG_LEVEL_INFORMATION;
 
@@ -93,6 +94,36 @@ DSN_API dsn_log_level_t dsn_log_get_start_level()
 
 DSN_API void dsn_logv(const char *file, const char *function, const int line, dsn_log_level_t log_level, const char* title, const char* fmt, va_list args)
 {
+    if (file == nullptr)
+    {
+        fprintf(stderr, "ERROR: dsn_logv got null file\n");
+        return;
+    }
+
+    if (function == nullptr)
+    {
+        fprintf(stderr, "ERROR: dsn_logv got null function\n");
+        return;
+    }
+
+    if (log_level < LOG_LEVEL_INFORMATION || log_level >= LOG_LEVEL_COUNT)
+    {
+        fprintf(stderr, "ERROR: dsn_logv got invalid log_level = %d\n", log_level);
+        return;
+    }
+
+    if (title == nullptr)
+    {
+        fprintf(stderr, "ERROR: dsn_logv got null title\n");
+        return;
+    }
+
+    if (fmt == nullptr)
+    {
+        fprintf(stderr, "ERROR: dsn_logv got null fmt\n");
+        return;
+    }
+
     ::dsn::logging_provider* logger = ::dsn::service_engine::instance().logging();
     if (logger != nullptr)
     {

--- a/src/core/src/lpc.test.cpp
+++ b/src/core/src/lpc.test.cpp
@@ -54,7 +54,7 @@ TEST(core, lpc)
     std::string result;
     auto t = dsn_task_create(LPC_TEST_HASH, on_lpc_test, (void*)&result, 1);
     dsn_task_add_ref(t);
-    dsn_task_call(t, 0);
+    ASSERT_TRUE(dsn_task_call(t, 0));
     dsn_task_wait(t);
     dsn_task_release_ref(t);
 

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -660,6 +660,27 @@ bool run(
 //
 DSN_API void dsn_run(int argc, char** argv, bool sleep_after_init)
 {
+    if (argc < 0)
+    {
+        derror("dsn_run got invalid argc = %d", argc);
+        return;
+    }
+
+    if (argc > 0 && argv == nullptr)
+    {
+        derror("dsn_run got null argv");
+        return;
+    }
+
+    for (int i = 0; i < argc; ++i)
+    {
+        if (argv[i] == nullptr)
+        {
+            derror("dsn_run got null argv at index = %d", i);
+            return;
+        }
+    }
+
     if (argc < 2)
     {
         fprintf(stderr, "invalid options for dsn_run\n"
@@ -728,12 +749,30 @@ DSN_API void dsn_run(int argc, char** argv, bool sleep_after_init)
 
 DSN_API bool dsn_run_config(const char* config, bool sleep_after_init)
 {
+    if (config == nullptr || config[0] == '\0')
+    {
+        derror("dsn_run_config got null or empty config");
+        return false;
+    }
+
     std::string name;
     return run(config, nullptr, nullptr, sleep_after_init, name);
 }
 
 DSN_API int dsn_get_all_apps(dsn_app_info* info_buffer, int count)
 {
+    if (info_buffer == nullptr)
+    {
+        derror("dsn_get_all_apps got null info_buffer");
+        return -1;
+    }
+
+    if (count < 0)
+    {
+        derror("dsn_get_all_apps got invalid count = %d", count);
+        return -1;
+    }
+
     auto& as = ::dsn::service_engine::fast_instance().get_all_nodes();
     int i = 0;
     for (auto& kv : as)

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -99,26 +99,128 @@ static struct _all_info_
 
 DSN_API const char* dsn_config_get_value_string(const char* section, const char* key, const char* default_value, const char* dsptr)
 {
+    if (section == nullptr || section[0] == '\0')
+    {
+        derror("dsn_config_get_value_string got null or empty section");
+        return default_value;
+    }
+
+    if (key == nullptr || key[0] == '\0')
+    {
+        derror("dsn_config_get_value_string got null or empty key");
+        return default_value;
+    }
+
+    if (default_value == nullptr)
+    {
+        derror("dsn_config_get_value_string got null default_value");
+        return default_value;
+    }
+
+    if (dsn_all.config == nullptr)
+    {
+        derror("dsn_config_get_value_string got null config");
+        return default_value;
+    }
+
     return dsn_all.config->get_string_value(section, key, default_value, dsptr);
 }
 
 DSN_API bool dsn_config_get_value_bool(const char* section, const char* key, bool default_value, const char* dsptr)
 {
+    if (section == nullptr || section[0] == '\0')
+    {
+        derror("dsn_config_get_value_bool got null or empty section");
+        return default_value;
+    }
+
+    if (key == nullptr || key[0] == '\0')
+    {
+        derror("dsn_config_get_value_bool got null or empty key");
+        return default_value;
+    }
+
+    if (dsn_all.config == nullptr)
+    {
+        derror("dsn_config_get_value_bool got null config");
+        return default_value;
+    }
+
     return dsn_all.config->get_value<bool>(section, key, default_value, dsptr);
 }
 
 DSN_API uint64_t dsn_config_get_value_uint64(const char* section, const char* key, uint64_t default_value, const char* dsptr)
 {
+    if (section == nullptr || section[0] == '\0')
+    {
+        derror("dsn_config_get_value_uint64 got null or empty section");
+        return default_value;
+    }
+
+    if (key == nullptr || key[0] == '\0')
+    {
+        derror("dsn_config_get_value_uint64 got null or empty key");
+        return default_value;
+    }
+
+    if (dsn_all.config == nullptr)
+    {
+        derror("dsn_config_get_value_uint64 got null config");
+        return default_value;
+    }
+
     return dsn_all.config->get_value<uint64_t>(section, key, default_value, dsptr);
 }
 
 DSN_API double dsn_config_get_value_double(const char* section, const char* key, double default_value, const char* dsptr)
 {
+    if (section == nullptr || section[0] == '\0')
+    {
+        derror("dsn_config_get_value_double got null or empty section");
+        return default_value;
+    }
+
+    if (key == nullptr || key[0] == '\0')
+    {
+        derror("dsn_config_get_value_double got null or empty key");
+        return default_value;
+    }
+
+    if (dsn_all.config == nullptr)
+    {
+        derror("dsn_config_get_value_double got null config");
+        return default_value;
+    }
+
     return dsn_all.config->get_value<double>(section, key, default_value, dsptr);
 }
 
 DSN_API int dsn_config_get_all_sections(const char** buffers, /*inout*/ int* buffer_count)
 {
+    if (buffer_count == nullptr)
+    {
+        derror("dsn_config_get_all_sections got null buffer_count");
+        return -1;
+    }
+
+    if (*buffer_count < 0)
+    {
+        derror("dsn_config_get_all_sections got invalid buffer_count = %d", *buffer_count);
+        return -1;
+    }
+
+    if (buffers == nullptr && *buffer_count > 0)
+    {
+        derror("dsn_config_get_all_sections got null buffers with buffer_count = %d", *buffer_count);
+        return -1;
+    }
+
+    if (dsn_all.config == nullptr)
+    {
+        derror("dsn_config_get_all_sections got null config");
+        return -1;
+    }
+
     std::vector<const char*> sections;
     dsn_all.config->get_all_section_ptrs(sections);
     int scount = (int)sections.size();
@@ -136,6 +238,36 @@ DSN_API int dsn_config_get_all_sections(const char** buffers, /*inout*/ int* buf
 
 DSN_API int dsn_config_get_all_keys(const char* section, const char** buffers, /*inout*/ int* buffer_count) // return all key count (may greater than buffer_count)
 {
+    if (section == nullptr || section[0] == '\0')
+    {
+        derror("dsn_config_get_all_keys got null or empty section");
+        return -1;
+    }
+
+    if (buffer_count == nullptr)
+    {
+        derror("dsn_config_get_all_keys got null buffer_count");
+        return -1;
+    }
+
+    if (*buffer_count < 0)
+    {
+        derror("dsn_config_get_all_keys got invalid buffer_count = %d", *buffer_count);
+        return -1;
+    }
+
+    if (buffers == nullptr && *buffer_count > 0)
+    {
+        derror("dsn_config_get_all_keys got null buffers with buffer_count = %d", *buffer_count);
+        return -1;
+    }
+
+    if (dsn_all.config == nullptr)
+    {
+        derror("dsn_config_get_all_keys got null config");
+        return -1;
+    }
+
     std::vector<const char*> keys;
     dsn_all.config->get_all_keys(section, keys);
     int kcount = (int)keys.size();
@@ -153,6 +285,18 @@ DSN_API int dsn_config_get_all_keys(const char* section, const char** buffers, /
 
 DSN_API void dsn_config_dump(const char* file)
 {
+    if (file == nullptr || file[0] == '\0')
+    {
+        derror("dsn_config_dump got null or empty file");
+        return;
+    }
+
+    if (dsn_all.config == nullptr)
+    {
+        derror("dsn_config_dump got null config");
+        return;
+    }
+
     std::ofstream os(file, std::ios::out);
     dsn_all.config->dump(os);
     os.close();

--- a/src/core/src/network.cpp
+++ b/src/core/src/network.cpp
@@ -247,7 +247,7 @@ namespace dsn
                     this
                     );
                 this->add_ref(); // released in __delayed_rpc_session_read_next__
-                dsn_task_call(delay_task, delay_ms);
+                dassert(dsn_task_call(delay_task, delay_ms), "dsn_task_call failed");
             }
             else
             {

--- a/src/core/src/perf_counters.cpp
+++ b/src/core/src/perf_counters.cpp
@@ -43,6 +43,30 @@
 
 DSN_API dsn_handle_t dsn_perf_counter_create(const char* section, const char* name, dsn_perf_counter_type_t type, const char* description)
 {
+    if (section == nullptr || section[0] == '\0')
+    {
+        derror("dsn_perf_counter_create got null or empty section");
+        return nullptr;
+    }
+
+    if (name == nullptr || name[0] == '\0')
+    {
+        derror("dsn_perf_counter_create got null or empty name");
+        return nullptr;
+    }
+
+    if (type < COUNTER_TYPE_NUMBER || type >= COUNTER_TYPE_INVALID)
+    {
+        derror("dsn_perf_counter_create got invalid type = %d", type);
+        return nullptr;
+    }
+
+    if (description == nullptr)
+    {
+        derror("dsn_perf_counter_create got null description");
+        return nullptr;
+    }
+
     auto cnode = dsn::task::get_current_node2();
     dassert(cnode != nullptr, "cannot get current service node!");
     auto c = dsn::perf_counters::instance().get_counter(cnode->name(), section, name, type, description, true);
@@ -52,6 +76,12 @@ DSN_API dsn_handle_t dsn_perf_counter_create(const char* section, const char* na
 
 DSN_API void dsn_perf_counter_remove(dsn_handle_t handle)
 {
+    if (handle == nullptr)
+    {
+        derror("dsn_perf_counter_remove got null handle");
+        return;
+    }
+
     auto sptr = reinterpret_cast<dsn::perf_counter*>(handle);
     if (dsn::perf_counters::instance().remove_counter(sptr->full_name()))
         sptr->release_ref();
@@ -63,31 +93,79 @@ DSN_API void dsn_perf_counter_remove(dsn_handle_t handle)
 
 DSN_API void dsn_perf_counter_increment(dsn_handle_t handle)
 {
+    if (handle == nullptr)
+    {
+        derror("dsn_perf_counter_increment got null handle");
+        return;
+    }
+
     reinterpret_cast<dsn::perf_counter*>(handle)->increment();
 }
 
 DSN_API void dsn_perf_counter_decrement(dsn_handle_t handle)
 {
+    if (handle == nullptr)
+    {
+        derror("dsn_perf_counter_decrement got null handle");
+        return;
+    }
+
     reinterpret_cast<dsn::perf_counter*>(handle)->decrement();
 }
 DSN_API void dsn_perf_counter_add(dsn_handle_t handle, uint64_t val)
 {
+    if (handle == nullptr)
+    {
+        derror("dsn_perf_counter_add got null handle");
+        return;
+    }
+
     reinterpret_cast<dsn::perf_counter*>(handle)->add(val);
 }
 DSN_API void dsn_perf_counter_set(dsn_handle_t handle, uint64_t val)
 {
+    if (handle == nullptr)
+    {
+        derror("dsn_perf_counter_set got null handle");
+        return;
+    }
+
     reinterpret_cast<dsn::perf_counter*>(handle)->set(val);
 }
 DSN_API double dsn_perf_counter_get_value(dsn_handle_t handle)
 {
+    if (handle == nullptr)
+    {
+        derror("dsn_perf_counter_get_value got null handle");
+        return -1.0;
+    }
+
     return reinterpret_cast<dsn::perf_counter*>(handle)->get_value();
 }
 DSN_API uint64_t dsn_perf_counter_get_integer_value(dsn_handle_t handle)
 {
+    if (handle == nullptr)
+    {
+        derror("dsn_perf_counter_get_integer_value got null handle");
+        return static_cast<uint64_t>(-1);
+    }
+
     return reinterpret_cast<dsn::perf_counter*>(handle)->get_integer_value();
 }
 DSN_API double dsn_perf_counter_get_percentile(dsn_handle_t handle, dsn_perf_counter_percentile_type_t type)
 {
+    if (handle == nullptr)
+    {
+        derror("dsn_perf_counter_get_percentile got null handle");
+        return -1.0;
+    }
+
+    if (type < COUNTER_PERCENTILE_50 || type >= COUNTER_PERCENTILE_COUNT)
+    {
+        derror("dsn_perf_counter_get_percentile got invalid type = %d", type);
+        return -1.0;
+    }
+
     return reinterpret_cast<dsn::perf_counter*>(handle)->get_percentile(type);
 }
 

--- a/src/core/src/perf_counters.test.cpp
+++ b/src/core/src/perf_counters.test.cpp
@@ -33,6 +33,7 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
+# include <dsn/cpp/perf_counter_.h>
 # include <dsn/tool-api/perf_counter.h>
 # include <gtest/gtest.h>
 
@@ -94,4 +95,24 @@ TEST(core, dsn_perf_counter_invalid_parameters)
     ASSERT_DOUBLE_EQ(-1.0,
                      dsn_perf_counter_get_percentile(reinterpret_cast<dsn_handle_t>(1),
                                                      COUNTER_PERCENTILE_INVALID));
+}
+
+TEST(core, perf_counter_cpp_invalid_parameters)
+{
+    perf_counter_ counter;
+    counter.increment();
+    counter.decrement();
+    counter.add(1);
+    counter.set(1);
+    ASSERT_DOUBLE_EQ(-1.0, counter.get_value());
+    ASSERT_EQ(static_cast<uint64_t>(-1), counter.get_integer_value());
+    ASSERT_DOUBLE_EQ(-1.0, counter.get_percentile(COUNTER_PERCENTILE_50));
+
+    counter.init(nullptr, "name", COUNTER_TYPE_NUMBER, "");
+    ASSERT_DOUBLE_EQ(-1.0, counter.get_value());
+
+    counter.init("section", nullptr, COUNTER_TYPE_NUMBER, "");
+    ASSERT_DOUBLE_EQ(-1.0, counter.get_value());
+
+    counter.destroy();
 }

--- a/src/core/src/perf_counters.test.cpp
+++ b/src/core/src/perf_counters.test.cpp
@@ -71,3 +71,27 @@ TEST(core, perf_counters)
     ASSERT_EQ(nullptr, p);
     ASSERT_FALSE(perf_counter::remove_counter("app*test*unexist_counter"));
 }
+
+TEST(core, dsn_perf_counter_invalid_parameters)
+{
+    ASSERT_EQ(nullptr, dsn_perf_counter_create(nullptr, "name", COUNTER_TYPE_NUMBER, ""));
+    ASSERT_EQ(nullptr, dsn_perf_counter_create("", "name", COUNTER_TYPE_NUMBER, ""));
+    ASSERT_EQ(nullptr, dsn_perf_counter_create("section", nullptr, COUNTER_TYPE_NUMBER, ""));
+    ASSERT_EQ(nullptr, dsn_perf_counter_create("section", "", COUNTER_TYPE_NUMBER, ""));
+    ASSERT_EQ(nullptr,
+              dsn_perf_counter_create("section", "name", COUNTER_TYPE_INVALID, ""));
+    ASSERT_EQ(nullptr,
+              dsn_perf_counter_create("section", "name", COUNTER_TYPE_NUMBER, nullptr));
+
+    dsn_perf_counter_remove(nullptr);
+    dsn_perf_counter_increment(nullptr);
+    dsn_perf_counter_decrement(nullptr);
+    dsn_perf_counter_add(nullptr, 1);
+    dsn_perf_counter_set(nullptr, 1);
+    ASSERT_DOUBLE_EQ(-1.0, dsn_perf_counter_get_value(nullptr));
+    ASSERT_EQ(static_cast<uint64_t>(-1), dsn_perf_counter_get_integer_value(nullptr));
+    ASSERT_DOUBLE_EQ(-1.0, dsn_perf_counter_get_percentile(nullptr, COUNTER_PERCENTILE_50));
+    ASSERT_DOUBLE_EQ(-1.0,
+                     dsn_perf_counter_get_percentile(reinterpret_cast<dsn_handle_t>(1),
+                                                     COUNTER_PERCENTILE_INVALID));
+}

--- a/src/core/src/rpc_engine.cpp
+++ b/src/core/src/rpc_engine.cpp
@@ -910,7 +910,11 @@ namespace dsn {
                                         nullptr,
                                         [server = req2->server_address.c_addr(), ctask]()
                                         {
-                                            dsn_rpc_call(server, ctask);
+                                            auto err = dsn_rpc_call(server, ctask);
+                                            if (err != ERR_OK)
+                                            {
+                                                ctask->enqueue(error_code(err), nullptr);
+                                            }
                                             ctask->release_ref(); // added when set-retry
                                         },
                                         0,

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -141,7 +141,7 @@ DSN_API dsn_message_t dsn_msg_create_response(dsn_message_t request)
     return msg;
 }
 
-DSN_API void dsn_msg_write_next(dsn_message_t msg, void** ptr, size_t* size, size_t min_size)
+DSN_API bool dsn_msg_write_next(dsn_message_t msg, void** ptr, size_t* size, size_t min_size)
 {
     if (msg == nullptr)
     {
@@ -154,33 +154,35 @@ DSN_API void dsn_msg_write_next(dsn_message_t msg, void** ptr, size_t* size, siz
         {
             *size = 0;
         }
-        return;
+        return false;
     }
 
     if (ptr == nullptr)
     {
         derror("dsn_msg_write_next got null ptr");
-        return;
+        return false;
     }
 
     if (size == nullptr)
     {
         derror("dsn_msg_write_next got null size");
-        return;
+        return false;
     }
 
     ((::dsn::message_ex*)msg)->write_next(ptr, size, min_size);
+    return true;
 }
 
-DSN_API void dsn_msg_write_commit(dsn_message_t msg, size_t size)
+DSN_API bool dsn_msg_write_commit(dsn_message_t msg, size_t size)
 {
     if (msg == nullptr)
     {
         derror("dsn_msg_write_commit got null message");
-        return;
+        return false;
     }
 
     ((::dsn::message_ex*)msg)->write_commit(size);
+    return true;
 }
 
 DSN_API bool dsn_msg_read_next(dsn_message_t msg, void** ptr, size_t* size)
@@ -214,15 +216,16 @@ DSN_API bool dsn_msg_read_next(dsn_message_t msg, void** ptr, size_t* size)
     return ((::dsn::message_ex*)msg)->read_next(ptr, size);
 }
 
-DSN_API void dsn_msg_read_commit(dsn_message_t msg, size_t size)
+DSN_API bool dsn_msg_read_commit(dsn_message_t msg, size_t size)
 {
     if (msg == nullptr)
     {
         derror("dsn_msg_read_commit got null message");
-        return;
+        return false;
     }
 
     ((::dsn::message_ex*)msg)->read_commit(size);
+    return true;
 }
 
 DSN_API size_t dsn_msg_body_size(dsn_message_t msg)
@@ -337,7 +340,7 @@ DSN_API dsn_task_code_t dsn_msg_task_code(dsn_message_t msg)
     return ((::dsn::message_ex*)msg)->rpc_code();
 }
 
-DSN_API void dsn_msg_set_options(
+DSN_API bool dsn_msg_set_options(
     dsn_message_t msg,
     dsn_msg_options_t *opts,
     uint32_t mask // set opt bits using DSN_MSGM_XXX
@@ -346,20 +349,20 @@ DSN_API void dsn_msg_set_options(
     if (msg == nullptr)
     {
         derror("dsn_msg_set_options got null message");
-        return;
+        return false;
     }
 
     if (opts == nullptr)
     {
         derror("dsn_msg_set_options got null opts");
-        return;
+        return false;
     }
 
     auto hdr = ((::dsn::message_ex*)msg)->header;
     if (hdr == nullptr)
     {
         derror("dsn_msg_set_options got message with null header");
-        return;
+        return false;
     }
 
     if (mask & DSN_MSGM_TIMEOUT)
@@ -367,7 +370,7 @@ DSN_API void dsn_msg_set_options(
         if (opts->timeout_ms < 0)
         {
             derror("dsn_msg_set_options got invalid timeout_ms = %d", opts->timeout_ms);
-            return;
+            return false;
         }
 
         hdr->client.timeout_ms = opts->timeout_ms;
@@ -392,6 +395,7 @@ DSN_API void dsn_msg_set_options(
     {
         hdr->context = opts->context;
     }
+    return true;
 }
 
 DSN_API dsn_msg_serialize_format dsn_msg_get_serialize_format(dsn_message_t msg)
@@ -412,31 +416,32 @@ DSN_API dsn_msg_serialize_format dsn_msg_get_serialize_format(dsn_message_t msg)
     return static_cast<dsn_msg_serialize_format>(hdr->context.u.serialize_format);
 }
 
-DSN_API void dsn_msg_set_serailize_format(dsn_message_t msg, dsn_msg_serialize_format fmt)
+DSN_API bool dsn_msg_set_serailize_format(dsn_message_t msg, dsn_msg_serialize_format fmt)
 {
     if (msg == nullptr)
     {
         derror("dsn_msg_set_serailize_format got null message");
-        return;
+        return false;
     }
 
     auto hdr = ((::dsn::message_ex*)msg)->header;
     if (hdr == nullptr)
     {
         derror("dsn_msg_set_serailize_format got message with null header");
-        return;
+        return false;
     }
 
     if (!is_valid_serialize_format(fmt))
     {
         derror("dsn_msg_set_serailize_format got invalid fmt = %d", fmt);
-        return;
+        return false;
     }
 
     hdr->context.u.serialize_format = fmt;
+    return true;
 }
 
-DSN_API void dsn_msg_get_options(
+DSN_API bool dsn_msg_get_options(
     dsn_message_t msg,
     /*out*/ dsn_msg_options_t* opts
     )
@@ -444,20 +449,20 @@ DSN_API void dsn_msg_get_options(
     if (msg == nullptr)
     {
         derror("dsn_msg_get_options got null message");
-        return;
+        return false;
     }
 
     if (opts == nullptr)
     {
         derror("dsn_msg_get_options got null opts");
-        return;
+        return false;
     }
 
     auto hdr = ((::dsn::message_ex*)msg)->header;
     if (hdr == nullptr)
     {
         derror("dsn_msg_get_options got message with null header");
-        return;
+        return false;
     }
 
     opts->timeout_ms = hdr->client.timeout_ms;
@@ -465,6 +470,7 @@ DSN_API void dsn_msg_get_options(
     opts->partition_hash = hdr->client.partition_hash;
     opts->gpid = hdr->gpid;
     opts->context = hdr->context;
+    return true;
 }
 
 namespace dsn {

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -68,6 +68,24 @@ DSN_API dsn_message_t dsn_msg_create_received_request(
     uint64_t partition_hash
     )
 {
+    if (::dsn::task_spec::get(rpc_code) == nullptr)
+    {
+        derror("dsn_msg_create_received_request got invalid rpc_code = %d", rpc_code);
+        return nullptr;
+    }
+
+    if (size < 0)
+    {
+        derror("dsn_msg_create_received_request got invalid size = %d", size);
+        return nullptr;
+    }
+
+    if (buffer == nullptr && size > 0)
+    {
+        derror("dsn_msg_create_received_request got null buffer with size = %d", size);
+        return nullptr;
+    }
+
     ::dsn::blob bb((const char*)buffer, 0, size);
     auto msg = ::dsn::message_ex::create_receive_message_with_standalone_header(bb);
     msg->local_rpc_code = rpc_code;
@@ -80,72 +98,226 @@ DSN_API dsn_message_t dsn_msg_create_received_request(
 
 DSN_API dsn_message_t dsn_msg_copy(dsn_message_t msg, bool clone_content, bool copy_for_receive)
 {
-    return msg ? ((::dsn::message_ex*)msg)->copy(clone_content, copy_for_receive) : nullptr;
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_copy got null message");
+        return nullptr;
+    }
+
+    return ((::dsn::message_ex*)msg)->copy(clone_content, copy_for_receive);
 }
 
 DSN_API dsn_message_t dsn_msg_create_response(dsn_message_t request)
 {
+    if (request == nullptr)
+    {
+        derror("dsn_msg_create_response got null request");
+        return nullptr;
+    }
+
+    if (((::dsn::message_ex*)request)->header == nullptr)
+    {
+        derror("dsn_msg_create_response got request with null header");
+        return nullptr;
+    }
+
     auto msg = ((::dsn::message_ex*)request)->create_response();
     return msg;
 }
 
 DSN_API void dsn_msg_write_next(dsn_message_t msg, void** ptr, size_t* size, size_t min_size)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_write_next got null message");
+        if (ptr != nullptr)
+        {
+            *ptr = nullptr;
+        }
+        if (size != nullptr)
+        {
+            *size = 0;
+        }
+        return;
+    }
+
+    if (ptr == nullptr)
+    {
+        derror("dsn_msg_write_next got null ptr");
+        return;
+    }
+
+    if (size == nullptr)
+    {
+        derror("dsn_msg_write_next got null size");
+        return;
+    }
+
     ((::dsn::message_ex*)msg)->write_next(ptr, size, min_size);
 }
 
 DSN_API void dsn_msg_write_commit(dsn_message_t msg, size_t size)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_write_commit got null message");
+        return;
+    }
+
     ((::dsn::message_ex*)msg)->write_commit(size);
 }
 
 DSN_API bool dsn_msg_read_next(dsn_message_t msg, void** ptr, size_t* size)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_read_next got null message");
+        if (ptr != nullptr)
+        {
+            *ptr = nullptr;
+        }
+        if (size != nullptr)
+        {
+            *size = 0;
+        }
+        return false;
+    }
+
+    if (ptr == nullptr)
+    {
+        derror("dsn_msg_read_next got null ptr");
+        return false;
+    }
+
+    if (size == nullptr)
+    {
+        derror("dsn_msg_read_next got null size");
+        return false;
+    }
+
     return ((::dsn::message_ex*)msg)->read_next(ptr, size);
 }
 
 DSN_API void dsn_msg_read_commit(dsn_message_t msg, size_t size)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_read_commit got null message");
+        return;
+    }
+
     ((::dsn::message_ex*)msg)->read_commit(size);
 }
 
 DSN_API size_t dsn_msg_body_size(dsn_message_t msg)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_body_size got null message");
+        return 0;
+    }
+
+    if (((::dsn::message_ex*)msg)->header == nullptr)
+    {
+        derror("dsn_msg_body_size got message with null header");
+        return 0;
+    }
+
     return ((::dsn::message_ex*)msg)->body_size();
 }
 
 DSN_API void* dsn_msg_rw_ptr(dsn_message_t msg, size_t offset_begin)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_rw_ptr got null message");
+        return nullptr;
+    }
+
     return ((::dsn::message_ex*)msg)->rw_ptr(offset_begin);
 }
 
 DSN_API void dsn_msg_add_ref(dsn_message_t msg)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_add_ref got null message");
+        return;
+    }
+
     ((::dsn::message_ex*)msg)->add_ref();
 }
 
 DSN_API void dsn_msg_release_ref(dsn_message_t msg)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_release_ref got null message");
+        return;
+    }
+
     ((::dsn::message_ex*)msg)->release_ref();
 }
 
 DSN_API dsn_address_t dsn_msg_from_address(dsn_message_t msg)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_from_address got null message");
+        return ::dsn::rpc_address().c_addr();
+    }
+
+    if (((::dsn::message_ex*)msg)->header == nullptr)
+    {
+        derror("dsn_msg_from_address got message with null header");
+        return ::dsn::rpc_address().c_addr();
+    }
+
     return ((::dsn::message_ex*)msg)->header->from_address.c_addr();
 }
 
 DSN_API dsn_address_t dsn_msg_to_address(dsn_message_t msg)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_to_address got null message");
+        return ::dsn::rpc_address().c_addr();
+    }
+
     return ((::dsn::message_ex*)msg)->to_address.c_addr();
 }
 
 DSN_API uint64_t dsn_msg_trace_id(dsn_message_t msg)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_trace_id got null message");
+        return 0;
+    }
+
+    if (((::dsn::message_ex*)msg)->header == nullptr)
+    {
+        derror("dsn_msg_trace_id got message with null header");
+        return 0;
+    }
+
     return ((::dsn::message_ex*)msg)->header->trace_id;
 }
 
 DSN_API dsn_task_code_t dsn_msg_task_code(dsn_message_t msg)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_task_code got null message");
+        return ::dsn::TASK_CODE_INVALID;
+    }
+
+    if (((::dsn::message_ex*)msg)->header == nullptr)
+    {
+        derror("dsn_msg_task_code got message with null header");
+        return ::dsn::TASK_CODE_INVALID;
+    }
+
     return ((::dsn::message_ex*)msg)->rpc_code();
 }
 
@@ -155,7 +327,24 @@ DSN_API void dsn_msg_set_options(
     uint32_t mask // set opt bits using DSN_MSGM_XXX
     )
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_set_options got null message");
+        return;
+    }
+
+    if (opts == nullptr)
+    {
+        derror("dsn_msg_set_options got null opts");
+        return;
+    }
+
     auto hdr = ((::dsn::message_ex*)msg)->header;
+    if (hdr == nullptr)
+    {
+        derror("dsn_msg_set_options got message with null header");
+        return;
+    }
 
     if (mask & DSN_MSGM_TIMEOUT)
     {
@@ -185,13 +374,37 @@ DSN_API void dsn_msg_set_options(
 
 DSN_API dsn_msg_serialize_format dsn_msg_get_serialize_format(dsn_message_t msg)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_get_serialize_format got null message");
+        return DSF_INVALID;
+    }
+
     auto hdr = ((::dsn::message_ex*)msg)->header;
+    if (hdr == nullptr)
+    {
+        derror("dsn_msg_get_serialize_format got message with null header");
+        return DSF_INVALID;
+    }
+
     return static_cast<dsn_msg_serialize_format>(hdr->context.u.serialize_format);
 }
 
 DSN_API void dsn_msg_set_serailize_format(dsn_message_t msg, dsn_msg_serialize_format fmt)
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_set_serailize_format got null message");
+        return;
+    }
+
     auto hdr = ((::dsn::message_ex*)msg)->header;
+    if (hdr == nullptr)
+    {
+        derror("dsn_msg_set_serailize_format got message with null header");
+        return;
+    }
+
     hdr->context.u.serialize_format = fmt;
 }
 
@@ -200,7 +413,25 @@ DSN_API void dsn_msg_get_options(
     /*out*/ dsn_msg_options_t* opts
     )
 {
+    if (msg == nullptr)
+    {
+        derror("dsn_msg_get_options got null message");
+        return;
+    }
+
+    if (opts == nullptr)
+    {
+        derror("dsn_msg_get_options got null opts");
+        return;
+    }
+
     auto hdr = ((::dsn::message_ex*)msg)->header;
+    if (hdr == nullptr)
+    {
+        derror("dsn_msg_get_options got message with null header");
+        return;
+    }
+
     opts->timeout_ms = hdr->client.timeout_ms;
     opts->thread_hash = hdr->client.thread_hash;
     opts->partition_hash = hdr->client.partition_hash;
@@ -390,6 +621,13 @@ message_ex* message_ex::copy_and_prepare_send(bool clone_content)
 
 message_ex* message_ex::create_request(dsn_task_code_t rpc_code, int timeout_milliseconds, int thread_hash, uint64_t partition_hash)
 {
+    task_spec* sp = task_spec::get(rpc_code);
+    if (sp == nullptr)
+    {
+        derror("message_ex::create_request got invalid rpc_code = %d", rpc_code);
+        return nullptr;
+    }
+
     message_ex* msg = new message_ex();
     msg->_is_read = false;
     msg->prepare_buffer_header();
@@ -406,7 +644,6 @@ message_ex* message_ex::create_request(dsn_task_code_t rpc_code, int timeout_mil
     hdr.client.thread_hash = thread_hash;
     hdr.client.partition_hash = partition_hash;
 
-    task_spec* sp = task_spec::get(rpc_code);
     if (0 == timeout_milliseconds)
     {
         hdr.client.timeout_ms = sp->rpc_timeout_milliseconds;

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -49,6 +49,15 @@ using namespace dsn::utils;
 # endif
 # define __TITLE__ "rpc.message"
 
+namespace {
+
+static inline bool is_valid_serialize_format(dsn_msg_serialize_format fmt)
+{
+    return fmt >= DSF_THRIFT_BINARY && fmt <= DSF_JSON;
+}
+
+} // anonymous namespace
+
 DSN_API dsn_message_t dsn_msg_create_request(
     dsn_task_code_t rpc_code, 
     int timeout_milliseconds,
@@ -83,6 +92,13 @@ DSN_API dsn_message_t dsn_msg_create_received_request(
     if (buffer == nullptr && size > 0)
     {
         derror("dsn_msg_create_received_request got null buffer with size = %d", size);
+        return nullptr;
+    }
+
+    if (!is_valid_serialize_format(serialization_type))
+    {
+        derror("dsn_msg_create_received_request got invalid serialization_type = %d",
+               serialization_type);
         return nullptr;
     }
 
@@ -408,6 +424,12 @@ DSN_API void dsn_msg_set_serailize_format(dsn_message_t msg, dsn_msg_serialize_f
     if (hdr == nullptr)
     {
         derror("dsn_msg_set_serailize_format got message with null header");
+        return;
+    }
+
+    if (!is_valid_serialize_format(fmt))
+    {
+        derror("dsn_msg_set_serailize_format got invalid fmt = %d", fmt);
         return;
     }
 

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -65,6 +65,13 @@ DSN_API dsn_message_t dsn_msg_create_request(
     uint64_t partition_hash
     )
 {
+    const auto spec = ::dsn::task_spec::get(rpc_code);
+    if (rpc_code == ::dsn::TASK_CODE_INVALID || spec == nullptr || spec->type != TASK_TYPE_RPC_REQUEST)
+    {
+        derror("dsn_msg_create_request got invalid rpc_code = %d", rpc_code);
+        return nullptr;
+    }
+
     return ::dsn::message_ex::create_request(rpc_code, timeout_milliseconds, thread_hash, partition_hash);
 }
 

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -77,7 +77,8 @@ DSN_API dsn_message_t dsn_msg_create_received_request(
     uint64_t partition_hash
     )
 {
-    if (::dsn::task_spec::get(rpc_code) == nullptr)
+    const auto spec = ::dsn::task_spec::get(rpc_code);
+    if (spec == nullptr || spec->type != TASK_TYPE_RPC_REQUEST)
     {
         derror("dsn_msg_create_received_request got invalid rpc_code = %d", rpc_code);
         return nullptr;

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -348,6 +348,12 @@ DSN_API void dsn_msg_set_options(
 
     if (mask & DSN_MSGM_TIMEOUT)
     {
+        if (opts->timeout_ms < 0)
+        {
+            derror("dsn_msg_set_options got invalid timeout_ms = %d", opts->timeout_ms);
+            return;
+        }
+
         hdr->client.timeout_ms = opts->timeout_ms;
     }
     
@@ -625,6 +631,13 @@ message_ex* message_ex::create_request(dsn_task_code_t rpc_code, int timeout_mil
     if (sp == nullptr)
     {
         derror("message_ex::create_request got invalid rpc_code = %d", rpc_code);
+        return nullptr;
+    }
+
+    if (timeout_milliseconds < 0)
+    {
+        derror("message_ex::create_request got invalid timeout_milliseconds = %d",
+               timeout_milliseconds);
         return nullptr;
     }
 

--- a/src/core/src/rpc_message.test.cpp
+++ b/src/core/src/rpc_message.test.cpp
@@ -251,6 +251,54 @@ TEST(core, dsn_msg_invalid_parameters)
     dsn_msg_options_t opts;
     opts.timeout_ms = 1;
 
+    char buffer[] = "message";
+    ASSERT_EQ(nullptr,
+              dsn_msg_create_received_request(TASK_CODE_INVALID,
+                                              DSF_THRIFT_BINARY,
+                                              buffer,
+                                              static_cast<int>(sizeof(buffer)),
+                                              0,
+                                              0));
+    ASSERT_EQ(nullptr,
+              dsn_msg_create_received_request(RPC_CODE_FOR_TEST,
+                                              DSF_THRIFT_BINARY,
+                                              buffer,
+                                              -1,
+                                              0,
+                                              0));
+    ASSERT_EQ(nullptr,
+              dsn_msg_create_received_request(RPC_CODE_FOR_TEST,
+                                              DSF_THRIFT_BINARY,
+                                              nullptr,
+                                              1,
+                                              0,
+                                              0));
+    ASSERT_EQ(nullptr,
+              dsn_msg_create_received_request(RPC_CODE_FOR_TEST,
+                                              DSF_INVALID,
+                                              nullptr,
+                                              0,
+                                              0,
+                                              0));
+    ASSERT_EQ(nullptr,
+              dsn_msg_create_received_request(
+                  RPC_CODE_FOR_TEST,
+                  static_cast<dsn_msg_serialize_format>(DSF_JSON + 1),
+                  nullptr,
+                  0,
+                  0,
+                  0));
+
+    ASSERT_EQ(nullptr, dsn_msg_copy(nullptr, true, false));
+    ASSERT_EQ(nullptr, dsn_msg_create_response(nullptr));
+    ASSERT_EQ(0u, dsn_msg_body_size(nullptr));
+    ASSERT_EQ(nullptr, dsn_msg_rw_ptr(nullptr, 0));
+    ASSERT_EQ(0u, dsn_msg_from_address(nullptr).u.value);
+    ASSERT_EQ(0u, dsn_msg_to_address(nullptr).u.value);
+    ASSERT_EQ(0u, dsn_msg_trace_id(nullptr));
+    ASSERT_EQ(TASK_CODE_INVALID, dsn_msg_task_code(nullptr));
+    ASSERT_EQ(DSF_INVALID, dsn_msg_get_serialize_format(nullptr));
+
     ASSERT_FALSE(dsn_msg_set_options(nullptr, &opts, DSN_MSGM_TIMEOUT));
     ASSERT_FALSE(dsn_msg_set_options(nullptr, nullptr, DSN_MSGM_TIMEOUT));
     ASSERT_FALSE(dsn_msg_get_options(nullptr, &opts));

--- a/src/core/src/rpc_message.test.cpp
+++ b/src/core/src/rpc_message.test.cpp
@@ -185,7 +185,7 @@ TEST(core, message_ex)
         opts.context.context = 444;
         opts.gpid.value = 333;
 
-        dsn_msg_set_options(request, &opts, DSN_MSGM_CONTEXT | DSN_MSGM_VNID);
+        ASSERT_TRUE(dsn_msg_set_options(request, &opts, DSN_MSGM_CONTEXT | DSN_MSGM_VNID));
         message_ex* m = (message_ex*)request;
         m->header->from_address = rpc_address("127.0.0.1", 8080);
         m->to_address = rpc_address("127.0.0.1", 9090);
@@ -206,9 +206,9 @@ TEST(core, message_ex)
         void* ptr;
         size_t sz;
 
-        dsn_msg_write_next(request, &ptr, &sz, data_size);
+        ASSERT_TRUE(dsn_msg_write_next(request, &ptr, &sz, data_size));
         memcpy(ptr, data, data_size);
-        dsn_msg_write_commit(request, data_size);
+        ASSERT_TRUE(dsn_msg_write_commit(request, data_size));
 
         ASSERT_EQ(data_size, dsn_msg_body_size(request));
 
@@ -228,7 +228,7 @@ TEST(core, message_ex)
 
         ASSERT_EQ(data_size, dsn_msg_body_size(receive));
 
-        dsn_msg_read_next(receive, &ptr, &sz);
+        ASSERT_TRUE(dsn_msg_read_next(receive, &ptr, &sz));
         ASSERT_EQ(data_size, sz);
         ASSERT_EQ(std::string(data), std::string((const char*)ptr, sz));
         dsn_msg_read_commit(receive, sz);
@@ -243,4 +243,3 @@ TEST(core, message_ex)
         dsn_msg_release_ref(request);
     }
 }
-

--- a/src/core/src/rpc_message.test.cpp
+++ b/src/core/src/rpc_message.test.cpp
@@ -243,3 +243,51 @@ TEST(core, message_ex)
         dsn_msg_release_ref(request);
     }
 }
+
+TEST(core, dsn_msg_invalid_parameters)
+{
+    void* ptr = reinterpret_cast<void*>(1);
+    size_t size = 1;
+    dsn_msg_options_t opts;
+    opts.timeout_ms = 1;
+
+    ASSERT_FALSE(dsn_msg_set_options(nullptr, &opts, DSN_MSGM_TIMEOUT));
+    ASSERT_FALSE(dsn_msg_set_options(nullptr, nullptr, DSN_MSGM_TIMEOUT));
+    ASSERT_FALSE(dsn_msg_get_options(nullptr, &opts));
+    ASSERT_FALSE(dsn_msg_get_options(nullptr, nullptr));
+    ASSERT_FALSE(dsn_msg_set_serailize_format(nullptr, DSF_THRIFT_BINARY));
+
+    ASSERT_FALSE(dsn_msg_write_next(nullptr, &ptr, &size, 1));
+    ASSERT_EQ(nullptr, ptr);
+    ASSERT_EQ(0u, size);
+    ASSERT_FALSE(dsn_msg_write_next(nullptr, nullptr, &size, 1));
+    ASSERT_FALSE(dsn_msg_write_next(nullptr, &ptr, nullptr, 1));
+    ASSERT_FALSE(dsn_msg_write_commit(nullptr, 0));
+
+    ptr = reinterpret_cast<void*>(1);
+    size = 1;
+    ASSERT_FALSE(dsn_msg_read_next(nullptr, &ptr, &size));
+    ASSERT_EQ(nullptr, ptr);
+    ASSERT_EQ(0u, size);
+    ASSERT_FALSE(dsn_msg_read_next(nullptr, nullptr, &size));
+    ASSERT_FALSE(dsn_msg_read_next(nullptr, &ptr, nullptr));
+    ASSERT_FALSE(dsn_msg_read_commit(nullptr, 0));
+
+    dsn_message_t request = dsn_msg_create_request(RPC_CODE_FOR_TEST, 100, 1, 2);
+    ASSERT_NE(nullptr, request);
+    dsn_msg_add_ref(request);
+
+    ASSERT_FALSE(dsn_msg_set_options(request, nullptr, DSN_MSGM_TIMEOUT));
+    opts.timeout_ms = -1;
+    ASSERT_FALSE(dsn_msg_set_options(request, &opts, DSN_MSGM_TIMEOUT));
+    ASSERT_FALSE(dsn_msg_get_options(request, nullptr));
+    ASSERT_FALSE(dsn_msg_set_serailize_format(request, DSF_INVALID));
+    ASSERT_FALSE(dsn_msg_set_serailize_format(
+        request, static_cast<dsn_msg_serialize_format>(DSF_JSON + 1)));
+    ASSERT_FALSE(dsn_msg_write_next(request, nullptr, &size, 1));
+    ASSERT_FALSE(dsn_msg_write_next(request, &ptr, nullptr, 1));
+    ASSERT_FALSE(dsn_msg_read_next(request, nullptr, &size));
+    ASSERT_FALSE(dsn_msg_read_next(request, &ptr, nullptr));
+
+    dsn_msg_release_ref(request);
+}

--- a/src/core/src/rpc_message.test.cpp
+++ b/src/core/src/rpc_message.test.cpp
@@ -33,6 +33,8 @@
  *     xxxx-xx-xx, author, fix bug about xxx
  */
 
+# include <dsn/cpp/rpc_stream.h>
+# include <dsn/cpp/serialization.h>
 # include <dsn/tool-api/rpc_message.h>
 # include <gtest/gtest.h>
 # include "transient_memory.h"
@@ -252,6 +254,8 @@ TEST(core, dsn_msg_invalid_parameters)
     opts.timeout_ms = 1;
 
     char buffer[] = "message";
+    ASSERT_EQ(nullptr, dsn_msg_create_request(TASK_CODE_INVALID, 0, 0, 0));
+    ASSERT_EQ(nullptr, dsn_msg_create_request(RPC_CODE_FOR_TEST, -1, 0, 0));
     ASSERT_EQ(nullptr,
               dsn_msg_create_received_request(TASK_CODE_INVALID,
                                               DSF_THRIFT_BINARY,

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -134,12 +134,31 @@ DSN_API volatile int* dsn_task_queue_virtual_length_ptr(
     int hash
     )
 {
-    return dsn::task::get_current_node()->computation()->get_task_queue_virtual_length_ptr(code, hash);
+    if (code < 0)
+    {
+        derror("dsn_task_queue_virtual_length_ptr got invalid code = %d", code);
+        return nullptr;
+    }
+
+    auto node = dsn::task::get_current_node();
+    if (node == nullptr)
+    {
+        derror("dsn_task_queue_virtual_length_ptr got null current node");
+        return nullptr;
+    }
+
+    return node->computation()->get_task_queue_virtual_length_ptr(code, hash);
 }
 
 // use ::dsn::threadpool_code2; for parsing purpose
 DSN_API dsn_threadpool_code_t dsn_threadpool_code_register(const char* name)
 {
+    if (name == nullptr || name[0] == '\0')
+    {
+        derror("dsn_threadpool_code_register got null or empty name");
+        return (dsn_threadpool_code_t)::dsn::THREAD_POOL_INVALID;
+    }
+
     return static_cast<dsn_threadpool_code_t>(
         ::dsn::utils::customized_id_mgr< ::dsn::threadpool_code2_>::instance().register_id(name)
         );
@@ -152,6 +171,12 @@ DSN_API const char* dsn_threadpool_code_to_string(dsn_threadpool_code_t pool_cod
 
 DSN_API dsn_threadpool_code_t dsn_threadpool_code_from_string(const char* s, dsn_threadpool_code_t default_code)
 {
+    if (s == nullptr || s[0] == '\0')
+    {
+        derror("dsn_threadpool_code_from_string got null or empty string");
+        return static_cast<dsn_threadpool_code_t>(::dsn::THREAD_POOL_INVALID);
+    }
+
     auto r = ::dsn::utils::customized_id_mgr< ::dsn::threadpool_code2_>::instance().get_id(s);
     return r == -1 ? default_code : r;
 }
@@ -174,11 +199,38 @@ DSN_API dsn_task_code_t dsn_task_code_register(
     dsn_threadpool_code_t pool
     )
 {
-    dassert(strlen(name) < DSN_MAX_TASK_CODE_NAME_LENGTH, 
-        "task code '%s' is too long - length must be smaller than %d",
-        name,
-        DSN_MAX_TASK_CODE_NAME_LENGTH
-        );
+    if (name == nullptr || name[0] == '\0')
+    {
+        derror("dsn_task_code_register got null or empty name");
+        return static_cast<dsn_task_code_t>(::dsn::TASK_CODE_INVALID);
+    }
+
+    if (strlen(name) >= DSN_MAX_TASK_CODE_NAME_LENGTH)
+    {
+        derror("dsn_task_code_register got too long name '%s' - length must be smaller than %d",
+               name,
+               DSN_MAX_TASK_CODE_NAME_LENGTH);
+        return static_cast<dsn_task_code_t>(::dsn::TASK_CODE_INVALID);
+    }
+
+    if (type < TASK_TYPE_RPC_REQUEST || type >= TASK_TYPE_COUNT)
+    {
+        derror("dsn_task_code_register got invalid type = %d", type);
+        return static_cast<dsn_task_code_t>(::dsn::TASK_CODE_INVALID);
+    }
+
+    if (pri < TASK_PRIORITY_LOW || pri >= TASK_PRIORITY_COUNT)
+    {
+        derror("dsn_task_code_register got invalid priority = %d", pri);
+        return static_cast<dsn_task_code_t>(::dsn::TASK_CODE_INVALID);
+    }
+
+    if (pool < 0)
+    {
+        derror("dsn_task_code_register got invalid pool = %d", pool);
+        return static_cast<dsn_task_code_t>(::dsn::TASK_CODE_INVALID);
+    }
+
     auto r = static_cast<dsn_task_code_t>(::dsn::utils::customized_id_mgr<task_code_placeholder>::instance().register_id(name));
     ::dsn::task_spec::register_task_code(r, type, pri, pool);
     return r;
@@ -187,7 +239,12 @@ DSN_API dsn_task_code_t dsn_task_code_register(
 DSN_API void dsn_task_code_query(dsn_task_code_t code, dsn_task_type_t *ptype, dsn_task_priority_t *ppri, dsn_threadpool_code_t *ppool)
 {
     auto sp = ::dsn::task_spec::get(code);
-    dassert(sp != nullptr, "");
+    if (sp == nullptr)
+    {
+        derror("dsn_task_code_query got invalid code = %d", code);
+        return;
+    }
+
     if (ptype) *ptype = sp->type;
     if (ppri) *ppri = sp->priority;
     if (ppool) *ppool = sp->pool_code;
@@ -196,24 +253,58 @@ DSN_API void dsn_task_code_query(dsn_task_code_t code, dsn_task_type_t *ptype, d
 DSN_API void dsn_task_code_set_threadpool(dsn_task_code_t code, dsn_threadpool_code_t pool)
 {
     auto sp = ::dsn::task_spec::get(code);
-    dassert(sp != nullptr, "");
+    if (sp == nullptr)
+    {
+        derror("dsn_task_code_set_threadpool got invalid code = %d", code);
+        return;
+    }
+
+    if (pool < 0)
+    {
+        derror("dsn_task_code_set_threadpool got invalid pool = %d", pool);
+        return;
+    }
+
     sp->pool_code = pool;
 }
 
 DSN_API void dsn_task_code_set_priority(dsn_task_code_t code, dsn_task_priority_t pri)
 {
     auto sp = ::dsn::task_spec::get(code);
-    dassert(sp != nullptr, "");
+    if (sp == nullptr)
+    {
+        derror("dsn_task_code_set_priority got invalid code = %d", code);
+        return;
+    }
+
+    if (pri < TASK_PRIORITY_LOW || pri >= TASK_PRIORITY_COUNT)
+    {
+        derror("dsn_task_code_set_priority got invalid priority = %d", pri);
+        return;
+    }
+
     sp->priority = pri;
 }
 
 DSN_API const char* dsn_task_code_to_string(dsn_task_code_t code)
 {
+    if (code < 0)
+    {
+        derror("dsn_task_code_to_string got invalid code = %d", code);
+        return "unknown";
+    }
+
     return ::dsn::utils::customized_id_mgr<task_code_placeholder>::instance().get_name(static_cast<int>(code));
 }
 
 DSN_API dsn_task_code_t dsn_task_code_from_string(const char* s, dsn_task_code_t default_code)
 {
+    if (s == nullptr || s[0] == '\0')
+    {
+        derror("dsn_task_code_from_string got null or empty string");
+        return static_cast<dsn_task_code_t>(::dsn::TASK_CODE_INVALID);
+    }
+
     auto r = ::dsn::utils::customized_id_mgr<task_code_placeholder>::instance().get_id(s);
     return r == -1 ? default_code : r;
 }
@@ -225,11 +316,23 @@ DSN_API int dsn_task_code_max()
 
 DSN_API const char* dsn_task_type_to_string(dsn_task_type_t tt)
 {
+    if (tt < TASK_TYPE_RPC_REQUEST || tt >= TASK_TYPE_COUNT)
+    {
+        derror("dsn_task_type_to_string got invalid task type = %d", tt);
+        return "Unknown";
+    }
+
     return enum_to_string(tt);
 }
 
 DSN_API const char* dsn_task_priority_to_string(dsn_task_priority_t tt)
 {
+    if (tt < TASK_PRIORITY_LOW || tt >= TASK_PRIORITY_COUNT)
+    {
+        derror("dsn_task_priority_to_string got invalid task priority = %d", tt);
+        return "Unknown";
+    }
+
     return enum_to_string(tt);
 }
 
@@ -293,7 +396,21 @@ DSN_API uint64_t dsn_crc64_concatenate(uint32_t xy_init, uint64_t x_init, uint64
 
 DSN_API dsn_task_t dsn_task_create(dsn_task_code_t code, dsn_task_handler_t cb, void* context, int hash, dsn_task_tracker_t tracker)
 {
-    auto t = new ::dsn::task_c(code, cb, context, nullptr, hash);
+    auto sp = ::dsn::task_spec::get(code);
+    if (sp == nullptr)
+    {
+        derror("dsn_task_create got invalid code = %d", code);
+        return nullptr;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_task_create got null callback");
+        return nullptr;
+    }
+
+    auto node = ::dsn::task::get_current_node();
+    auto t = new ::dsn::task_c(code, cb, context, nullptr, hash, node);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
     return t;
@@ -302,6 +419,25 @@ DSN_API dsn_task_t dsn_task_create(dsn_task_code_t code, dsn_task_handler_t cb, 
 DSN_API dsn_task_t dsn_task_create_timer(dsn_task_code_t code, dsn_task_handler_t cb, 
     void* context, int hash, int interval_milliseconds, dsn_task_tracker_t tracker)
 {
+    auto sp = ::dsn::task_spec::get(code);
+    if (sp == nullptr)
+    {
+        derror("dsn_task_create_timer got invalid code = %d", code);
+        return nullptr;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_task_create_timer got null callback");
+        return nullptr;
+    }
+
+    if (interval_milliseconds < 0)
+    {
+        derror("dsn_task_create_timer got invalid interval_milliseconds = %d", interval_milliseconds);
+        return nullptr;
+    }
+
     auto t = new ::dsn::timer_task(code, cb, context, nullptr, interval_milliseconds, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -311,6 +447,19 @@ DSN_API dsn_task_t dsn_task_create_timer(dsn_task_code_t code, dsn_task_handler_
 DSN_API dsn_task_t dsn_task_create_ex(dsn_task_code_t code, dsn_task_handler_t cb, 
     dsn_task_cancelled_handler_t on_cancel, void* context, int hash, dsn_task_tracker_t tracker)
 {
+    auto sp = ::dsn::task_spec::get(code);
+    if (sp == nullptr)
+    {
+        derror("dsn_task_create_ex got invalid code = %d", code);
+        return nullptr;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_task_create_ex got null callback");
+        return nullptr;
+    }
+
     auto t = new ::dsn::task_c(code, cb, context, on_cancel, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -321,6 +470,26 @@ DSN_API dsn_task_t dsn_task_create_timer_ex(dsn_task_code_t code, dsn_task_handl
     dsn_task_cancelled_handler_t on_cancel, 
     void* context, int hash, int interval_milliseconds, dsn_task_tracker_t tracker)
 {
+    auto sp = ::dsn::task_spec::get(code);
+    if (sp == nullptr)
+    {
+        derror("dsn_task_create_timer_ex got invalid code = %d", code);
+        return nullptr;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_task_create_timer_ex got null callback");
+        return nullptr;
+    }
+
+    if (interval_milliseconds < 0)
+    {
+        derror("dsn_task_create_timer_ex got invalid interval_milliseconds = %d",
+               interval_milliseconds);
+        return nullptr;
+    }
+
     auto t = new ::dsn::timer_task(code, cb, context, on_cancel, interval_milliseconds, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -768,7 +937,14 @@ DSN_API bool dsn_semaphore_wait_timeout(dsn_handle_t s, int timeout_milliseconds
 // rpc calls
 DSN_API dsn_address_t dsn_primary_address()
 {
-    return ::dsn::task::get_current_rpc()->primary_address().c_addr();
+    auto rpc = ::dsn::task::get_current_rpc();
+    if (rpc == nullptr)
+    {
+        derror("dsn_primary_address got null current rpc engine");
+        return ::dsn::rpc_address().c_addr();
+    }
+
+    return rpc->primary_address().c_addr();
 }
 
 DSN_API bool dsn_rpc_register_handler(
@@ -779,6 +955,25 @@ DSN_API bool dsn_rpc_register_handler(
     dsn_gpid gpid
     )
 {
+    auto sp = ::dsn::task_spec::get(code);
+    if (sp == nullptr)
+    {
+        derror("dsn_rpc_register_handler got invalid code = %d", code);
+        return false;
+    }
+
+    if (name == nullptr || name[0] == '\0')
+    {
+        derror("dsn_rpc_register_handler got null or empty name");
+        return false;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_rpc_register_handler got null callback");
+        return false;
+    }
+
     ::dsn::rpc_handler_info* h(new ::dsn::rpc_handler_info(code));
     h->name = name;
     h->c_handler = cb;
@@ -796,6 +991,13 @@ DSN_API bool dsn_rpc_register_handler(
 
 DSN_API void* dsn_rpc_unregiser_handler(dsn_task_code_t code, dsn_gpid gpid)
 {
+    auto sp = ::dsn::task_spec::get(code);
+    if (sp == nullptr)
+    {
+        derror("dsn_rpc_unregiser_handler got invalid code = %d", code);
+        return nullptr;
+    }
+
     auto h = ::dsn::task::get_current_node()->rpc_unregister_handler(code, gpid);
     void* param = nullptr;
 
@@ -813,6 +1015,18 @@ DSN_API dsn_task_t dsn_rpc_create_response_task(dsn_message_t request, dsn_rpc_r
     void* context, int reply_thread_hash, dsn_task_tracker_t tracker)
 {
     auto msg = ((::dsn::message_ex*)request);
+    if (msg == nullptr)
+    {
+        derror("dsn_rpc_create_response_task got null request");
+        return nullptr;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_rpc_create_response_task got null callback");
+        return nullptr;
+    }
+
     auto t = new ::dsn::rpc_response_task(msg, cb, context, nullptr, reply_thread_hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -824,6 +1038,18 @@ DSN_API dsn_task_t dsn_rpc_create_response_task_ex(dsn_message_t request, dsn_rp
     void* context, int reply_thread_hash, dsn_task_tracker_t tracker)
 {
     auto msg = ((::dsn::message_ex*)request);
+    if (msg == nullptr)
+    {
+        derror("dsn_rpc_create_response_task_ex got null request");
+        return nullptr;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_rpc_create_response_task_ex got null callback");
+        return nullptr;
+    }
+
     auto t = new ::dsn::rpc_response_task(msg, cb, context, on_cancel, reply_thread_hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -833,22 +1059,69 @@ DSN_API dsn_task_t dsn_rpc_create_response_task_ex(dsn_message_t request, dsn_rp
 DSN_API void dsn_rpc_call(dsn_address_t server, dsn_task_t rpc_call)
 {
     ::dsn::rpc_response_task* task = (::dsn::rpc_response_task*)rpc_call;
-    dassert(task->spec().type == TASK_TYPE_RPC_RESPONSE, "");
+    if (task == nullptr)
+    {
+        derror("dsn_rpc_call got null rpc_call");
+        return;
+    }
+
+    if (task->spec().type != TASK_TYPE_RPC_RESPONSE)
+    {
+        derror("dsn_rpc_call got non-rpc-response task");
+        return;
+    }
+
+    if (::dsn::rpc_address(server).is_invalid())
+    {
+        derror("dsn_rpc_call got invalid server address");
+        return;
+    }
+
+    auto rpc = ::dsn::task::get_current_rpc();
+    if (rpc == nullptr)
+    {
+        derror("dsn_rpc_call got null current rpc engine");
+        return;
+    }
     
     auto msg = task->get_request();
+    if (msg == nullptr)
+    {
+        derror("dsn_rpc_call got null request message");
+        return;
+    }
+
     msg->server_address = server;
-    ::dsn::task::get_current_rpc()->call(msg, task);
+    rpc->call(msg, task);
 }
 
 DSN_API dsn_message_t dsn_rpc_call_wait(dsn_address_t server, dsn_message_t request)
 {
     auto msg = ((::dsn::message_ex*)request);
+    if (msg == nullptr)
+    {
+        derror("dsn_rpc_call_wait got null request");
+        return nullptr;
+    }
+
+    if (::dsn::rpc_address(server).is_invalid())
+    {
+        derror("dsn_rpc_call_wait got invalid server address");
+        return nullptr;
+    }
+
+    auto rpc = ::dsn::task::get_current_rpc();
+    if (rpc == nullptr)
+    {
+        derror("dsn_rpc_call_wait got null current rpc engine");
+        return nullptr;
+    }
+
     msg->server_address = server;
 
-    ::dsn::rpc_response_task* rtask = 
-        new ::dsn::rpc_response_task(msg, nullptr, nullptr, 0);
+    ::dsn::rpc_response_task* rtask = new ::dsn::rpc_response_task(msg, nullptr, nullptr, 0);
     rtask->add_ref();
-    ::dsn::task::get_current_rpc()->call(msg, rtask);
+    rpc->call(msg, rtask);
     rtask->wait();
     if (rtask->error() == ::dsn::ERR_OK)
     {
@@ -867,26 +1140,90 @@ DSN_API dsn_message_t dsn_rpc_call_wait(dsn_address_t server, dsn_message_t requ
 DSN_API void dsn_rpc_call_one_way(dsn_address_t server, dsn_message_t request)
 {
     auto msg = ((::dsn::message_ex*)request);
+    if (msg == nullptr)
+    {
+        derror("dsn_rpc_call_one_way got null request");
+        return;
+    }
+
+    if (::dsn::rpc_address(server).is_invalid())
+    {
+        derror("dsn_rpc_call_one_way got invalid server address");
+        return;
+    }
+
+    auto rpc = ::dsn::task::get_current_rpc();
+    if (rpc == nullptr)
+    {
+        derror("dsn_rpc_call_one_way got null current rpc engine");
+        return;
+    }
+
     msg->server_address = server;
 
-    ::dsn::task::get_current_rpc()->call(msg, nullptr);
+    rpc->call(msg, nullptr);
 }
 
 DSN_API void dsn_rpc_reply(dsn_message_t response, dsn_error_t err)
 {
     auto msg = ((::dsn::message_ex*)response);
-    ::dsn::task::get_current_rpc()->reply(msg, err);
+    if (msg == nullptr)
+    {
+        derror("dsn_rpc_reply got null response");
+        return;
+    }
+
+    auto rpc = ::dsn::task::get_current_rpc();
+    if (rpc == nullptr)
+    {
+        derror("dsn_rpc_reply got null current rpc engine");
+        return;
+    }
+
+    rpc->reply(msg, err);
 }
 
 DSN_API void dsn_rpc_forward(dsn_message_t request, dsn_address_t addr)
 {
-    ::dsn::task::get_current_rpc()->forward((::dsn::message_ex*)(request), ::dsn::rpc_address(addr));
+    auto msg = (::dsn::message_ex*)(request);
+    if (msg == nullptr)
+    {
+        derror("dsn_rpc_forward got null request");
+        return;
+    }
+
+    auto target = ::dsn::rpc_address(addr);
+    if (target.is_invalid())
+    {
+        derror("dsn_rpc_forward got invalid target address");
+        return;
+    }
+
+    auto rpc = ::dsn::task::get_current_rpc();
+    if (rpc == nullptr)
+    {
+        derror("dsn_rpc_forward got null current rpc engine");
+        return;
+    }
+
+    rpc->forward(msg, target);
 }
 
 DSN_API dsn_message_t dsn_rpc_get_response(dsn_task_t rpc_call)
 {
     ::dsn::rpc_response_task* task = (::dsn::rpc_response_task*)rpc_call;
-    dassert(task->spec().type == TASK_TYPE_RPC_RESPONSE, "");
+    if (task == nullptr)
+    {
+        derror("dsn_rpc_get_response got null rpc_call");
+        return nullptr;
+    }
+
+    if (task->spec().type != TASK_TYPE_RPC_RESPONSE)
+    {
+        derror("dsn_rpc_get_response got non-rpc-response task");
+        return nullptr;
+    }
+
     auto msg = task->get_response();
     if (nullptr != msg)
     {
@@ -900,7 +1237,17 @@ DSN_API dsn_message_t dsn_rpc_get_response(dsn_task_t rpc_call)
 DSN_API void dsn_rpc_enqueue_response(dsn_task_t rpc_call, dsn_error_t err, dsn_message_t response)
 {
     ::dsn::rpc_response_task* task = (::dsn::rpc_response_task*)rpc_call;
-    dassert(task->spec().type == TASK_TYPE_RPC_RESPONSE, "");
+    if (task == nullptr)
+    {
+        derror("dsn_rpc_enqueue_response got null rpc_call");
+        return;
+    }
+
+    if (task->spec().type != TASK_TYPE_RPC_RESPONSE)
+    {
+        derror("dsn_rpc_enqueue_response got non-rpc-response task");
+        return;
+    }
 
     auto resp = ((::dsn::message_ex*)response);
     task->enqueue(err, resp);
@@ -914,28 +1261,86 @@ DSN_API void dsn_rpc_enqueue_response(dsn_task_t rpc_call, dsn_error_t err, dsn_
 
 DSN_API dsn_handle_t dsn_file_open(const char* file_name, int flag, int pmode)
 {
-    return ::dsn::task::get_current_disk()->open(file_name, flag, pmode);
+    if (file_name == nullptr || file_name[0] == '\0')
+    {
+        derror("dsn_file_open got null or empty file_name");
+        return nullptr;
+    }
+
+    auto disk = ::dsn::task::get_current_disk();
+    if (disk == nullptr)
+    {
+        derror("dsn_file_open got null current disk engine");
+        return nullptr;
+    }
+
+    return disk->open(file_name, flag, pmode);
 }
 
 DSN_API dsn_error_t dsn_file_close(dsn_handle_t file)
 {
-    return ::dsn::task::get_current_disk()->close(file);
+    if (file == nullptr)
+    {
+        derror("dsn_file_close got null file handle");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    auto disk = ::dsn::task::get_current_disk();
+    if (disk == nullptr)
+    {
+        derror("dsn_file_close got null current disk engine");
+        return ::dsn::ERR_INVALID_STATE.get();
+    }
+
+    return disk->close(file);
 }
 
 DSN_API dsn_error_t dsn_file_flush(dsn_handle_t file)
 {
-    return ::dsn::task::get_current_disk()->flush(file);
+    if (file == nullptr)
+    {
+        derror("dsn_file_flush got null file handle");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    auto disk = ::dsn::task::get_current_disk();
+    if (disk == nullptr)
+    {
+        derror("dsn_file_flush got null current disk engine");
+        return ::dsn::ERR_INVALID_STATE.get();
+    }
+
+    return disk->flush(file);
 }
 
 // native HANDLE: HANDLE for windows, int for non-windows
 DSN_API void* dsn_file_native_handle(dsn_handle_t file)
 {
+    if (file == nullptr)
+    {
+        derror("dsn_file_native_handle got null file handle");
+        return nullptr;
+    }
+
     auto dfile = (::dsn::disk_file*)file;
     return dfile->native_handle();
 }
 
 DSN_API dsn_task_t dsn_file_create_aio_task(dsn_task_code_t code, dsn_aio_handler_t cb, void* context, int hash, dsn_task_tracker_t tracker)
 {
+    auto sp = ::dsn::task_spec::get(code);
+    if (sp == nullptr)
+    {
+        derror("dsn_file_create_aio_task got invalid code = %d", code);
+        return nullptr;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_file_create_aio_task got null callback");
+        return nullptr;
+    }
+
     auto t = new ::dsn::aio_task(code, cb, context, nullptr, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -946,6 +1351,19 @@ DSN_API dsn_task_t dsn_file_create_aio_task_ex(dsn_task_code_t code, dsn_aio_han
     dsn_task_cancelled_handler_t on_cancel,
     void* context, int hash, dsn_task_tracker_t tracker)
 {
+    auto sp = ::dsn::task_spec::get(code);
+    if (sp == nullptr)
+    {
+        derror("dsn_file_create_aio_task_ex got invalid code = %d", code);
+        return nullptr;
+    }
+
+    if (cb == nullptr)
+    {
+        derror("dsn_file_create_aio_task_ex got null callback");
+        return nullptr;
+    }
+
     auto t = new ::dsn::aio_task(code, cb, context, on_cancel, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -954,7 +1372,38 @@ DSN_API dsn_task_t dsn_file_create_aio_task_ex(dsn_task_code_t code, dsn_aio_han
 
 DSN_API void dsn_file_read(dsn_handle_t file, char* buffer, int count, uint64_t offset, dsn_task_t cb)
 {
-    ::dsn::aio_task* callback((::dsn::aio_task*)cb);    
+    if (file == nullptr)
+    {
+        derror("dsn_file_read got null file handle");
+        return;
+    }
+
+    if (buffer == nullptr)
+    {
+        derror("dsn_file_read got null buffer");
+        return;
+    }
+
+    if (count < 0)
+    {
+        derror("dsn_file_read got invalid count = %d", count);
+        return;
+    }
+
+    ::dsn::aio_task* callback((::dsn::aio_task*)cb);
+    if (callback == nullptr)
+    {
+        derror("dsn_file_read got null callback task");
+        return;
+    }
+
+    auto disk = ::dsn::task::get_current_disk();
+    if (disk == nullptr)
+    {
+        derror("dsn_file_read got null current disk engine");
+        return;
+    }
+
     callback->aio()->buffer = buffer;
     callback->aio()->buffer_size = count;
     callback->aio()->engine = nullptr;
@@ -962,12 +1411,43 @@ DSN_API void dsn_file_read(dsn_handle_t file, char* buffer, int count, uint64_t 
     callback->aio()->file_offset = offset;
     callback->aio()->type = ::dsn::AIO_Read;
 
-    ::dsn::task::get_current_disk()->read(callback);
+    disk->read(callback);
 }
 
 DSN_API void dsn_file_write(dsn_handle_t file, const char* buffer, int count, uint64_t offset, dsn_task_t cb)
 {
+    if (file == nullptr)
+    {
+        derror("dsn_file_write got null file handle");
+        return;
+    }
+
+    if (buffer == nullptr)
+    {
+        derror("dsn_file_write got null buffer");
+        return;
+    }
+
+    if (count < 0)
+    {
+        derror("dsn_file_write got invalid count = %d", count);
+        return;
+    }
+
     ::dsn::aio_task* callback((::dsn::aio_task*)cb);
+    if (callback == nullptr)
+    {
+        derror("dsn_file_write got null callback task");
+        return;
+    }
+
+    auto disk = ::dsn::task::get_current_disk();
+    if (disk == nullptr)
+    {
+        derror("dsn_file_write got null current disk engine");
+        return;
+    }
+
     callback->aio()->buffer = (char*)buffer;
     callback->aio()->buffer_size = count;
     callback->aio()->engine = nullptr;
@@ -975,30 +1455,110 @@ DSN_API void dsn_file_write(dsn_handle_t file, const char* buffer, int count, ui
     callback->aio()->file_offset = offset;
     callback->aio()->type = ::dsn::AIO_Write;
 
-    ::dsn::task::get_current_disk()->write(callback);
+    disk->write(callback);
 }
 
 DSN_API void dsn_file_write_vector(dsn_handle_t file, const dsn_file_buffer_t* buffers, int buffer_count, uint64_t offset, dsn_task_t cb)
 {
+    if (file == nullptr)
+    {
+        derror("dsn_file_write_vector got null file handle");
+        return;
+    }
+
+    if (buffers == nullptr)
+    {
+        derror("dsn_file_write_vector got null buffers");
+        return;
+    }
+
+    if (buffer_count <= 0)
+    {
+        derror("dsn_file_write_vector got invalid buffer_count = %d", buffer_count);
+        return;
+    }
+
     ::dsn::aio_task* callback((::dsn::aio_task*)cb);
+    if (callback == nullptr)
+    {
+        derror("dsn_file_write_vector got null callback task");
+        return;
+    }
+
+    auto disk = ::dsn::task::get_current_disk();
+    if (disk == nullptr)
+    {
+        derror("dsn_file_write_vector got null current disk engine");
+        return;
+    }
+
+    for (int i = 0; i < buffer_count; i++)
+    {
+        if (buffers[i].size < 0)
+        {
+            derror("dsn_file_write_vector got invalid buffer size = %d at index = %d",
+                   buffers[i].size,
+                   i);
+            return;
+        }
+
+        if (buffers[i].buffer == nullptr)
+        {
+            derror("dsn_file_write_vector got null buffer at index = %d", i);
+            return;
+        }
+    }
+
     callback->aio()->buffer = nullptr;
     callback->aio()->buffer_size = 0;
     callback->aio()->engine = nullptr;
     callback->aio()->file = file;
     callback->aio()->file_offset = offset;
     callback->aio()->type = ::dsn::AIO_Write;
-    for (int i = 0; i < buffer_count; i ++)
+    for (int i = 0; i < buffer_count; i++)
     {
         callback->_unmerged_write_buffers.push_back(buffers[i]);
         callback->aio()->buffer_size += buffers[i].size;
     }
 
-    ::dsn::task::get_current_disk()->write(callback);
+    disk->write(callback);
 }
 
 DSN_API void dsn_file_copy_remote_directory(dsn_address_t remote, const char* source_dir, 
     const char* dest_dir, bool overwrite, dsn_task_t cb)
 {
+    if (::dsn::rpc_address(remote).is_invalid())
+    {
+        derror("dsn_file_copy_remote_directory got invalid remote address");
+        return;
+    }
+
+    if (source_dir == nullptr || source_dir[0] == '\0')
+    {
+        derror("dsn_file_copy_remote_directory got null or empty source_dir");
+        return;
+    }
+
+    if (dest_dir == nullptr || dest_dir[0] == '\0')
+    {
+        derror("dsn_file_copy_remote_directory got null or empty dest_dir");
+        return;
+    }
+
+    ::dsn::aio_task* callback((::dsn::aio_task*)cb);
+    if (callback == nullptr)
+    {
+        derror("dsn_file_copy_remote_directory got null callback task");
+        return;
+    }
+
+    auto nfs = ::dsn::task::get_current_nfs();
+    if (nfs == nullptr)
+    {
+        derror("dsn_file_copy_remote_directory got null current nfs node");
+        return;
+    }
+
     std::shared_ptr< ::dsn::remote_copy_request> rci(new ::dsn::remote_copy_request());
     rci->source = remote;
     rci->source_dir = source_dir;
@@ -1006,13 +1566,49 @@ DSN_API void dsn_file_copy_remote_directory(dsn_address_t remote, const char* so
     rci->dest_dir = dest_dir;
     rci->overwrite = overwrite;
 
-    ::dsn::aio_task* callback((::dsn::aio_task*)cb);
-
-    ::dsn::task::get_current_nfs()->call(rci, callback);
+    nfs->call(rci, callback);
 }
 
 DSN_API void dsn_file_copy_remote_files(dsn_address_t remote, const char* source_dir, const char** source_files, const char* dest_dir, bool overwrite, dsn_task_t cb)
 {
+    if (::dsn::rpc_address(remote).is_invalid())
+    {
+        derror("dsn_file_copy_remote_files got invalid remote address");
+        return;
+    }
+
+    if (source_dir == nullptr || source_dir[0] == '\0')
+    {
+        derror("dsn_file_copy_remote_files got null or empty source_dir");
+        return;
+    }
+
+    if (source_files == nullptr)
+    {
+        derror("dsn_file_copy_remote_files got null source_files");
+        return;
+    }
+
+    if (dest_dir == nullptr || dest_dir[0] == '\0')
+    {
+        derror("dsn_file_copy_remote_files got null or empty dest_dir");
+        return;
+    }
+
+    ::dsn::aio_task* callback((::dsn::aio_task*)cb);
+    if (callback == nullptr)
+    {
+        derror("dsn_file_copy_remote_files got null callback task");
+        return;
+    }
+
+    auto nfs = ::dsn::task::get_current_nfs();
+    if (nfs == nullptr)
+    {
+        derror("dsn_file_copy_remote_files got null current nfs node");
+        return;
+    }
+
     std::shared_ptr< ::dsn::remote_copy_request> rci(new ::dsn::remote_copy_request());
     rci->source = remote;
     rci->source_dir = source_dir;
@@ -1033,22 +1629,41 @@ DSN_API void dsn_file_copy_remote_files(dsn_address_t remote, const char* source
     rci->dest_dir = dest_dir;
     rci->overwrite = overwrite;
 
-    ::dsn::aio_task* callback((::dsn::aio_task*)cb);
-
-    ::dsn::task::get_current_nfs()->call(rci, callback);
+    nfs->call(rci, callback);
 }
 
 DSN_API size_t dsn_file_get_io_size(dsn_task_t cb_task)
 {
     ::dsn::task* task = (::dsn::task*)cb_task;
-    dassert(task->spec().type == TASK_TYPE_AIO, "");
+    if (task == nullptr)
+    {
+        derror("dsn_file_get_io_size got null callback task");
+        return static_cast<size_t>(-1);
+    }
+
+    if (task->spec().type != TASK_TYPE_AIO)
+    {
+        derror("dsn_file_get_io_size got non-aio callback task");
+        return static_cast<size_t>(-1);
+    }
+
     return ((::dsn::aio_task*)task)->get_transferred_size();
 }
 
 DSN_API void dsn_file_task_enqueue(dsn_task_t cb_task, dsn_error_t err, size_t size)
 {
     ::dsn::task* task = (::dsn::task*)cb_task;
-    dassert(task->spec().type == TASK_TYPE_AIO, "");
+    if (task == nullptr)
+    {
+        derror("dsn_file_task_enqueue got null callback task");
+        return;
+    }
+
+    if (task->spec().type != TASK_TYPE_AIO)
+    {
+        derror("dsn_file_task_enqueue got non-aio callback task");
+        return;
+    }
 
     ((::dsn::aio_task*)task)->enqueue(err, size);
 }
@@ -1153,8 +1768,24 @@ NORETURN DSN_API void dsn_exit(int code)
 
 DSN_API bool dsn_mimic_app(const char* app_name, int index)
 {
+    if (app_name == nullptr || app_name[0] == '\0')
+    {
+        derror("dsn_mimic_app got null or empty app_name");
+        return false;
+    }
+
+    if (index <= 0)
+    {
+        derror("dsn_mimic_app got invalid index = %d", index);
+        return false;
+    }
+
     auto worker = ::dsn::task::get_current_worker2();
-    dassert(worker == nullptr, "cannot call dsn_mimic_app in rDSN threads");
+    if (worker != nullptr)
+    {
+        derror("cannot call dsn_mimic_app in rDSN threads");
+        return false;
+    }
 
     auto cnode = ::dsn::task::get_current_node2();
     if (cnode != nullptr)
@@ -1189,12 +1820,26 @@ DSN_API bool dsn_mimic_app(const char* app_name, int index)
 
 DSN_API const char* dsn_get_app_data_dir(dsn_gpid gpid)
 {
+    if (gpid.value != 0 && (gpid.u.app_id <= 0 || gpid.u.partition_index < 0))
+    {
+        derror("dsn_get_app_data_dir got invalid gpid = %d.%d",
+               gpid.u.app_id,
+               gpid.u.partition_index);
+        return nullptr;
+    }
+
     auto info = dsn_get_app_info_ptr(gpid);
     return info ? info->data_dir : nullptr;
 }
 
 DSN_API bool dsn_get_current_app_info(/*out*/ dsn_app_info* app_info)
 {
+    if (app_info == nullptr)
+    {
+        derror("dsn_get_current_app_info got null app_info");
+        return false;
+    }
+
     auto info = dsn_get_app_info_ptr(dsn_gpid());
     if (info)
     {
@@ -1207,6 +1852,14 @@ DSN_API bool dsn_get_current_app_info(/*out*/ dsn_app_info* app_info)
 
 DSN_API dsn_app_info* dsn_get_app_info_ptr(dsn_gpid gpid)
 {
+    if (gpid.value != 0 && (gpid.u.app_id <= 0 || gpid.u.partition_index < 0))
+    {
+        derror("dsn_get_app_info_ptr got invalid gpid = %d.%d",
+               gpid.u.app_id,
+               gpid.u.partition_index);
+        return nullptr;
+    }
+
     auto cnode = ::dsn::task::get_current_node2();
     if (cnode != nullptr)
     {

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -239,7 +239,7 @@ DSN_API dsn_task_code_t dsn_task_code_register(
 DSN_API void dsn_task_code_query(dsn_task_code_t code, dsn_task_type_t *ptype, dsn_task_priority_t *ppri, dsn_threadpool_code_t *ppool)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr)
     {
         derror("dsn_task_code_query got invalid code = %d", code);
         return;
@@ -253,7 +253,7 @@ DSN_API void dsn_task_code_query(dsn_task_code_t code, dsn_task_type_t *ptype, d
 DSN_API void dsn_task_code_set_threadpool(dsn_task_code_t code, dsn_threadpool_code_t pool)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr)
     {
         derror("dsn_task_code_set_threadpool got invalid code = %d", code);
         return;
@@ -271,7 +271,7 @@ DSN_API void dsn_task_code_set_threadpool(dsn_task_code_t code, dsn_threadpool_c
 DSN_API void dsn_task_code_set_priority(dsn_task_code_t code, dsn_task_priority_t pri)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr)
     {
         derror("dsn_task_code_set_priority got invalid code = %d", code);
         return;
@@ -397,7 +397,7 @@ DSN_API uint64_t dsn_crc64_concatenate(uint32_t xy_init, uint64_t x_init, uint64
 DSN_API dsn_task_t dsn_task_create(dsn_task_code_t code, dsn_task_handler_t cb, void* context, int hash, dsn_task_tracker_t tracker)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr || sp->type != TASK_TYPE_COMPUTE)
     {
         derror("dsn_task_create got invalid code = %d", code);
         return nullptr;
@@ -420,7 +420,7 @@ DSN_API dsn_task_t dsn_task_create_timer(dsn_task_code_t code, dsn_task_handler_
     void* context, int hash, int interval_milliseconds, dsn_task_tracker_t tracker)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr || sp->type != TASK_TYPE_COMPUTE)
     {
         derror("dsn_task_create_timer got invalid code = %d", code);
         return nullptr;
@@ -448,7 +448,7 @@ DSN_API dsn_task_t dsn_task_create_ex(dsn_task_code_t code, dsn_task_handler_t c
     dsn_task_cancelled_handler_t on_cancel, void* context, int hash, dsn_task_tracker_t tracker)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr || sp->type != TASK_TYPE_COMPUTE)
     {
         derror("dsn_task_create_ex got invalid code = %d", code);
         return nullptr;
@@ -471,7 +471,7 @@ DSN_API dsn_task_t dsn_task_create_timer_ex(dsn_task_code_t code, dsn_task_handl
     void* context, int hash, int interval_milliseconds, dsn_task_tracker_t tracker)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr || sp->type != TASK_TYPE_COMPUTE)
     {
         derror("dsn_task_create_timer_ex got invalid code = %d", code);
         return nullptr;
@@ -974,7 +974,7 @@ DSN_API bool dsn_rpc_register_handler(
     )
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr || sp->type != TASK_TYPE_RPC_REQUEST)
     {
         derror("dsn_rpc_register_handler got invalid code = %d", code);
         return false;
@@ -1010,7 +1010,7 @@ DSN_API bool dsn_rpc_register_handler(
 DSN_API void* dsn_rpc_unregiser_handler(dsn_task_code_t code, dsn_gpid gpid)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr || sp->type != TASK_TYPE_RPC_REQUEST)
     {
         derror("dsn_rpc_unregiser_handler got invalid code = %d", code);
         return nullptr;
@@ -1340,7 +1340,7 @@ DSN_API void* dsn_file_native_handle(dsn_handle_t file)
 DSN_API dsn_task_t dsn_file_create_aio_task(dsn_task_code_t code, dsn_aio_handler_t cb, void* context, int hash, dsn_task_tracker_t tracker)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr || sp->type != TASK_TYPE_AIO)
     {
         derror("dsn_file_create_aio_task got invalid code = %d", code);
         return nullptr;
@@ -1357,7 +1357,7 @@ DSN_API dsn_task_t dsn_file_create_aio_task_ex(dsn_task_code_t code, dsn_aio_han
     void* context, int hash, dsn_task_tracker_t tracker)
 {
     auto sp = ::dsn::task_spec::get(code);
-    if (sp == nullptr)
+    if (code == ::dsn::TASK_CODE_INVALID || sp == nullptr || sp->type != TASK_TYPE_AIO)
     {
         derror("dsn_file_create_aio_task_ex got invalid code = %d", code);
         return nullptr;

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -540,25 +540,30 @@ DSN_API void dsn_task_tracker_wait_all(dsn_task_tracker_t tracker)
     ((::dsn::task_tracker*)tracker)->wait_outstanding_tasks();
 }
 
-DSN_API void dsn_task_call(dsn_task_t task, int delay_milliseconds)
+DSN_API bool dsn_task_call(dsn_task_t task, int delay_milliseconds)
 {
     if (task == nullptr)
     {
         derror("dsn_task_call got null task");
-        return;
+        return false;
     }
 
     if (delay_milliseconds < 0)
     {
         derror("dsn_task_call got invalid delay_milliseconds = %d", delay_milliseconds);
-        return;
+        return false;
     }
 
     auto t = (::dsn::task*)task;
-    dassert(t->spec().type == TASK_TYPE_COMPUTE, "must be common or timer task");
+    if (t->spec().type != TASK_TYPE_COMPUTE)
+    {
+        derror("dsn_task_call got non-compute task");
+        return false;
+    }
 
     t->set_delay(delay_milliseconds);
     t->enqueue();
+    return true;
 }
 
 DSN_API void dsn_task_add_ref(dsn_task_t task)
@@ -605,21 +610,22 @@ DSN_API bool dsn_task_cancel(dsn_task_t task, bool wait_until_finished)
     return ((::dsn::task*)(task))->cancel(wait_until_finished);
 }
 
-DSN_API void dsn_task_set_delay(dsn_task_t task, int delay_ms)
+DSN_API bool dsn_task_set_delay(dsn_task_t task, int delay_ms)
 {
     if (task == nullptr)
     {
         derror("dsn_task_set_delay got null task");
-        return;
+        return false;
     }
 
     if (delay_ms < 0)
     {
         derror("dsn_task_set_delay got invalid delay_ms = %d", delay_ms);
-        return;
+        return false;
     }
 
     ((::dsn::task*)(task))->set_delay(delay_ms);
+    return true;
 }
 
 DSN_API bool dsn_task_cancel2(dsn_task_t task, bool wait_until_finished, bool* finished)

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -1039,12 +1039,6 @@ DSN_API dsn_task_t dsn_rpc_create_response_task(dsn_message_t request, dsn_rpc_r
         return nullptr;
     }
 
-    if (cb == nullptr)
-    {
-        derror("dsn_rpc_create_response_task got null callback");
-        return nullptr;
-    }
-
     auto t = new ::dsn::rpc_response_task(msg, cb, context, nullptr, reply_thread_hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -1059,12 +1053,6 @@ DSN_API dsn_task_t dsn_rpc_create_response_task_ex(dsn_message_t request, dsn_rp
     if (msg == nullptr)
     {
         derror("dsn_rpc_create_response_task_ex got null request");
-        return nullptr;
-    }
-
-    if (cb == nullptr)
-    {
-        derror("dsn_rpc_create_response_task_ex got null callback");
         return nullptr;
     }
 

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -288,7 +288,7 @@ DSN_API void dsn_task_code_set_priority(dsn_task_code_t code, dsn_task_priority_
 
 DSN_API const char* dsn_task_code_to_string(dsn_task_code_t code)
 {
-    if (code < 0 || code == ::dsn::TASK_CODE_INVALID)
+    if (code < 0)
     {
         derror("dsn_task_code_to_string got invalid code = %d", code);
         return "unknown";

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -1074,43 +1074,44 @@ DSN_API dsn_task_t dsn_rpc_create_response_task_ex(dsn_message_t request, dsn_rp
     return t;
 }
 
-DSN_API void dsn_rpc_call(dsn_address_t server, dsn_task_t rpc_call)
+DSN_API dsn_error_t dsn_rpc_call(dsn_address_t server, dsn_task_t rpc_call)
 {
     ::dsn::rpc_response_task* task = (::dsn::rpc_response_task*)rpc_call;
     if (task == nullptr)
     {
         derror("dsn_rpc_call got null rpc_call");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (task->spec().type != TASK_TYPE_RPC_RESPONSE)
     {
         derror("dsn_rpc_call got non-rpc-response task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (::dsn::rpc_address(server).is_invalid())
     {
         derror("dsn_rpc_call got invalid server address");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto rpc = ::dsn::task::get_current_rpc();
     if (rpc == nullptr)
     {
         derror("dsn_rpc_call got null current rpc engine");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
     
     auto msg = task->get_request();
     if (msg == nullptr)
     {
         derror("dsn_rpc_call got null request message");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     msg->server_address = server;
     rpc->call(msg, task);
+    return ::dsn::ERR_OK.get();
 }
 
 DSN_API dsn_message_t dsn_rpc_call_wait(dsn_address_t server, dsn_message_t request)
@@ -1155,76 +1156,79 @@ DSN_API dsn_message_t dsn_rpc_call_wait(dsn_address_t server, dsn_message_t requ
     }
 }
 
-DSN_API void dsn_rpc_call_one_way(dsn_address_t server, dsn_message_t request)
+DSN_API dsn_error_t dsn_rpc_call_one_way(dsn_address_t server, dsn_message_t request)
 {
     auto msg = ((::dsn::message_ex*)request);
     if (msg == nullptr)
     {
         derror("dsn_rpc_call_one_way got null request");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (::dsn::rpc_address(server).is_invalid())
     {
         derror("dsn_rpc_call_one_way got invalid server address");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto rpc = ::dsn::task::get_current_rpc();
     if (rpc == nullptr)
     {
         derror("dsn_rpc_call_one_way got null current rpc engine");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     msg->server_address = server;
 
     rpc->call(msg, nullptr);
+    return ::dsn::ERR_OK.get();
 }
 
-DSN_API void dsn_rpc_reply(dsn_message_t response, dsn_error_t err)
+DSN_API dsn_error_t dsn_rpc_reply(dsn_message_t response, dsn_error_t err)
 {
     auto msg = ((::dsn::message_ex*)response);
     if (msg == nullptr)
     {
         derror("dsn_rpc_reply got null response");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto rpc = ::dsn::task::get_current_rpc();
     if (rpc == nullptr)
     {
         derror("dsn_rpc_reply got null current rpc engine");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     rpc->reply(msg, err);
+    return ::dsn::ERR_OK.get();
 }
 
-DSN_API void dsn_rpc_forward(dsn_message_t request, dsn_address_t addr)
+DSN_API dsn_error_t dsn_rpc_forward(dsn_message_t request, dsn_address_t addr)
 {
     auto msg = (::dsn::message_ex*)(request);
     if (msg == nullptr)
     {
         derror("dsn_rpc_forward got null request");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto target = ::dsn::rpc_address(addr);
     if (target.is_invalid())
     {
         derror("dsn_rpc_forward got invalid target address");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto rpc = ::dsn::task::get_current_rpc();
     if (rpc == nullptr)
     {
         derror("dsn_rpc_forward got null current rpc engine");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     rpc->forward(msg, target);
+    return ::dsn::ERR_OK.get();
 }
 
 DSN_API dsn_message_t dsn_rpc_get_response(dsn_task_t rpc_call)
@@ -1252,23 +1256,24 @@ DSN_API dsn_message_t dsn_rpc_get_response(dsn_task_t rpc_call)
         return nullptr;
 }
 
-DSN_API void dsn_rpc_enqueue_response(dsn_task_t rpc_call, dsn_error_t err, dsn_message_t response)
+DSN_API dsn_error_t dsn_rpc_enqueue_response(dsn_task_t rpc_call, dsn_error_t err, dsn_message_t response)
 {
     ::dsn::rpc_response_task* task = (::dsn::rpc_response_task*)rpc_call;
     if (task == nullptr)
     {
         derror("dsn_rpc_enqueue_response got null rpc_call");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (task->spec().type != TASK_TYPE_RPC_RESPONSE)
     {
         derror("dsn_rpc_enqueue_response got non-rpc-response task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto resp = ((::dsn::message_ex*)response);
     task->enqueue(err, resp);
+    return ::dsn::ERR_OK.get();
 }
 
 //------------------------------------------------------------------------------
@@ -1388,38 +1393,38 @@ DSN_API dsn_task_t dsn_file_create_aio_task_ex(dsn_task_code_t code, dsn_aio_han
     return t;
 }
 
-DSN_API void dsn_file_read(dsn_handle_t file, char* buffer, int count, uint64_t offset, dsn_task_t cb)
+DSN_API dsn_error_t dsn_file_read(dsn_handle_t file, char* buffer, int count, uint64_t offset, dsn_task_t cb)
 {
     if (file == nullptr)
     {
         derror("dsn_file_read got null file handle");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (buffer == nullptr)
     {
         derror("dsn_file_read got null buffer");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (count < 0)
     {
         derror("dsn_file_read got invalid count = %d", count);
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     ::dsn::aio_task* callback((::dsn::aio_task*)cb);
     if (callback == nullptr)
     {
         derror("dsn_file_read got null callback task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto disk = ::dsn::task::get_current_disk();
     if (disk == nullptr)
     {
         derror("dsn_file_read got null current disk engine");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     callback->aio()->buffer = buffer;
@@ -1430,40 +1435,41 @@ DSN_API void dsn_file_read(dsn_handle_t file, char* buffer, int count, uint64_t 
     callback->aio()->type = ::dsn::AIO_Read;
 
     disk->read(callback);
+    return ::dsn::ERR_OK.get();
 }
 
-DSN_API void dsn_file_write(dsn_handle_t file, const char* buffer, int count, uint64_t offset, dsn_task_t cb)
+DSN_API dsn_error_t dsn_file_write(dsn_handle_t file, const char* buffer, int count, uint64_t offset, dsn_task_t cb)
 {
     if (file == nullptr)
     {
         derror("dsn_file_write got null file handle");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (buffer == nullptr)
     {
         derror("dsn_file_write got null buffer");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (count < 0)
     {
         derror("dsn_file_write got invalid count = %d", count);
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     ::dsn::aio_task* callback((::dsn::aio_task*)cb);
     if (callback == nullptr)
     {
         derror("dsn_file_write got null callback task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto disk = ::dsn::task::get_current_disk();
     if (disk == nullptr)
     {
         derror("dsn_file_write got null current disk engine");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     callback->aio()->buffer = (char*)buffer;
@@ -1474,40 +1480,41 @@ DSN_API void dsn_file_write(dsn_handle_t file, const char* buffer, int count, ui
     callback->aio()->type = ::dsn::AIO_Write;
 
     disk->write(callback);
+    return ::dsn::ERR_OK.get();
 }
 
-DSN_API void dsn_file_write_vector(dsn_handle_t file, const dsn_file_buffer_t* buffers, int buffer_count, uint64_t offset, dsn_task_t cb)
+DSN_API dsn_error_t dsn_file_write_vector(dsn_handle_t file, const dsn_file_buffer_t* buffers, int buffer_count, uint64_t offset, dsn_task_t cb)
 {
     if (file == nullptr)
     {
         derror("dsn_file_write_vector got null file handle");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (buffers == nullptr)
     {
         derror("dsn_file_write_vector got null buffers");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (buffer_count <= 0)
     {
         derror("dsn_file_write_vector got invalid buffer_count = %d", buffer_count);
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     ::dsn::aio_task* callback((::dsn::aio_task*)cb);
     if (callback == nullptr)
     {
         derror("dsn_file_write_vector got null callback task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto disk = ::dsn::task::get_current_disk();
     if (disk == nullptr)
     {
         derror("dsn_file_write_vector got null current disk engine");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     for (int i = 0; i < buffer_count; i++)
@@ -1517,13 +1524,13 @@ DSN_API void dsn_file_write_vector(dsn_handle_t file, const dsn_file_buffer_t* b
             derror("dsn_file_write_vector got invalid buffer size = %d at index = %d",
                    buffers[i].size,
                    i);
-            return;
+            return ::dsn::ERR_INVALID_PARAMETERS.get();
         }
 
         if (buffers[i].buffer == nullptr)
         {
             derror("dsn_file_write_vector got null buffer at index = %d", i);
-            return;
+            return ::dsn::ERR_INVALID_PARAMETERS.get();
         }
     }
 
@@ -1540,41 +1547,42 @@ DSN_API void dsn_file_write_vector(dsn_handle_t file, const dsn_file_buffer_t* b
     }
 
     disk->write(callback);
+    return ::dsn::ERR_OK.get();
 }
 
-DSN_API void dsn_file_copy_remote_directory(dsn_address_t remote, const char* source_dir, 
+DSN_API dsn_error_t dsn_file_copy_remote_directory(dsn_address_t remote, const char* source_dir,
     const char* dest_dir, bool overwrite, dsn_task_t cb)
 {
     if (::dsn::rpc_address(remote).is_invalid())
     {
         derror("dsn_file_copy_remote_directory got invalid remote address");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (source_dir == nullptr || source_dir[0] == '\0')
     {
         derror("dsn_file_copy_remote_directory got null or empty source_dir");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (dest_dir == nullptr || dest_dir[0] == '\0')
     {
         derror("dsn_file_copy_remote_directory got null or empty dest_dir");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     ::dsn::aio_task* callback((::dsn::aio_task*)cb);
     if (callback == nullptr)
     {
         derror("dsn_file_copy_remote_directory got null callback task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto nfs = ::dsn::task::get_current_nfs();
     if (nfs == nullptr)
     {
         derror("dsn_file_copy_remote_directory got null current nfs node");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     std::shared_ptr< ::dsn::remote_copy_request> rci(new ::dsn::remote_copy_request());
@@ -1585,46 +1593,47 @@ DSN_API void dsn_file_copy_remote_directory(dsn_address_t remote, const char* so
     rci->overwrite = overwrite;
 
     nfs->call(rci, callback);
+    return ::dsn::ERR_OK.get();
 }
 
-DSN_API void dsn_file_copy_remote_files(dsn_address_t remote, const char* source_dir, const char** source_files, const char* dest_dir, bool overwrite, dsn_task_t cb)
+DSN_API dsn_error_t dsn_file_copy_remote_files(dsn_address_t remote, const char* source_dir, const char** source_files, const char* dest_dir, bool overwrite, dsn_task_t cb)
 {
     if (::dsn::rpc_address(remote).is_invalid())
     {
         derror("dsn_file_copy_remote_files got invalid remote address");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (source_dir == nullptr || source_dir[0] == '\0')
     {
         derror("dsn_file_copy_remote_files got null or empty source_dir");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (source_files == nullptr)
     {
         derror("dsn_file_copy_remote_files got null source_files");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (dest_dir == nullptr || dest_dir[0] == '\0')
     {
         derror("dsn_file_copy_remote_files got null or empty dest_dir");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     ::dsn::aio_task* callback((::dsn::aio_task*)cb);
     if (callback == nullptr)
     {
         derror("dsn_file_copy_remote_files got null callback task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     auto nfs = ::dsn::task::get_current_nfs();
     if (nfs == nullptr)
     {
         derror("dsn_file_copy_remote_files got null current nfs node");
-        return;
+        return ::dsn::ERR_INVALID_STATE.get();
     }
 
     std::shared_ptr< ::dsn::remote_copy_request> rci(new ::dsn::remote_copy_request());
@@ -1648,6 +1657,7 @@ DSN_API void dsn_file_copy_remote_files(dsn_address_t remote, const char* source
     rci->overwrite = overwrite;
 
     nfs->call(rci, callback);
+    return ::dsn::ERR_OK.get();
 }
 
 DSN_API size_t dsn_file_get_io_size(dsn_task_t cb_task)
@@ -1668,22 +1678,23 @@ DSN_API size_t dsn_file_get_io_size(dsn_task_t cb_task)
     return ((::dsn::aio_task*)task)->get_transferred_size();
 }
 
-DSN_API void dsn_file_task_enqueue(dsn_task_t cb_task, dsn_error_t err, size_t size)
+DSN_API dsn_error_t dsn_file_task_enqueue(dsn_task_t cb_task, dsn_error_t err, size_t size)
 {
     ::dsn::task* task = (::dsn::task*)cb_task;
     if (task == nullptr)
     {
         derror("dsn_file_task_enqueue got null callback task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     if (task->spec().type != TASK_TYPE_AIO)
     {
         derror("dsn_file_task_enqueue got non-aio callback task");
-        return;
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
     }
 
     ((::dsn::aio_task*)task)->enqueue(err, size);
+    return ::dsn::ERR_OK.get();
 }
 
 //------------------------------------------------------------------------------

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -507,17 +507,35 @@ DSN_API dsn_handle_t dsn_exlock_create(bool recursive)
 
 DSN_API void dsn_exlock_destroy(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_exlock_destroy got null lock");
+        return;
+    }
+
     delete (::dsn::ilock*)(l);
 }
 
 DSN_API void dsn_exlock_lock(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_exlock_lock got null lock");
+        return;
+    }
+
     ((::dsn::ilock*)(l))->lock();
     ::dsn::lock_checker::zlock_exclusive_count++;
 }
 
 DSN_API bool dsn_exlock_try_lock(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_exlock_try_lock got null lock");
+        return false;
+    }
+
     auto r = ((::dsn::ilock*)(l))->try_lock();
     if (r)
     {
@@ -528,6 +546,12 @@ DSN_API bool dsn_exlock_try_lock(dsn_handle_t l)
 
 DSN_API void dsn_exlock_unlock(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_exlock_unlock got null lock");
+        return;
+    }
+
     ::dsn::lock_checker::zlock_exclusive_count--;
     ((::dsn::ilock*)(l))->unlock();
 }
@@ -548,23 +572,47 @@ DSN_API dsn_handle_t dsn_rwlock_nr_create()
 
 DSN_API void dsn_rwlock_nr_destroy(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_rwlock_nr_destroy got null lock");
+        return;
+    }
+
     delete (::dsn::rwlock_nr_provider*)(l);
 }
 
 DSN_API void dsn_rwlock_nr_lock_read(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_rwlock_nr_lock_read got null lock");
+        return;
+    }
+
     ((::dsn::rwlock_nr_provider*)(l))->lock_read();
     ::dsn::lock_checker::zlock_shared_count++;
 }
 
 DSN_API void dsn_rwlock_nr_unlock_read(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_rwlock_nr_unlock_read got null lock");
+        return;
+    }
+
     ::dsn::lock_checker::zlock_shared_count--;
     ((::dsn::rwlock_nr_provider*)(l))->unlock_read();
 }
 
 DSN_API bool dsn_rwlock_nr_try_lock_read(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_rwlock_nr_try_lock_read got null lock");
+        return false;
+    }
+
     auto r = ((::dsn::rwlock_nr_provider*)(l))->try_lock_read();
     if (r) ::dsn::lock_checker::zlock_shared_count++;
     return r;
@@ -572,18 +620,36 @@ DSN_API bool dsn_rwlock_nr_try_lock_read(dsn_handle_t l)
 
 DSN_API void dsn_rwlock_nr_lock_write(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_rwlock_nr_lock_write got null lock");
+        return;
+    }
+
     ((::dsn::rwlock_nr_provider*)(l))->lock_write();
     ::dsn::lock_checker::zlock_exclusive_count++;
 }
 
 DSN_API void dsn_rwlock_nr_unlock_write(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_rwlock_nr_unlock_write got null lock");
+        return;
+    }
+
     ::dsn::lock_checker::zlock_exclusive_count--;
     ((::dsn::rwlock_nr_provider*)(l))->unlock_write();
 }
 
 DSN_API bool dsn_rwlock_nr_try_lock_write(dsn_handle_t l)
 {
+    if (l == nullptr)
+    {
+        derror("dsn_rwlock_nr_try_lock_write got null lock");
+        return false;
+    }
+
     auto r = ((::dsn::rwlock_nr_provider*)(l))->try_lock_write();
     if (r) ::dsn::lock_checker::zlock_exclusive_count++;
     return r;
@@ -591,6 +657,12 @@ DSN_API bool dsn_rwlock_nr_try_lock_write(dsn_handle_t l)
 
 DSN_API dsn_handle_t dsn_semaphore_create(int initial_count)
 {
+    if (initial_count < 0)
+    {
+        derror("dsn_semaphore_create got invalid initial_count = %d", initial_count);
+        return nullptr;
+    }
+
     ::dsn::semaphore_provider* last = ::dsn::utils::factory_store< ::dsn::semaphore_provider>::create(
         ::dsn::service_engine::fast_instance().spec().semaphore_factory_name.c_str(), ::dsn::PROVIDER_TYPE_MAIN, initial_count, nullptr);
 
@@ -605,22 +677,52 @@ DSN_API dsn_handle_t dsn_semaphore_create(int initial_count)
 
 DSN_API void dsn_semaphore_destroy(dsn_handle_t s)
 {
+    if (s == nullptr)
+    {
+        derror("dsn_semaphore_destroy got null semaphore");
+        return;
+    }
+
     delete (::dsn::semaphore_provider*)(s);
 }
 
 DSN_API void dsn_semaphore_signal(dsn_handle_t s, int count)
 {
+    if (s == nullptr)
+    {
+        derror("dsn_semaphore_signal got null semaphore");
+        return;
+    }
+
+    if (count <= 0)
+    {
+        derror("dsn_semaphore_signal got invalid count = %d", count);
+        return;
+    }
+
     ((::dsn::semaphore_provider*)(s))->signal(count);
 }
 
 DSN_API void dsn_semaphore_wait(dsn_handle_t s)
 {
+    if (s == nullptr)
+    {
+        derror("dsn_semaphore_wait got null semaphore");
+        return;
+    }
+
     ::dsn::lock_checker::check_wait_safety();
     ((::dsn::semaphore_provider*)(s))->wait();
 }
 
 DSN_API bool dsn_semaphore_wait_timeout(dsn_handle_t s, int timeout_milliseconds)
 {
+    if (s == nullptr)
+    {
+        derror("dsn_semaphore_wait_timeout got null semaphore");
+        return false;
+    }
+
     return ((::dsn::semaphore_provider*)(s))->wait(timeout_milliseconds);
 }
 

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -252,6 +252,12 @@ DSN_API void dsn_coredump()
 
 DSN_API uint32_t dsn_crc32_compute(const void* ptr, size_t size, uint32_t init_crc)
 {
+    if (ptr == nullptr)
+    {
+        derror("dsn_crc32_compute got null ptr");
+        return CRC_INVALID;
+    }
+
     return ::dsn::utils::crc32::compute(ptr, size, init_crc);
 }
 
@@ -267,6 +273,12 @@ DSN_API uint32_t dsn_crc32_concatenate(uint32_t xy_init, uint32_t x_init, uint32
 
 DSN_API uint64_t dsn_crc64_compute(const void* ptr, size_t size, uint64_t init_crc)
 {
+    if (ptr == nullptr)
+    {
+        derror("dsn_crc64_compute got null ptr");
+        return CRC_INVALID;
+    }
+
     return ::dsn::utils::crc64::compute(ptr, size, init_crc);
 }
 

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -548,6 +548,12 @@ DSN_API void dsn_task_call(dsn_task_t task, int delay_milliseconds)
         return;
     }
 
+    if (delay_milliseconds < 0)
+    {
+        derror("dsn_task_call got invalid delay_milliseconds = %d", delay_milliseconds);
+        return;
+    }
+
     auto t = (::dsn::task*)task;
     dassert(t->spec().type == TASK_TYPE_COMPUTE, "must be common or timer task");
 
@@ -604,6 +610,12 @@ DSN_API void dsn_task_set_delay(dsn_task_t task, int delay_ms)
     if (task == nullptr)
     {
         derror("dsn_task_set_delay got null task");
+        return;
+    }
+
+    if (delay_ms < 0)
+    {
+        derror("dsn_task_set_delay got invalid delay_ms = %d", delay_ms);
         return;
     }
 

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -89,21 +89,42 @@ public:
 
 DSN_API dsn_error_t dsn_error_register(const char* name)
 {
-    dassert(strlen(name) < DSN_MAX_ERROR_CODE_NAME_LENGTH,
-        "error code '%s' is too long - length must be smaller than %d",
-        name,
-        DSN_MAX_ERROR_CODE_NAME_LENGTH
-        );
+    if (name == nullptr || name[0] == '\0')
+    {
+        derror("dsn_error_register got null or empty name");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
+    if (strlen(name) >= DSN_MAX_ERROR_CODE_NAME_LENGTH)
+    {
+        derror("dsn_error_register got too long name '%s' - length must be smaller than %d",
+               name,
+               DSN_MAX_ERROR_CODE_NAME_LENGTH);
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
     return static_cast<dsn_error_t>(error_code_mgr::instance().register_id(name));
 }
 
 DSN_API const char* dsn_error_to_string(dsn_error_t err)
 {
+    if (err < 0)
+    {
+        derror("dsn_error_to_string got invalid error code = %d", err);
+        return "unknown";
+    }
+
     return error_code_mgr::instance().get_name(static_cast<int>(err));
 }
 
 DSN_API dsn_error_t dsn_error_from_string(const char* s, dsn_error_t default_err)
 {
+    if (s == nullptr || s[0] == '\0')
+    {
+        derror("dsn_error_from_string got null or empty string");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
     auto r = error_code_mgr::instance().get_id(s);
     return r == -1 ? default_err : r;
 }

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -214,7 +214,13 @@ DSN_API const char* dsn_task_priority_to_string(dsn_task_priority_t tt)
 
 DSN_API bool dsn_task_is_running_inside(dsn_task_t t)
 {
-    return ::dsn::task::get_current_task() == (::dsn::task*)(t);
+    if (t == nullptr)
+    {
+        derror("dsn_task_is_running_inside got null task");
+        return false;
+    }
+
+    return ::dsn::task::get_current_task() == (::dsn::task*)t;
 }
 
 DSN_API void dsn_coredump()
@@ -290,27 +296,57 @@ DSN_API dsn_task_t dsn_task_create_timer_ex(dsn_task_code_t code, dsn_task_handl
 
 DSN_API dsn_task_tracker_t dsn_task_tracker_create(int task_bucket_count)
 {
+    if (task_bucket_count <= 0)
+    {
+        derror("dsn_task_tracker_create got invalid task_bucket_count = %d", task_bucket_count);
+        return nullptr;
+    }
+
     return (dsn_task_tracker_t)(new ::dsn::task_tracker(task_bucket_count));
 }
 
 DSN_API void dsn_task_tracker_destroy(dsn_task_tracker_t tracker)
 {
+    if (tracker == nullptr)
+    {
+        derror("dsn_task_tracker_destroy got null tracker");
+        return;
+    }
+
     delete ((::dsn::task_tracker*)tracker);
 }
 
 DSN_API void dsn_task_tracker_cancel_all(dsn_task_tracker_t tracker)
 {
+    if (tracker == nullptr)
+    {
+        derror("dsn_task_tracker_cancel_all got null tracker");
+        return;
+    }
+
     ((::dsn::task_tracker*)tracker)->cancel_outstanding_tasks();
 }
 
 DSN_API void dsn_task_tracker_wait_all(dsn_task_tracker_t tracker)
 {
+    if (tracker == nullptr)
+    {
+        derror("dsn_task_tracker_wait_all got null tracker");
+        return;
+    }
+
     ((::dsn::task_tracker*)tracker)->wait_outstanding_tasks();
 }
 
 DSN_API void dsn_task_call(dsn_task_t task, int delay_milliseconds)
 {
-    auto t = ((::dsn::task*)(task));
+    if (task == nullptr)
+    {
+        derror("dsn_task_call got null task");
+        return;
+    }
+
+    auto t = (::dsn::task*)task;
     dassert(t->spec().type == TASK_TYPE_COMPUTE, "must be common or timer task");
 
     t->set_delay(delay_milliseconds);
@@ -319,31 +355,71 @@ DSN_API void dsn_task_call(dsn_task_t task, int delay_milliseconds)
 
 DSN_API void dsn_task_add_ref(dsn_task_t task)
 {
+    if (task == nullptr)
+    {
+        derror("dsn_task_add_ref got null task");
+        return;
+    }
+
     ((::dsn::task*)(task))->add_ref();
 }
 
 DSN_API void dsn_task_release_ref(dsn_task_t task)
 {
+    if (task == nullptr)
+    {
+        derror("dsn_task_release_ref got null task");
+        return;
+    }
+
     ((::dsn::task*)(task))->release_ref();
 }
 
 DSN_API int dsn_task_get_ref(dsn_task_t task)
 {
+    if (task == nullptr)
+    {
+        derror("dsn_task_get_ref got null task");
+        return 0;
+    }
+
     return ((::dsn::task*)(task))->get_count();
 }
 
 DSN_API bool dsn_task_cancel(dsn_task_t task, bool wait_until_finished)
 {
+    if (task == nullptr)
+    {
+        derror("dsn_task_cancel got null task");
+        return false;
+    }
+
     return ((::dsn::task*)(task))->cancel(wait_until_finished);
 }
 
 DSN_API void dsn_task_set_delay(dsn_task_t task, int delay_ms)
 {
+    if (task == nullptr)
+    {
+        derror("dsn_task_set_delay got null task");
+        return;
+    }
+
     ((::dsn::task*)(task))->set_delay(delay_ms);
 }
 
 DSN_API bool dsn_task_cancel2(dsn_task_t task, bool wait_until_finished, bool* finished)
 {
+    if (task == nullptr)
+    {
+        derror("dsn_task_cancel2 got null task");
+        if (finished != nullptr)
+        {
+            *finished = false;
+        }
+        return false;
+    }
+
     return ((::dsn::task*)(task))->cancel(wait_until_finished, finished);
 }
 
@@ -358,20 +434,39 @@ DSN_API void dsn_task_cancel_current_timer()
 
 DSN_API void dsn_task_wait(dsn_task_t task)
 {
-    auto r = ((::dsn::task*)(task))->wait();
+    if (task == nullptr)
+    {
+        derror("dsn_task_wait got null task");
+        return;
+    }
+
+    auto t = (::dsn::task*)task;
+    auto r = t->wait();
     dassert(r, 
         "task wait without timeout must succeeds (task_id = %016" PRIx64 ")",
-        ((::dsn::task*)(task))->id()
+        t->id()
         );
 }
 
 DSN_API bool dsn_task_wait_timeout(dsn_task_t task, int timeout_milliseconds)
 {
+    if (task == nullptr)
+    {
+        derror("dsn_task_wait_timeout got null task");
+        return false;
+    }
+
     return ((::dsn::task*)(task))->wait(timeout_milliseconds);
 }
 
 DSN_API dsn_error_t dsn_task_error(dsn_task_t task)
 {
+    if (task == nullptr)
+    {
+        derror("dsn_task_error got null task");
+        return ::dsn::ERR_INVALID_PARAMETERS.get();
+    }
+
     return ((::dsn::task*)(task))->error().get();
 }
 

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -225,7 +225,7 @@ DSN_API dsn_task_code_t dsn_task_code_register(
         return static_cast<dsn_task_code_t>(::dsn::TASK_CODE_INVALID);
     }
 
-    if (pool < 0)
+    if (pool < 0 || pool == ::dsn::THREAD_POOL_INVALID)
     {
         derror("dsn_task_code_register got invalid pool = %d", pool);
         return static_cast<dsn_task_code_t>(::dsn::TASK_CODE_INVALID);
@@ -259,7 +259,7 @@ DSN_API void dsn_task_code_set_threadpool(dsn_task_code_t code, dsn_threadpool_c
         return;
     }
 
-    if (pool < 0)
+    if (pool < 0 || pool == ::dsn::THREAD_POOL_INVALID)
     {
         derror("dsn_task_code_set_threadpool got invalid pool = %d", pool);
         return;

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -134,7 +134,7 @@ DSN_API volatile int* dsn_task_queue_virtual_length_ptr(
     int hash
     )
 {
-    if (code < 0)
+    if (code < 0 || code == ::dsn::TASK_CODE_INVALID)
     {
         derror("dsn_task_queue_virtual_length_ptr got invalid code = %d", code);
         return nullptr;
@@ -288,7 +288,7 @@ DSN_API void dsn_task_code_set_priority(dsn_task_code_t code, dsn_task_priority_
 
 DSN_API const char* dsn_task_code_to_string(dsn_task_code_t code)
 {
-    if (code < 0)
+    if (code < 0 || code == ::dsn::TASK_CODE_INVALID)
     {
         derror("dsn_task_code_to_string got invalid code = %d", code);
         return "unknown";

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -1303,7 +1303,7 @@ DSN_API dsn_error_t dsn_file_close(dsn_handle_t file)
         return ::dsn::ERR_INVALID_STATE.get();
     }
 
-    return disk->close(file);
+    return disk->close(file).get();
 }
 
 DSN_API dsn_error_t dsn_file_flush(dsn_handle_t file)
@@ -1321,7 +1321,7 @@ DSN_API dsn_error_t dsn_file_flush(dsn_handle_t file)
         return ::dsn::ERR_INVALID_STATE.get();
     }
 
-    return disk->flush(file);
+    return disk->flush(file).get();
 }
 
 // native HANDLE: HANDLE for windows, int for non-windows

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -1358,12 +1358,6 @@ DSN_API dsn_task_t dsn_file_create_aio_task(dsn_task_code_t code, dsn_aio_handle
         return nullptr;
     }
 
-    if (cb == nullptr)
-    {
-        derror("dsn_file_create_aio_task got null callback");
-        return nullptr;
-    }
-
     auto t = new ::dsn::aio_task(code, cb, context, nullptr, hash);
     t->set_tracker((dsn::task_tracker*)tracker);
     t->spec().on_task_create.execute(::dsn::task::get_current_task(), t);
@@ -1378,12 +1372,6 @@ DSN_API dsn_task_t dsn_file_create_aio_task_ex(dsn_task_code_t code, dsn_aio_han
     if (sp == nullptr)
     {
         derror("dsn_file_create_aio_task_ex got invalid code = %d", code);
-        return nullptr;
-    }
-
-    if (cb == nullptr)
-    {
-        derror("dsn_file_create_aio_task_ex got null callback");
         return nullptr;
     }
 

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -244,7 +244,7 @@ TEST(core, dsn_file)
         dsn_task_add_ref(tin);
         ASSERT_NE(nullptr, tin);
         ASSERT_EQ(1, dsn_task_get_ref(tin));
-        dsn_file_read(fin, buffer, 1024, offset, tin);
+        ASSERT_EQ(ERR_OK, dsn_file_read(fin, buffer, 1024, offset, tin));
         dsn_task_wait(tin);
         ASSERT_EQ(rin.err, dsn_task_error(tin));
         if (rin.err != ERR_OK)
@@ -272,7 +272,7 @@ TEST(core, dsn_file)
             &rout, 0);
         dsn_task_add_ref(tout);
         ASSERT_NE(nullptr, tout);
-        dsn_file_write(fout, buffer, rin.sz, offset, tout);
+        ASSERT_EQ(ERR_OK, dsn_file_write(fout, buffer, rin.sz, offset, tout));
         dsn_task_wait(tout);
         ASSERT_EQ(ERR_OK, rout.err);
         ASSERT_EQ(ERR_OK, dsn_task_error(tout));
@@ -331,8 +331,8 @@ TEST(core, dsn_nfs)
                 &r, 0);
         dsn_task_add_ref(t);
         ASSERT_NE(nullptr, t);
-        dsn_file_copy_remote_files(dsn_address_build("localhost", 20101),
-                ".", files, "nfs_test_dir", false, t);
+        ASSERT_EQ(ERR_OK, dsn_file_copy_remote_files(dsn_address_build("localhost", 20101),
+                ".", files, "nfs_test_dir", false, t));
         ASSERT_TRUE(dsn_task_wait_timeout(t, 20000));
         ASSERT_EQ(r.err, dsn_task_error(t));
         ASSERT_EQ(ERR_OK, r.err);
@@ -373,8 +373,8 @@ TEST(core, dsn_nfs)
                 &r, 0);
         dsn_task_add_ref(t);
         ASSERT_NE(nullptr, t);
-        dsn_file_copy_remote_files(dsn_address_build("localhost", 20101),
-                ".", files, "nfs_test_dir", true, t);
+        ASSERT_EQ(ERR_OK, dsn_file_copy_remote_files(dsn_address_build("localhost", 20101),
+                ".", files, "nfs_test_dir", true, t));
         ASSERT_TRUE(dsn_task_wait_timeout(t, 20000));
         ASSERT_EQ(r.err, dsn_task_error(t));
         ASSERT_EQ(ERR_OK, r.err);
@@ -401,8 +401,8 @@ TEST(core, dsn_nfs)
                 &r, 0);
         dsn_task_add_ref(t);
         ASSERT_NE(nullptr, t);
-        dsn_file_copy_remote_directory(dsn_address_build("localhost", 20101),
-                "nfs_test_dir", "nfs_test_dir_copy", false, t);
+        ASSERT_EQ(ERR_OK, dsn_file_copy_remote_directory(dsn_address_build("localhost", 20101),
+                "nfs_test_dir", "nfs_test_dir_copy", false, t));
         ASSERT_TRUE(dsn_task_wait_timeout(t, 20000));
         ASSERT_EQ(r.err, dsn_task_error(t));
         ASSERT_EQ(ERR_OK, r.err);
@@ -478,4 +478,3 @@ TEST(core, dsn_system)
         ASSERT_EQ(app_count, count);
     }
 }
-

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -164,6 +164,32 @@ TEST(core, dsn_task)
 {
 }
 
+TEST(core, dsn_task_invalid_parameters)
+{
+    ASSERT_FALSE(dsn_task_is_running_inside(nullptr));
+    ASSERT_FALSE(dsn_task_call(nullptr, 0));
+    ASSERT_FALSE(dsn_task_set_delay(nullptr, 0));
+    ASSERT_FALSE(dsn_task_cancel(nullptr, false));
+    ASSERT_FALSE(dsn_task_wait_timeout(nullptr, 0));
+
+    bool finished = true;
+    ASSERT_FALSE(dsn_task_cancel2(nullptr, false, &finished));
+    ASSERT_FALSE(finished);
+
+    auto compute_task = dsn_task_create(TASK_CODE_COMPUTE_FOR_TEST, noop_task_handler, nullptr, 0);
+    ASSERT_NE(nullptr, compute_task);
+    dsn_task_add_ref(compute_task);
+    ASSERT_FALSE(dsn_task_call(compute_task, -1));
+    ASSERT_FALSE(dsn_task_set_delay(compute_task, -1));
+    dsn_task_release_ref(compute_task);
+
+    auto aio_task = dsn_file_create_aio_task(TASK_CODE_AIO_FOR_TEST, noop_aio_handler, nullptr, 0);
+    ASSERT_NE(nullptr, aio_task);
+    dsn_task_add_ref(aio_task);
+    ASSERT_FALSE(dsn_task_call(aio_task, 0));
+    dsn_task_release_ref(aio_task);
+}
+
 TEST(core, dsn_exlock)
 {
     if(dsn::service_engine::fast_instance().spec().semaphore_factory_name == "dsn::tools::sim_semaphore_provider")

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -213,7 +213,8 @@ TEST(core, dsn_task_code_invalid_parameters)
     dsn_task_code_set_priority(TASK_CODE_INVALID, TASK_PRIORITY_COMMON);
     dsn_task_code_set_priority(TASK_CODE_COMPUTE_FOR_TEST, TASK_PRIORITY_COUNT);
 
-    ASSERT_STREQ("unknown", dsn_task_code_to_string(TASK_CODE_INVALID));
+    ASSERT_STREQ("TASK_CODE_INVALID", dsn_task_code_to_string(TASK_CODE_INVALID));
+    ASSERT_STREQ("unknown", dsn_task_code_to_string(static_cast<dsn_task_code_t>(-1)));
     ASSERT_EQ(TASK_CODE_INVALID, dsn_task_code_from_string(nullptr, TASK_CODE_COMPUTE_FOR_TEST));
     ASSERT_EQ(TASK_CODE_INVALID, dsn_task_code_from_string("", TASK_CODE_COMPUTE_FOR_TEST));
     ASSERT_STREQ("Unknown", dsn_task_type_to_string(TASK_TYPE_COUNT));

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -97,6 +97,8 @@ void noop_task_handler(void*) {}
 
 void noop_rpc_response_handler(dsn_error_t, dsn_message_t, dsn_message_t, void*) {}
 
+void noop_rpc_request_handler(dsn_message_t, void*) {}
+
 void noop_aio_handler(dsn_error_t, size_t, void*) {}
 
 } // anonymous namespace
@@ -331,6 +333,35 @@ TEST(core, dsn_exlock)
     }
 }
 
+TEST(core, dsn_sync_invalid_parameters)
+{
+    dsn_exlock_destroy(nullptr);
+    dsn_exlock_lock(nullptr);
+    ASSERT_FALSE(dsn_exlock_try_lock(nullptr));
+    dsn_exlock_unlock(nullptr);
+
+    dsn_rwlock_nr_destroy(nullptr);
+    dsn_rwlock_nr_lock_read(nullptr);
+    dsn_rwlock_nr_unlock_read(nullptr);
+    ASSERT_FALSE(dsn_rwlock_nr_try_lock_read(nullptr));
+    dsn_rwlock_nr_lock_write(nullptr);
+    dsn_rwlock_nr_unlock_write(nullptr);
+    ASSERT_FALSE(dsn_rwlock_nr_try_lock_write(nullptr));
+
+    ASSERT_EQ(nullptr, dsn_semaphore_create(-1));
+    dsn_semaphore_destroy(nullptr);
+    dsn_semaphore_signal(nullptr, 1);
+    dsn_semaphore_signal(nullptr, 0);
+    dsn_semaphore_wait(nullptr);
+    ASSERT_FALSE(dsn_semaphore_wait_timeout(nullptr, 0));
+
+    auto semaphore = dsn_semaphore_create(0);
+    ASSERT_NE(nullptr, semaphore);
+    dsn_semaphore_signal(semaphore, 0);
+    dsn_semaphore_signal(semaphore, -1);
+    dsn_semaphore_destroy(semaphore);
+}
+
 TEST(core, dsn_rwlock)
 {
     if(dsn::service_engine::fast_instance().spec().semaphore_factory_name == "dsn::tools::sim_semaphore_provider")
@@ -359,6 +390,31 @@ TEST(core, dsn_semaphore)
 
 TEST(core, dsn_rpc)
 {
+}
+
+TEST(core, dsn_rpc_registration_invalid_parameters)
+{
+    ASSERT_FALSE(dsn_rpc_register_handler(TASK_CODE_INVALID,
+                                          "invalid_code",
+                                          noop_rpc_request_handler,
+                                          nullptr,
+                                          dsn_gpid()));
+    ASSERT_FALSE(dsn_rpc_register_handler(TASK_CODE_RPC_FOR_TEST,
+                                          nullptr,
+                                          noop_rpc_request_handler,
+                                          nullptr,
+                                          dsn_gpid()));
+    ASSERT_FALSE(dsn_rpc_register_handler(TASK_CODE_RPC_FOR_TEST,
+                                          "",
+                                          noop_rpc_request_handler,
+                                          nullptr,
+                                          dsn_gpid()));
+    ASSERT_FALSE(dsn_rpc_register_handler(TASK_CODE_RPC_FOR_TEST,
+                                          "null_callback",
+                                          nullptr,
+                                          nullptr,
+                                          dsn_gpid()));
+    ASSERT_EQ(nullptr, dsn_rpc_unregiser_handler(TASK_CODE_INVALID, dsn_gpid()));
 }
 
 TEST(core, dsn_rpc_dispatch_invalid_parameters)
@@ -491,6 +547,55 @@ TEST(core, dsn_file_dispatch_invalid_parameters)
     dsn_task_release_ref(compute_task);
 
     dsn_task_release_ref(aio_task);
+}
+
+TEST(core, dsn_file_handle_invalid_parameters)
+{
+    ASSERT_EQ(nullptr, dsn_file_open(nullptr, O_RDONLY, 0));
+    ASSERT_EQ(nullptr, dsn_file_open("", O_RDONLY, 0));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_close(nullptr));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_flush(nullptr));
+    ASSERT_EQ(nullptr, dsn_file_native_handle(nullptr));
+    ASSERT_EQ(nullptr, dsn_file_create_aio_task(TASK_CODE_INVALID, noop_aio_handler, nullptr, 0));
+    ASSERT_EQ(nullptr, dsn_file_create_aio_task(TASK_CODE_AIO_FOR_TEST, nullptr, nullptr, 0));
+    ASSERT_EQ(nullptr,
+              dsn_file_create_aio_task_ex(TASK_CODE_INVALID,
+                                          noop_aio_handler,
+                                          nullptr,
+                                          nullptr,
+                                          0));
+    ASSERT_EQ(nullptr,
+              dsn_file_create_aio_task_ex(TASK_CODE_AIO_FOR_TEST,
+                                          nullptr,
+                                          nullptr,
+                                          nullptr,
+                                          0));
+    ASSERT_EQ(static_cast<size_t>(-1), dsn_file_get_io_size(nullptr));
+
+    auto compute_task = dsn_task_create(TASK_CODE_COMPUTE_FOR_TEST, noop_task_handler, nullptr, 0);
+    ASSERT_NE(nullptr, compute_task);
+    dsn_task_add_ref(compute_task);
+    ASSERT_EQ(static_cast<size_t>(-1), dsn_file_get_io_size(compute_task));
+    dsn_task_release_ref(compute_task);
+}
+
+TEST(core, dsn_app_info_invalid_parameters)
+{
+    dsn_gpid invalid_app_id = {};
+    invalid_app_id.u.app_id = 0;
+    invalid_app_id.u.partition_index = 1;
+    dsn_gpid invalid_partition_index = {};
+    invalid_partition_index.u.app_id = 1;
+    invalid_partition_index.u.partition_index = -1;
+
+    ASSERT_FALSE(dsn_mimic_app(nullptr, 1));
+    ASSERT_FALSE(dsn_mimic_app("", 1));
+    ASSERT_FALSE(dsn_mimic_app("client", 0));
+    ASSERT_FALSE(dsn_get_current_app_info(nullptr));
+    ASSERT_EQ(nullptr, dsn_get_app_data_dir(invalid_app_id));
+    ASSERT_EQ(nullptr, dsn_get_app_data_dir(invalid_partition_index));
+    ASSERT_EQ(nullptr, dsn_get_app_info_ptr(invalid_app_id));
+    ASSERT_EQ(nullptr, dsn_get_app_info_ptr(invalid_partition_index));
 }
 
 TEST(core, dsn_file)

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -196,6 +196,11 @@ TEST(core, dsn_task_code_invalid_parameters)
                                      TASK_TYPE_COMPUTE,
                                      TASK_PRIORITY_COMMON,
                                      THREAD_POOL_INVALID));
+    ASSERT_EQ(TASK_CODE_INVALID,
+              dsn_task_code_register("negative_task_pool",
+                                     TASK_TYPE_COMPUTE,
+                                     TASK_PRIORITY_COMMON,
+                                     static_cast<dsn_threadpool_code_t>(-1)));
 
     dsn_task_code_query(TASK_CODE_INVALID, &type, &priority, &pool);
     ASSERT_EQ(TASK_TYPE_COUNT, type);
@@ -203,6 +208,8 @@ TEST(core, dsn_task_code_invalid_parameters)
     ASSERT_EQ(THREAD_POOL_INVALID, pool);
     dsn_task_code_set_threadpool(TASK_CODE_INVALID, THREAD_POOL_DEFAULT);
     dsn_task_code_set_threadpool(TASK_CODE_COMPUTE_FOR_TEST, THREAD_POOL_INVALID);
+    dsn_task_code_set_threadpool(TASK_CODE_COMPUTE_FOR_TEST,
+                                 static_cast<dsn_threadpool_code_t>(-1));
     dsn_task_code_set_priority(TASK_CODE_INVALID, TASK_PRIORITY_COMMON);
     dsn_task_code_set_priority(TASK_CODE_COMPUTE_FOR_TEST, TASK_PRIORITY_COUNT);
 

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -606,6 +606,15 @@ TEST(core, dsn_app_registration_invalid_parameters)
     dsn_app_callbacks callbacks = {};
 
     ASSERT_FALSE(dsn_register_app(nullptr));
+    dsn_app app = {};
+    ASSERT_FALSE(dsn_register_app(&app));
+    memset(app.type_name, 'a', sizeof(app.type_name));
+    ASSERT_FALSE(dsn_register_app(&app));
+    memset(app.type_name, 0, sizeof(app.type_name));
+    snprintf(app.type_name, sizeof(app.type_name), "%s", "dsn_app_registration_invalid_test");
+    ASSERT_TRUE(dsn_register_app(&app));
+    ASSERT_FALSE(dsn_register_app(&app));
+
     ASSERT_FALSE(dsn_get_app_callbacks(nullptr, &callbacks));
     ASSERT_FALSE(dsn_get_app_callbacks("", &callbacks));
     ASSERT_FALSE(dsn_get_app_callbacks("test", nullptr));

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -611,7 +611,7 @@ TEST(core, dsn_app_registration_invalid_parameters)
     memset(app.type_name, 'a', sizeof(app.type_name));
     ASSERT_FALSE(dsn_register_app(&app));
     memset(app.type_name, 0, sizeof(app.type_name));
-    snprintf(app.type_name, sizeof(app.type_name), "%s", "dsn_app_registration_invalid_test");
+    snprintf(app.type_name, sizeof(app.type_name), "%s", "dsn_app_reg_test");
     ASSERT_TRUE(dsn_register_app(&app));
     ASSERT_FALSE(dsn_register_app(&app));
 

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -67,6 +67,18 @@ TEST(core, dsn_threadpool_code)
 DEFINE_TASK_CODE(TASK_CODE_COMPUTE_FOR_TEST, TASK_PRIORITY_HIGH, THREAD_POOL_DEFAULT)
 DEFINE_TASK_CODE_AIO(TASK_CODE_AIO_FOR_TEST, TASK_PRIORITY_COMMON, THREAD_POOL_DEFAULT)
 DEFINE_TASK_CODE_RPC(TASK_CODE_RPC_FOR_TEST, TASK_PRIORITY_LOW, THREAD_POOL_DEFAULT)
+
+namespace
+{
+
+void noop_task_handler(void*) {}
+
+void noop_rpc_response_handler(dsn_error_t, dsn_message_t, dsn_message_t, void*) {}
+
+void noop_aio_handler(dsn_error_t, size_t, void*) {}
+
+} // anonymous namespace
+
 TEST(core, dsn_task_code)
 {
     dsn_task_type_t type;
@@ -210,11 +222,138 @@ TEST(core, dsn_rpc)
 {
 }
 
+TEST(core, dsn_rpc_dispatch_invalid_parameters)
+{
+    const dsn_address_t invalid_address = {};
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_call(invalid_address, nullptr));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_call_one_way(invalid_address, nullptr));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_reply(nullptr, ERR_OK));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_forward(nullptr, invalid_address));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_enqueue_response(nullptr, ERR_OK, nullptr));
+
+    auto request = dsn_msg_create_request(TASK_CODE_RPC_FOR_TEST, 100, 0, 0);
+    ASSERT_NE(nullptr, request);
+    dsn_msg_add_ref(request);
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_call_one_way(invalid_address, request));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_forward(request, invalid_address));
+
+    auto rpc_response_task =
+        dsn_rpc_create_response_task(request, noop_rpc_response_handler, nullptr, 0);
+    ASSERT_NE(nullptr, rpc_response_task);
+    dsn_task_add_ref(rpc_response_task);
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_call(invalid_address, rpc_response_task));
+    dsn_task_release_ref(rpc_response_task);
+
+    auto compute_task = dsn_task_create(TASK_CODE_COMPUTE_FOR_TEST, noop_task_handler, nullptr, 0);
+    ASSERT_NE(nullptr, compute_task);
+    dsn_task_add_ref(compute_task);
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_call(invalid_address, compute_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_enqueue_response(compute_task, ERR_OK, nullptr));
+    dsn_task_release_ref(compute_task);
+
+    dsn_msg_release_ref(request);
+}
+
+TEST(core, dsn_hosted_app_invalid_parameters)
+{
+    auto fake_app_context = reinterpret_cast<void*>(1);
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_commit_rpc_request(nullptr, nullptr, false));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_commit_rpc_request(fake_app_context, nullptr, false));
+}
+
 struct aio_result
 {
     dsn_error_t err;
     size_t sz;
 };
+
+TEST(core, dsn_file_dispatch_invalid_parameters)
+{
+    auto fake_file = reinterpret_cast<dsn_handle_t>(1);
+    char buffer[16];
+    dsn_file_buffer_t valid_buffers[] = {{buffer, static_cast<int>(sizeof(buffer))}};
+    const char* source_files[] = {"command.txt", nullptr};
+    const auto remote = dsn_address_build("localhost", 20101);
+    const dsn_address_t invalid_address = {};
+
+    auto aio_task = dsn_file_create_aio_task(TASK_CODE_AIO_FOR_TEST, noop_aio_handler, nullptr, 0);
+    ASSERT_NE(nullptr, aio_task);
+    dsn_task_add_ref(aio_task);
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_read(nullptr, buffer, sizeof(buffer), 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_read(fake_file, nullptr, sizeof(buffer), 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_read(fake_file, buffer, -1, 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_read(fake_file, buffer, sizeof(buffer), 0, nullptr));
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_write(nullptr, buffer, sizeof(buffer), 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_write(fake_file, nullptr, sizeof(buffer), 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_write(fake_file, buffer, -1, 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_write(fake_file, buffer, sizeof(buffer), 0, nullptr));
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_write_vector(nullptr, valid_buffers, 1, 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_write_vector(fake_file, nullptr, 1, 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_write_vector(fake_file, valid_buffers, 0, 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_write_vector(fake_file, valid_buffers, -1, 0, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_write_vector(fake_file, valid_buffers, 1, 0, nullptr));
+
+    if (task::get_current_disk() != nullptr)
+    {
+        dsn_file_buffer_t negative_size_buffers[] = {{buffer, -1}};
+        dsn_file_buffer_t null_data_buffers[] = {{nullptr, static_cast<int>(sizeof(buffer))}};
+        ASSERT_EQ(ERR_INVALID_PARAMETERS,
+                  dsn_file_write_vector(fake_file, negative_size_buffers, 1, 0, aio_task));
+        ASSERT_EQ(ERR_INVALID_PARAMETERS,
+                  dsn_file_write_vector(fake_file, null_data_buffers, 1, 0, aio_task));
+    }
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_directory(invalid_address, ".", ".", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_directory(remote, nullptr, ".", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_directory(remote, "", ".", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_directory(remote, ".", nullptr, false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_directory(remote, ".", "", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_directory(remote, ".", ".", false, nullptr));
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_files(invalid_address, ".", source_files, ".", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_files(remote, nullptr, source_files, ".", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_files(remote, "", source_files, ".", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_files(remote, ".", nullptr, ".", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_files(remote, ".", source_files, nullptr, false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_files(remote, ".", source_files, "", false, aio_task));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_copy_remote_files(remote, ".", source_files, ".", false, nullptr));
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_task_enqueue(nullptr, ERR_OK, 0));
+
+    auto compute_task = dsn_task_create(TASK_CODE_COMPUTE_FOR_TEST, noop_task_handler, nullptr, 0);
+    ASSERT_NE(nullptr, compute_task);
+    dsn_task_add_ref(compute_task);
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_task_enqueue(compute_task, ERR_OK, 0));
+    dsn_task_release_ref(compute_task);
+
+    dsn_task_release_ref(aio_task);
+}
+
 TEST(core, dsn_file)
 {
     // if in dsn_mimic_app() and disk_io_mode == IOE_PER_QUEUE

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -101,6 +101,10 @@ void noop_rpc_request_handler(dsn_message_t, void*) {}
 
 void noop_aio_handler(dsn_error_t, size_t, void*) {}
 
+void* noop_checker_create(const char*, dsn_app_info*, int) { return nullptr; }
+
+void noop_checker_apply(void*) {}
+
 } // anonymous namespace
 
 TEST(core, dsn_task_code)
@@ -228,6 +232,61 @@ TEST(core, dsn_config)
     ASSERT_STREQ("count", buffers[0]);
 }
 
+TEST(core, dsn_config_invalid_parameters)
+{
+    const char* buffers[1];
+    int buffer_count = 1;
+    int invalid_buffer_count = -1;
+
+    ASSERT_STREQ("default", dsn_config_get_value_string(nullptr, "key", "default", ""));
+    ASSERT_STREQ("default", dsn_config_get_value_string("", "key", "default", ""));
+    ASSERT_STREQ("default", dsn_config_get_value_string("section", nullptr, "default", ""));
+    ASSERT_STREQ("default", dsn_config_get_value_string("section", "", "default", ""));
+    ASSERT_EQ(nullptr, dsn_config_get_value_string("section", "key", nullptr, ""));
+
+    ASSERT_TRUE(dsn_config_get_value_bool(nullptr, "key", true, ""));
+    ASSERT_TRUE(dsn_config_get_value_bool("", "key", true, ""));
+    ASSERT_TRUE(dsn_config_get_value_bool("section", nullptr, true, ""));
+    ASSERT_TRUE(dsn_config_get_value_bool("section", "", true, ""));
+
+    ASSERT_EQ(123u, dsn_config_get_value_uint64(nullptr, "key", 123, ""));
+    ASSERT_EQ(123u, dsn_config_get_value_uint64("", "key", 123, ""));
+    ASSERT_EQ(123u, dsn_config_get_value_uint64("section", nullptr, 123, ""));
+    ASSERT_EQ(123u, dsn_config_get_value_uint64("section", "", 123, ""));
+
+    ASSERT_EQ(1.5, dsn_config_get_value_double(nullptr, "key", 1.5, ""));
+    ASSERT_EQ(1.5, dsn_config_get_value_double("", "key", 1.5, ""));
+    ASSERT_EQ(1.5, dsn_config_get_value_double("section", nullptr, 1.5, ""));
+    ASSERT_EQ(1.5, dsn_config_get_value_double("section", "", 1.5, ""));
+
+    ASSERT_EQ(-1, dsn_config_get_all_sections(buffers, nullptr));
+    ASSERT_EQ(-1, dsn_config_get_all_sections(buffers, &invalid_buffer_count));
+    ASSERT_EQ(-1, dsn_config_get_all_sections(nullptr, &buffer_count));
+
+    ASSERT_EQ(-1, dsn_config_get_all_keys(nullptr, buffers, &buffer_count));
+    ASSERT_EQ(-1, dsn_config_get_all_keys("", buffers, &buffer_count));
+    ASSERT_EQ(-1, dsn_config_get_all_keys("section", buffers, nullptr));
+    invalid_buffer_count = -1;
+    ASSERT_EQ(-1, dsn_config_get_all_keys("section", buffers, &invalid_buffer_count));
+    buffer_count = 1;
+    ASSERT_EQ(-1, dsn_config_get_all_keys("section", nullptr, &buffer_count));
+
+    dsn_config_dump(nullptr);
+    dsn_config_dump("");
+}
+
+TEST(core, dsn_run_invalid_parameters)
+{
+    char arg0[] = "dsn";
+    char* null_argv[] = {arg0, nullptr};
+
+    dsn_run(-1, nullptr, false);
+    dsn_run(1, nullptr, false);
+    dsn_run(2, null_argv, false);
+    ASSERT_FALSE(dsn_run_config(nullptr, false));
+    ASSERT_FALSE(dsn_run_config("", false));
+}
+
 TEST(core, dsn_coredump)
 {
 }
@@ -303,6 +362,9 @@ TEST(core, dsn_task_create_invalid_parameters)
                                                 -1));
     ASSERT_EQ(nullptr, dsn_task_tracker_create(0));
     ASSERT_EQ(nullptr, dsn_task_tracker_create(-1));
+    dsn_task_tracker_cancel_all(nullptr);
+    dsn_task_tracker_destroy(nullptr);
+    dsn_task_tracker_wait_all(nullptr);
 }
 
 TEST(core, dsn_exlock)
@@ -431,6 +493,21 @@ TEST(core, dsn_rpc_dispatch_invalid_parameters)
     ASSERT_NE(nullptr, request);
     dsn_msg_add_ref(request);
 
+    ASSERT_EQ(nullptr, dsn_rpc_create_response_task_ex(nullptr,
+                                                       noop_rpc_response_handler,
+                                                       nullptr,
+                                                       nullptr,
+                                                       0,
+                                                       nullptr));
+    ASSERT_EQ(nullptr, dsn_rpc_create_response_task_ex(request,
+                                                       nullptr,
+                                                       nullptr,
+                                                       nullptr,
+                                                       0,
+                                                       nullptr));
+    ASSERT_EQ(nullptr, dsn_rpc_call_wait(invalid_address, nullptr));
+    ASSERT_EQ(nullptr, dsn_rpc_call_wait(invalid_address, request));
+
     ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_call_one_way(invalid_address, request));
     ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_forward(request, invalid_address));
 
@@ -446,19 +523,94 @@ TEST(core, dsn_rpc_dispatch_invalid_parameters)
     dsn_task_add_ref(compute_task);
     ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_call(invalid_address, compute_task));
     ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_enqueue_response(compute_task, ERR_OK, nullptr));
+    ASSERT_EQ(nullptr, dsn_rpc_get_response(compute_task));
     dsn_task_release_ref(compute_task);
 
+    ASSERT_EQ(nullptr, dsn_rpc_get_response(nullptr));
     dsn_msg_release_ref(request);
 }
 
 TEST(core, dsn_hosted_app_invalid_parameters)
 {
     auto fake_app_context = reinterpret_cast<void*>(1);
+    void* downcall_context = nullptr;
+    void* callback_context = nullptr;
+    dsn_gpid invalid_app_id = {};
+    invalid_app_id.u.app_id = 0;
+    invalid_app_id.u.partition_index = 1;
+    dsn_gpid invalid_partition_index = {};
+    invalid_partition_index.u.app_id = 1;
+    invalid_partition_index.u.partition_index = -1;
+    dsn_gpid valid_gpid = {};
+    valid_gpid.u.app_id = 1;
+    valid_gpid.u.partition_index = 0;
+    char* null_argv[] = {nullptr};
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_create(nullptr,
+                                    valid_gpid,
+                                    "data",
+                                    &downcall_context,
+                                    &callback_context));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_create("",
+                                    valid_gpid,
+                                    "data",
+                                    &downcall_context,
+                                    &callback_context));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_create("test",
+                                    invalid_app_id,
+                                    "data",
+                                    &downcall_context,
+                                    &callback_context));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_create("test",
+                                    invalid_partition_index,
+                                    "data",
+                                    &downcall_context,
+                                    &callback_context));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_create("test",
+                                    valid_gpid,
+                                    nullptr,
+                                    &downcall_context,
+                                    &callback_context));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_create("test",
+                                    valid_gpid,
+                                    "",
+                                    &downcall_context,
+                                    &callback_context));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_create("test", valid_gpid, "data", nullptr, &callback_context));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_hosted_app_create("test", valid_gpid, "data", &downcall_context, nullptr));
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_hosted_app_start(nullptr, 0, nullptr));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_hosted_app_start(fake_app_context, -1, nullptr));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_hosted_app_start(fake_app_context, 1, nullptr));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_hosted_app_start(fake_app_context, 1, null_argv));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_hosted_app_destroy(nullptr, false));
 
     ASSERT_EQ(ERR_INVALID_PARAMETERS,
               dsn_hosted_app_commit_rpc_request(nullptr, nullptr, false));
     ASSERT_EQ(ERR_INVALID_PARAMETERS,
               dsn_hosted_app_commit_rpc_request(fake_app_context, nullptr, false));
+}
+
+TEST(core, dsn_app_registration_invalid_parameters)
+{
+    dsn_app_callbacks callbacks = {};
+
+    ASSERT_FALSE(dsn_register_app(nullptr));
+    ASSERT_FALSE(dsn_get_app_callbacks(nullptr, &callbacks));
+    ASSERT_FALSE(dsn_get_app_callbacks("", &callbacks));
+    ASSERT_FALSE(dsn_get_app_callbacks("test", nullptr));
+    ASSERT_FALSE(dsn_register_app_checker(nullptr, noop_checker_create, noop_checker_apply));
+    ASSERT_FALSE(dsn_register_app_checker("", noop_checker_create, noop_checker_apply));
+    ASSERT_FALSE(dsn_register_app_checker("invalid_checker", nullptr, noop_checker_apply));
+    ASSERT_FALSE(dsn_register_app_checker("invalid_checker", noop_checker_create, nullptr));
 }
 
 struct aio_result
@@ -592,6 +744,9 @@ TEST(core, dsn_app_info_invalid_parameters)
     ASSERT_FALSE(dsn_mimic_app("", 1));
     ASSERT_FALSE(dsn_mimic_app("client", 0));
     ASSERT_FALSE(dsn_get_current_app_info(nullptr));
+    ASSERT_EQ(-1, dsn_get_all_apps(nullptr, 1));
+    dsn_app_info apps[1];
+    ASSERT_EQ(-1, dsn_get_all_apps(apps, -1));
     ASSERT_EQ(nullptr, dsn_get_app_data_dir(invalid_app_id));
     ASSERT_EQ(nullptr, dsn_get_app_data_dir(invalid_partition_index));
     ASSERT_EQ(nullptr, dsn_get_app_info_ptr(invalid_app_id));

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -709,16 +709,9 @@ TEST(core, dsn_file_handle_invalid_parameters)
     ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_flush(nullptr));
     ASSERT_EQ(nullptr, dsn_file_native_handle(nullptr));
     ASSERT_EQ(nullptr, dsn_file_create_aio_task(TASK_CODE_INVALID, noop_aio_handler, nullptr, 0));
-    ASSERT_EQ(nullptr, dsn_file_create_aio_task(TASK_CODE_AIO_FOR_TEST, nullptr, nullptr, 0));
     ASSERT_EQ(nullptr,
               dsn_file_create_aio_task_ex(TASK_CODE_INVALID,
                                           noop_aio_handler,
-                                          nullptr,
-                                          nullptr,
-                                          0));
-    ASSERT_EQ(nullptr,
-              dsn_file_create_aio_task_ex(TASK_CODE_AIO_FOR_TEST,
-                                          nullptr,
                                           nullptr,
                                           nullptr,
                                           0));

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -499,12 +499,6 @@ TEST(core, dsn_rpc_dispatch_invalid_parameters)
                                                        nullptr,
                                                        0,
                                                        nullptr));
-    ASSERT_EQ(nullptr, dsn_rpc_create_response_task_ex(request,
-                                                       nullptr,
-                                                       nullptr,
-                                                       nullptr,
-                                                       0,
-                                                       nullptr));
     ASSERT_EQ(nullptr, dsn_rpc_call_wait(invalid_address, nullptr));
     ASSERT_EQ(nullptr, dsn_rpc_call_wait(invalid_address, request));
 

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -48,6 +48,18 @@ TEST(core, dsn_error)
     ASSERT_STREQ("ERR_OK", dsn_error_to_string(ERR_OK));
 }
 
+TEST(core, dsn_error_invalid_parameters)
+{
+    const auto too_long_error_name = std::string(DSN_MAX_ERROR_CODE_NAME_LENGTH, 'e');
+
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_error_register(nullptr));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_error_register(""));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_error_register(too_long_error_name.c_str()));
+    ASSERT_STREQ("unknown", dsn_error_to_string(-1));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_error_from_string(nullptr, ERR_OK));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_error_from_string("", ERR_OK));
+}
+
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_FOR_TEST)
 TEST(core, dsn_threadpool_code)
 {
@@ -62,6 +74,16 @@ TEST(core, dsn_threadpool_code)
     ASSERT_LE(THREAD_POOL_FOR_TEST, dsn_threadpool_code_max());
 
     ASSERT_LT(0, dsn_threadpool_get_current_tid());
+}
+
+TEST(core, dsn_threadpool_code_invalid_parameters)
+{
+    ASSERT_EQ(THREAD_POOL_INVALID, dsn_threadpool_code_register(nullptr));
+    ASSERT_EQ(THREAD_POOL_INVALID, dsn_threadpool_code_register(""));
+    ASSERT_EQ(THREAD_POOL_INVALID,
+              dsn_threadpool_code_from_string(nullptr, THREAD_POOL_DEFAULT));
+    ASSERT_EQ(THREAD_POOL_INVALID,
+              dsn_threadpool_code_from_string("", THREAD_POOL_DEFAULT));
 }
 
 DEFINE_TASK_CODE(TASK_CODE_COMPUTE_FOR_TEST, TASK_PRIORITY_HIGH, THREAD_POOL_DEFAULT)
@@ -134,6 +156,58 @@ TEST(core, dsn_task_code)
     dsn_task_code_set_priority(TASK_CODE_COMPUTE_FOR_TEST, TASK_PRIORITY_HIGH);
 }
 
+TEST(core, dsn_task_code_invalid_parameters)
+{
+    const auto too_long_task_name = std::string(DSN_MAX_TASK_CODE_NAME_LENGTH, 't');
+    dsn_task_type_t type = TASK_TYPE_COUNT;
+    dsn_task_priority_t priority = TASK_PRIORITY_COUNT;
+    dsn_threadpool_code_t pool = THREAD_POOL_INVALID;
+
+    ASSERT_EQ(TASK_CODE_INVALID, dsn_task_code_register(nullptr,
+                                                        TASK_TYPE_COMPUTE,
+                                                        TASK_PRIORITY_COMMON,
+                                                        THREAD_POOL_DEFAULT));
+    ASSERT_EQ(TASK_CODE_INVALID, dsn_task_code_register("",
+                                                        TASK_TYPE_COMPUTE,
+                                                        TASK_PRIORITY_COMMON,
+                                                        THREAD_POOL_DEFAULT));
+    ASSERT_EQ(TASK_CODE_INVALID, dsn_task_code_register(too_long_task_name.c_str(),
+                                                        TASK_TYPE_COMPUTE,
+                                                        TASK_PRIORITY_COMMON,
+                                                        THREAD_POOL_DEFAULT));
+    ASSERT_EQ(TASK_CODE_INVALID,
+              dsn_task_code_register("invalid_task_type",
+                                     TASK_TYPE_COUNT,
+                                     TASK_PRIORITY_COMMON,
+                                     THREAD_POOL_DEFAULT));
+    ASSERT_EQ(TASK_CODE_INVALID,
+              dsn_task_code_register("invalid_task_priority",
+                                     TASK_TYPE_COMPUTE,
+                                     TASK_PRIORITY_COUNT,
+                                     THREAD_POOL_DEFAULT));
+    ASSERT_EQ(TASK_CODE_INVALID,
+              dsn_task_code_register("invalid_task_pool",
+                                     TASK_TYPE_COMPUTE,
+                                     TASK_PRIORITY_COMMON,
+                                     THREAD_POOL_INVALID));
+
+    dsn_task_code_query(TASK_CODE_INVALID, &type, &priority, &pool);
+    ASSERT_EQ(TASK_TYPE_COUNT, type);
+    ASSERT_EQ(TASK_PRIORITY_COUNT, priority);
+    ASSERT_EQ(THREAD_POOL_INVALID, pool);
+    dsn_task_code_set_threadpool(TASK_CODE_INVALID, THREAD_POOL_DEFAULT);
+    dsn_task_code_set_threadpool(TASK_CODE_COMPUTE_FOR_TEST, THREAD_POOL_INVALID);
+    dsn_task_code_set_priority(TASK_CODE_INVALID, TASK_PRIORITY_COMMON);
+    dsn_task_code_set_priority(TASK_CODE_COMPUTE_FOR_TEST, TASK_PRIORITY_COUNT);
+
+    ASSERT_STREQ("unknown", dsn_task_code_to_string(TASK_CODE_INVALID));
+    ASSERT_EQ(TASK_CODE_INVALID, dsn_task_code_from_string(nullptr, TASK_CODE_COMPUTE_FOR_TEST));
+    ASSERT_EQ(TASK_CODE_INVALID, dsn_task_code_from_string("", TASK_CODE_COMPUTE_FOR_TEST));
+    ASSERT_STREQ("Unknown", dsn_task_type_to_string(TASK_TYPE_COUNT));
+    ASSERT_STREQ("Unknown", dsn_task_priority_to_string(TASK_PRIORITY_COUNT));
+    ASSERT_EQ(nullptr, dsn_task_queue_virtual_length_ptr(TASK_CODE_INVALID, 0));
+}
+
 TEST(core, dsn_config)
 {
     ASSERT_TRUE(dsn_config_get_value_bool("apps.client", "run", false, "client run"));
@@ -160,6 +234,12 @@ TEST(core, dsn_crc32)
 {
 }
 
+TEST(core, dsn_crc_invalid_parameters)
+{
+    ASSERT_EQ(CRC_INVALID, dsn_crc32_compute(nullptr, 1, 0));
+    ASSERT_EQ(static_cast<uint64_t>(CRC_INVALID), dsn_crc64_compute(nullptr, 1, 0));
+}
+
 TEST(core, dsn_task)
 {
 }
@@ -167,6 +247,8 @@ TEST(core, dsn_task)
 TEST(core, dsn_task_invalid_parameters)
 {
     ASSERT_FALSE(dsn_task_is_running_inside(nullptr));
+    ASSERT_EQ(0, dsn_task_get_ref(nullptr));
+    ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_task_error(nullptr));
     ASSERT_FALSE(dsn_task_call(nullptr, 0));
     ASSERT_FALSE(dsn_task_set_delay(nullptr, 0));
     ASSERT_FALSE(dsn_task_cancel(nullptr, false));
@@ -188,6 +270,37 @@ TEST(core, dsn_task_invalid_parameters)
     dsn_task_add_ref(aio_task);
     ASSERT_FALSE(dsn_task_call(aio_task, 0));
     dsn_task_release_ref(aio_task);
+}
+
+TEST(core, dsn_task_create_invalid_parameters)
+{
+    ASSERT_EQ(nullptr, dsn_task_create(TASK_CODE_INVALID, noop_task_handler, nullptr, 0));
+    ASSERT_EQ(nullptr, dsn_task_create(TASK_CODE_COMPUTE_FOR_TEST, nullptr, nullptr, 0));
+    ASSERT_EQ(nullptr, dsn_task_create_ex(TASK_CODE_INVALID, noop_task_handler, nullptr, nullptr, 0));
+    ASSERT_EQ(nullptr, dsn_task_create_ex(TASK_CODE_COMPUTE_FOR_TEST, nullptr, nullptr, nullptr, 0));
+    ASSERT_EQ(nullptr, dsn_task_create_timer(TASK_CODE_INVALID, noop_task_handler, nullptr, 0, 1));
+    ASSERT_EQ(nullptr, dsn_task_create_timer(TASK_CODE_COMPUTE_FOR_TEST, nullptr, nullptr, 0, 1));
+    ASSERT_EQ(nullptr, dsn_task_create_timer(TASK_CODE_COMPUTE_FOR_TEST, noop_task_handler, nullptr, 0, -1));
+    ASSERT_EQ(nullptr, dsn_task_create_timer_ex(TASK_CODE_INVALID,
+                                                noop_task_handler,
+                                                nullptr,
+                                                nullptr,
+                                                0,
+                                                1));
+    ASSERT_EQ(nullptr, dsn_task_create_timer_ex(TASK_CODE_COMPUTE_FOR_TEST,
+                                                nullptr,
+                                                nullptr,
+                                                nullptr,
+                                                0,
+                                                1));
+    ASSERT_EQ(nullptr, dsn_task_create_timer_ex(TASK_CODE_COMPUTE_FOR_TEST,
+                                                noop_task_handler,
+                                                nullptr,
+                                                nullptr,
+                                                0,
+                                                -1));
+    ASSERT_EQ(nullptr, dsn_task_tracker_create(0));
+    ASSERT_EQ(nullptr, dsn_task_tracker_create(-1));
 }
 
 TEST(core, dsn_exlock)

--- a/src/core/src/task_engine.h
+++ b/src/core/src/task_engine.h
@@ -110,7 +110,10 @@ public:
     //
     // task management routines
     //
-    task_worker_pool* get_pool(int code) const { return _pools[code]; }
+    task_worker_pool* get_pool(int code) const
+    {
+        return ((code >= 0) && (code < static_cast<int>(_pools.size()))) ? _pools[code] : nullptr;
+    }
     std::vector<task_worker_pool*>& pools() { return _pools; }
 
     bool is_started() const { return _is_running.load(std::memory_order_acquire); }

--- a/src/core/src/transient_memory.cpp
+++ b/src/core/src/transient_memory.cpp
@@ -38,6 +38,11 @@
 # include <cstddef>
 # include <cstdint>
 
+# if defined(__TITLE__)
+# undef __TITLE__
+# endif
+# define __TITLE__ "transient_memory"
+
 namespace dsn 
 {
     __thread tls_transient_memory_t tls_trans_memory;

--- a/src/core/src/transient_memory.cpp
+++ b/src/core/src/transient_memory.cpp
@@ -160,6 +160,12 @@ DSN_API void* dsn_transient_malloc(uint32_t size)
 
 DSN_API void dsn_transient_free(void* ptr)
 {
+    if (ptr == nullptr)
+    {
+        derror("dsn_transient_free got null ptr");
+        return;
+    }
+
     return ::dsn::tls_trans_free(ptr);
 }
 
@@ -170,5 +176,11 @@ DSN_API void* dsn_malloc(uint32_t size)
 
 DSN_API void dsn_free(void* ptr)
 {
+    if (ptr == nullptr)
+    {
+        derror("dsn_free got null ptr");
+        return;
+    }
+
     return free(ptr);
 }

--- a/src/core/src/transient_memory.test.cpp
+++ b/src/core/src/transient_memory.test.cpp
@@ -107,3 +107,8 @@ TEST(core, transient_memory)
     tls_trans_mem_init(1024 * 1024); // restore
 }
 
+TEST(core, dsn_transient_memory_invalid_parameters)
+{
+    dsn_transient_free(nullptr);
+    dsn_free(nullptr);
+}

--- a/src/core/src/unit_test_driver.cpp
+++ b/src/core/src/unit_test_driver.cpp
@@ -56,7 +56,7 @@ void run_all_unit_tests_prepare_when_necessary()
     command_manager_module_init();
 
     // register all possible services
-    dsn::register_app<test_client>("test");
+    dassert(dsn::register_app<test_client>("test"), "register test app failed");
 }
 
 void run_all_unit_tests_when_necessary()
@@ -99,4 +99,3 @@ void run_all_unit_tests_when_necessary()
 
     dassert(false, "impossible execution here");
 }
-

--- a/src/core/src/utils.test.cpp
+++ b/src/core/src/utils.test.cpp
@@ -58,6 +58,7 @@ TEST(core, get_last_component)
     ASSERT_EQ("b", get_last_component("a//b", "/"));
     ASSERT_EQ("", get_last_component("a/", "/"));
     ASSERT_EQ("c", get_last_component("a/b_c", "/_"));
+    ASSERT_EQ("a/b", get_last_component("a/b", nullptr));
 }
 
 TEST(core, crc)
@@ -163,6 +164,20 @@ TEST(core, binary_io_blob)
     }
 }
 
+TEST(core, binary_io_invalid_parameters)
+{
+    blob valid_blob("abc", 0, 3);
+
+    binary_reader default_reader;
+    EXPECT_EQ(0, default_reader.get_remaining_size());
+    EXPECT_EQ(0u, default_reader.get_remaining_buffer().length());
+    EXPECT_FALSE(default_reader.backup(-1));
+
+    binary_writer writer;
+    EXPECT_EQ(0, writer.total_size());
+    EXPECT_EQ(0u, writer.get_first_buffer().length());
+}
+
 
 TEST(core, split_args)
 {
@@ -182,6 +197,20 @@ TEST(core, split_args)
     EXPECT_EQ(*it++, "a");
     EXPECT_EQ(*it++, "b");
     EXPECT_EQ(*it++, "c");
+
+    ::dsn::utils::split_args(nullptr, sargs, ',');
+    EXPECT_TRUE(sargs.empty());
+
+    ::dsn::utils::split_args(nullptr, sargs2, ',');
+    EXPECT_TRUE(sargs2.empty());
+
+    safe_vector<safe_string> safe_args;
+    ::dsn::utils::split_args(nullptr, safe_args, ',');
+    EXPECT_TRUE(safe_args.empty());
+
+    safe_list<safe_string> safe_args2;
+    ::dsn::utils::split_args(nullptr, safe_args2, ',');
+    EXPECT_TRUE(safe_args2.empty());
 }
 
 TEST(core, trim_string)
@@ -189,6 +218,23 @@ TEST(core, trim_string)
     std::string value = " x x x x ";
     auto r = trim_string((char*)value.c_str());
     EXPECT_EQ(std::string(r), "x x x x");
+    EXPECT_EQ(nullptr, trim_string(nullptr));
+
+    char empty[] = "";
+    EXPECT_STREQ("", trim_string(empty));
+}
+
+TEST(core, time_ms_to_string_invalid_parameters)
+{
+    time_ms_to_string(0, nullptr, 0);
+
+    char small[sizeof("00:00:00.000") - 1] = "unchanged";
+    time_ms_to_string(0, small, sizeof(small));
+    EXPECT_STREQ("", small);
+
+    char output[sizeof("00:00:00.000")];
+    time_ms_to_string(0, output, sizeof(output));
+    EXPECT_EQ(12u, strlen(output));
 }
 
 TEST(core, host_name)

--- a/src/dev/cpp/clientlet.cpp
+++ b/src/dev/cpp/clientlet.cpp
@@ -126,7 +126,7 @@ namespace dsn
         }
 
 
-        void copy_remote_files_impl(
+        error_code copy_remote_files_impl(
             ::dsn::rpc_address remote,
             const std::string& source_dir,
             const std::vector<std::string>& files,  // empty for all
@@ -137,7 +137,7 @@ namespace dsn
         {
             if (files.empty())
             {
-                dsn_file_copy_remote_directory(remote.c_addr(), source_dir.c_str(), dest_dir.c_str(),
+                return dsn_file_copy_remote_directory(remote.c_addr(), source_dir.c_str(), dest_dir.c_str(),
                     overwrite, native_task);
             }
             else
@@ -150,7 +150,7 @@ namespace dsn
                 }
                 *ptr = nullptr;
 
-                dsn_file_copy_remote_files(
+                return dsn_file_copy_remote_files(
                     remote.c_addr(), source_dir.c_str(), ptr_base,
                     dest_dir.c_str(), overwrite, native_task
                     );

--- a/src/dev/cpp/clientlet.cpp
+++ b/src/dev/cpp/clientlet.cpp
@@ -98,8 +98,6 @@ namespace dsn
 
     task_ptr rpc::create_rpc_response_task(dsn_message_t request, clientlet* svc, empty_callback_t, int reply_thread_hash)
     {
-        task_ptr tsk = new safe_task_handle;
-        //do not add_ref here
         auto t = dsn_rpc_create_response_task(
             request,
             nullptr,
@@ -107,6 +105,13 @@ namespace dsn
             reply_thread_hash,
             svc ? svc->tracker() : nullptr
             );
+        if (t == nullptr)
+        {
+            return nullptr;
+        }
+
+        task_ptr tsk = new safe_task_handle;
+        //do not add_ref here
         tsk->set_task_info(t);
         return tsk;
     }
@@ -115,12 +120,17 @@ namespace dsn
     {
         task_ptr create_aio_task(dsn_task_code_t callback_code, clientlet* svc, empty_callback_t, int hash)
         {
-            task_ptr tsk = new safe_task_handle;
-            //do not add_ref here
             dsn_task_t t = dsn_file_create_aio_task(callback_code,
                 nullptr,
                 nullptr, hash, svc ? svc->tracker() : nullptr
                 );
+            if (t == nullptr)
+            {
+                return nullptr;
+            }
+
+            task_ptr tsk = new safe_task_handle;
+            //do not add_ref here
             tsk->set_task_info(t);
             return tsk;
         }

--- a/src/dev/cpp/perf_test_helper.cpp
+++ b/src/dev/cpp/perf_test_helper.cpp
@@ -271,7 +271,7 @@ namespace dsn {
                 {
                     uint64_t ts = dsn_now_ns();
                     char str[24];
-                    ::dsn::utils::time_ms_to_string(ts / 1000000, str);
+                    ::dsn::utils::time_ms_to_string(ts / 1000000, str, sizeof(str));
                     std::stringstream ss;
 
                     ss << "TEST end at " << str << std::endl;
@@ -353,6 +353,5 @@ namespace dsn {
         }
     }
 }
-
 
 

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -92,6 +92,12 @@ namespace dsn {
 
         std::string get_last_component(const std::string& input, const char splitters[])
         {
+            if (splitters == nullptr)
+            {
+                derror("get_last_component got null splitters");
+                return input;
+            }
+
             int index = -1;
             const char* s = splitters;
 
@@ -112,6 +118,11 @@ namespace dsn {
         void split_args(const char* args, /*out*/ std::vector<std::string>& sargs, char splitter)
         {
             sargs.clear();
+            if (args == nullptr)
+            {
+                derror("split_args got null args");
+                return;
+            }
 
             std::string v(args);
 
@@ -147,6 +158,11 @@ namespace dsn {
         void split_args(const char* args, /*out*/ safe_vector<safe_string>& sargs, char splitter)
         {
             sargs.clear();
+            if (args == nullptr)
+            {
+                derror("split_args got null args");
+                return;
+            }
 
             safe_string v(args);
 
@@ -182,6 +198,11 @@ namespace dsn {
         void split_args(const char* args, /*out*/ std::list<std::string>& sargs, char splitter)
         {
             sargs.clear();
+            if (args == nullptr)
+            {
+                derror("split_args got null args");
+                return;
+            }
 
             std::string v(args);
 
@@ -217,6 +238,11 @@ namespace dsn {
         void split_args(const char* args, /*out*/ safe_list<safe_string>& sargs, char splitter)
         {
             sargs.clear();
+            if (args == nullptr)
+            {
+                derror("split_args got null args");
+                return;
+            }
 
             safe_string v(args);
 
@@ -261,6 +287,12 @@ namespace dsn {
 
         char* trim_string(char* s)
         {
+            if (s == nullptr)
+            {
+                derror("trim_string got null string");
+                return nullptr;
+            }
+
             while (*s != '\0' && (*s == ' ' || *s == '\t')) { s++; }
             char* r = s;
             s += strlen(s);
@@ -275,8 +307,25 @@ namespace dsn {
             return nanos;
         }
 
-        void time_ms_to_string(uint64_t ts_ms, char* str)
+        void time_ms_to_string(uint64_t ts_ms, char* str, size_t str_size)
         {
+            static const size_t kTimeStringBufferSize = sizeof("00:00:00.000");
+
+            if (str == nullptr)
+            {
+                derror("time_ms_to_string got null output string");
+                return;
+            }
+            if (str_size < kTimeStringBufferSize)
+            {
+                derror("time_ms_to_string got insufficient output string size = %zu", str_size);
+                if (str_size > 0)
+                {
+                    str[0] = '\0';
+                }
+                return;
+            }
+
             auto t = (time_t)(ts_ms / 1000);
 # if defined(_WIN32)
             auto ret = localtime(&t);
@@ -286,7 +335,7 @@ namespace dsn {
 # endif
             auto ms = static_cast<uint32_t>(ts_ms % 1000);
 
-            snprintf(str, 13, "%02d:%02d:%02d.%03u", ret->tm_hour, ret->tm_min, ret->tm_sec, ms);
+            snprintf(str, str_size, "%02d:%02d:%02d.%03u", ret->tm_hour, ret->tm_min, ret->tm_sec, ms);
         }
     }
 }
@@ -420,6 +469,8 @@ namespace dsn
         }
         else if (sz <= get_remaining_size())
         {
+            dassert(buffer != nullptr, "binary_reader::read got null buffer");
+
             memcpy((void*)buffer, _ptr, sz);
             _ptr += sz;
             _remaining_size -= sz;
@@ -434,6 +485,8 @@ namespace dsn
 
     bool binary_reader::next(const void** data, int* size)
     {
+        dassert(data != nullptr && size != nullptr, "binary_reader::next got null output parameter");
+
         if (get_remaining_size() > 0)
         {
             *data = (const void*)_ptr;
@@ -485,9 +538,11 @@ namespace dsn
 
     binary_writer::binary_writer(int reserveBufferSize)
     {
+        dassert(reserveBufferSize >= 0, "binary_writer got negative reserve buffer size");
         _total_size = 0;
         _buffers.reserve(1);
-        _reserved_size_per_buffer = (reserveBufferSize == 0) ? _reserved_size_per_buffer_static : reserveBufferSize;
+        _reserved_size_per_buffer =
+            (reserveBufferSize == 0) ? _reserved_size_per_buffer_static : reserveBufferSize;
         _current_buffer = nullptr;
         _current_offset = 0;
         _current_buffer_length = 0;
@@ -598,6 +653,12 @@ namespace dsn
 
     void binary_writer::write_empty(int sz)
     {
+        dassert(sz >= 0, "binary_writer::write_empty got negative size");
+        if (sz == 0)
+        {
+            return;
+        }
+
         int sz0 = sz;
         int rem_size = _current_buffer_length - _current_offset;
         if (rem_size >= sz)
@@ -614,6 +675,8 @@ namespace dsn
                 allocSize = sz;
 
             create_buffer(allocSize);
+            dassert(_current_buffer != nullptr && _current_buffer_length > 0,
+                    "binary_writer::write_empty failed to create buffer");
             _current_offset += sz;
         }
 
@@ -622,6 +685,13 @@ namespace dsn
 
     void binary_writer::write(const char* buffer, int sz)
     {
+        dassert(sz >= 0, "binary_writer::write got negative size");
+        if (sz == 0)
+        {
+            return;
+        }
+        dassert(buffer != nullptr, "binary_writer::write got null buffer");
+
         int rem_size = _current_buffer_length - _current_offset;
         if (rem_size >= sz)
         {
@@ -644,6 +714,8 @@ namespace dsn
                 allocSize = sz;
 
             create_buffer(allocSize);
+            dassert(_current_buffer != nullptr && _current_buffer_length > 0,
+                    "binary_writer::write failed to create buffer");
             memcpy((void*)(_current_buffer + _current_offset), buffer + rem_size, (size_t)sz);
             _current_offset += sz;
             _total_size += sz;
@@ -652,11 +724,15 @@ namespace dsn
 
     bool binary_writer::next(void** data, int* size)
     {
+        dassert(data != nullptr && size != nullptr, "binary_writer::next got null output parameter");
+
         int rem_size = _current_buffer_length - _current_offset;
         if (rem_size == 0)
         {
             create_buffer(_reserved_size_per_buffer);
             rem_size = _current_buffer_length;
+            dassert(_current_buffer != nullptr && rem_size > 0,
+                    "binary_writer::next failed to create buffer");
         }
 
         *size = rem_size;
@@ -668,7 +744,8 @@ namespace dsn
 
     bool binary_writer::backup(int count)
     {
-        dassert(count <= _current_offset, "currently we don't support backup before the last buffer's header");
+        dassert(count >= 0 && count <= _current_offset,
+                "currently we don't support backup before the last buffer's header");
         _current_offset -= count;
         _total_size -= count;
         return true;

--- a/src/dev/csharp/Clientlet.cs
+++ b/src/dev/csharp/Clientlet.cs
@@ -140,7 +140,7 @@ namespace dsn.dev.csharp
         {
             var idx = GlobalInterOpLookupTable.Put(callback);
             var task = Native.dsn_task_create(evt, _c_task_handler_holder, (IntPtr)idx, hash, callbackOwner?.tracker() ?? IntPtr.Zero);
-            Native.dsn_task_call(task, delay_milliseconds);
+            Logging.dassert(Native.dsn_task_call(task, delay_milliseconds), "dsn_task_call failed");
         }
 
         //
@@ -161,7 +161,7 @@ namespace dsn.dev.csharp
             var task = timer_interval_milliseconds == 0 ? Native.dsn_task_create(evt, _c_task_handler_holder, (IntPtr)idx, hash, callbackOwner?.tracker() ?? IntPtr.Zero) : Native.dsn_task_create_timer(evt, _c_timer_task_handler_holder, (IntPtr)idx, hash, timer_interval_milliseconds, callbackOwner?.tracker() ?? IntPtr.Zero);
 
             var ret = new SafeTaskHandle(task, idx);
-            Native.dsn_task_call(task, delay_milliseconds);
+            Logging.dassert(Native.dsn_task_call(task, delay_milliseconds), "dsn_task_call failed");
             return ret;
         }
 
@@ -174,7 +174,8 @@ namespace dsn.dev.csharp
             Logging.dassert(requestStream.IsFlushed(),
                 "RpcWriteStream must be flushed after write in the same thread");
 
-            Native.dsn_rpc_call_one_way(server.addr, requestStream.DangerousGetHandle());
+            var err = Native.dsn_rpc_call_one_way(server.addr, requestStream.DangerousGetHandle());
+            Logging.dassert(err == ErrorCode.ERR_OK, "dsn_rpc_call_one_way failed: " + new ErrorCode(err).ToString());
         }
 
         public static RpcReadStream RpcCallSync(
@@ -228,7 +229,13 @@ namespace dsn.dev.csharp
                 replyHash,
                 callbackOwner?.tracker() ?? IntPtr.Zero
                 );
-            Native.dsn_rpc_call(server.addr, task);
+            var err = Native.dsn_rpc_call(server.addr, task);
+            if (err != ErrorCode.ERR_OK)
+            {
+                var enqueueErr = Native.dsn_rpc_enqueue_response(task, err, IntPtr.Zero);
+                Logging.dassert(enqueueErr == ErrorCode.ERR_OK,
+                    "dsn_rpc_enqueue_response failed: " + new ErrorCode(enqueueErr).ToString());
+            }
         }
 
         //
@@ -256,7 +263,13 @@ namespace dsn.dev.csharp
                 );
 
             var ret = new SafeTaskHandle(task, idx);
-            Native.dsn_rpc_call(server.addr, task);
+            var err = Native.dsn_rpc_call(server.addr, task);
+            if (err != ErrorCode.ERR_OK)
+            {
+                var enqueueErr = Native.dsn_rpc_enqueue_response(task, err, IntPtr.Zero);
+                Logging.dassert(enqueueErr == ErrorCode.ERR_OK,
+                    "dsn_rpc_enqueue_response failed: " + new ErrorCode(enqueueErr).ToString());
+            }
             return ret;
         }
 
@@ -296,7 +309,13 @@ namespace dsn.dev.csharp
         {
             var idx = GlobalInterOpLookupTable.Put(callback);
             var task = Native.dsn_file_create_aio_task(callbackCode, _c_aio_handler_holder, (IntPtr)idx, hash, callbackOwner?.tracker() ?? IntPtr.Zero);
-            Native.dsn_file_read(hFile, buffer, count, offset, task);
+            var err = Native.dsn_file_read(hFile, buffer, count, offset, task);
+            if (err != ErrorCode.ERR_OK)
+            {
+                var enqueueErr = Native.dsn_file_task_enqueue(task, err, IntPtr.Zero);
+                Logging.dassert(enqueueErr == ErrorCode.ERR_OK,
+                    "dsn_file_task_enqueue failed: " + new ErrorCode(enqueueErr).ToString());
+            }
             return new SafeTaskHandle(task, idx);
         }
 
@@ -313,7 +332,13 @@ namespace dsn.dev.csharp
         {
             var idx = GlobalInterOpLookupTable.Put(callback);
             var task = Native.dsn_file_create_aio_task(callbackCode, _c_aio_handler_holder, (IntPtr)idx, hash, callbackOwner?.tracker() ?? IntPtr.Zero);
-            Native.dsn_file_write(hFile, buffer, count, offset, task);
+            var err = Native.dsn_file_write(hFile, buffer, count, offset, task);
+            if (err != ErrorCode.ERR_OK)
+            {
+                var enqueueErr = Native.dsn_file_task_enqueue(task, err, IntPtr.Zero);
+                Logging.dassert(enqueueErr == ErrorCode.ERR_OK,
+                    "dsn_file_task_enqueue failed: " + new ErrorCode(enqueueErr).ToString());
+            }
             return new SafeTaskHandle(task, idx);
         }
 
@@ -331,7 +356,13 @@ namespace dsn.dev.csharp
         {
             var idx = GlobalInterOpLookupTable.Put(callback);
             var task = Native.dsn_file_create_aio_task(callbackCode, _c_aio_handler_holder, (IntPtr)idx, hash, callbackOwner?.tracker() ?? IntPtr.Zero);
-            Native.dsn_file_copy_remote_files(remote, source_dir, files, dest_dir, overwrite, task);
+            var err = Native.dsn_file_copy_remote_files(remote, source_dir, files, dest_dir, overwrite, task);
+            if (err != ErrorCode.ERR_OK)
+            {
+                var enqueueErr = Native.dsn_file_task_enqueue(task, err, IntPtr.Zero);
+                Logging.dassert(enqueueErr == ErrorCode.ERR_OK,
+                    "dsn_file_task_enqueue failed: " + new ErrorCode(enqueueErr).ToString());
+            }
             return new SafeTaskHandle(task, idx);
         }
 
@@ -348,7 +379,13 @@ namespace dsn.dev.csharp
         {
             var idx = GlobalInterOpLookupTable.Put(callback);
             var task = Native.dsn_file_create_aio_task(callbackCode, _c_aio_handler_holder, (IntPtr)idx, hash, callbackOwner?.tracker() ?? IntPtr.Zero);
-            Native.dsn_file_copy_remote_directory(remote, source_dir, dest_dir, overwrite, task);
+            var err = Native.dsn_file_copy_remote_directory(remote, source_dir, dest_dir, overwrite, task);
+            if (err != ErrorCode.ERR_OK)
+            {
+                var enqueueErr = Native.dsn_file_task_enqueue(task, err, IntPtr.Zero);
+                Logging.dassert(enqueueErr == ErrorCode.ERR_OK,
+                    "dsn_file_task_enqueue failed: " + new ErrorCode(enqueueErr).ToString());
+            }
             return new SafeTaskHandle(task, idx);
         }            
     }

--- a/src/dev/csharp/NativeCalls.cs
+++ b/src/dev/csharp/NativeCalls.cs
@@ -348,7 +348,7 @@ namespace dsn.dev.csharp
             return dsn_register_app(app);
         }
 
-        public static int dsn_register_app_checker_managed(string name, dsn_checker_create_managed create, dsn_checker_apply apply)
+        public static bool dsn_register_app_checker_managed(string name, dsn_checker_create_managed create, dsn_checker_apply apply)
         {
             dsn_checker_create create2 = (name2, app_info, app_info_count) => 
             {
@@ -367,7 +367,7 @@ namespace dsn.dev.csharp
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern bool dsn_register_app(dsn_app app);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern int  dsn_register_app_checker(string name, dsn_checker_create create, dsn_checker_apply apply);
+        public static extern bool dsn_register_app_checker(string name, dsn_checker_create create, dsn_checker_apply apply);
         [DllImport(DSN_CORE_DLL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern bool dsn_mimic_app(string app_name, int index); // index starts from 1
         [DllImport(DSN_CORE_DLL, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi), SuppressUnmanagedCodeSecurity]

--- a/src/dev/csharp/NativeCalls.cs
+++ b/src/dev/csharp/NativeCalls.cs
@@ -510,7 +510,7 @@ namespace dsn.dev.csharp
         // common task 
         //
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void        dsn_task_call(dsn_task_t task, int delay_milliseconds);
+        public static extern bool        dsn_task_call(dsn_task_t task, int delay_milliseconds);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern bool        dsn_task_cancel(dsn_task_t task, bool wait_until_finished);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
@@ -637,13 +637,13 @@ namespace dsn.dev.csharp
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern void          dsn_msg_query_request(dsn_message_t msg, out int ptimeout_milliseconds, out int phash);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void          dsn_msg_write_next(dsn_message_t msg, out IntPtr ptr, out size_t size, size_t min_size);
+        public static extern bool          dsn_msg_write_next(dsn_message_t msg, out IntPtr ptr, out size_t size, size_t min_size);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void          dsn_msg_write_commit(dsn_message_t msg, size_t size);
+        public static extern bool          dsn_msg_write_commit(dsn_message_t msg, size_t size);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern bool          dsn_msg_read_next(dsn_message_t msg, out IntPtr ptr, out size_t size);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void          dsn_msg_read_commit(dsn_message_t msg, size_t size);
+        public static extern bool          dsn_msg_read_commit(dsn_message_t msg, size_t size);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern size_t        dsn_msg_body_size(dsn_message_t msg);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]

--- a/src/dev/csharp/NativeCalls.cs
+++ b/src/dev/csharp/NativeCalls.cs
@@ -661,17 +661,17 @@ namespace dsn.dev.csharp
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern dsn_task_t     dsn_rpc_create_response_task(dsn_message_t request, dsn_rpc_response_handler_t cb, IntPtr param, int reply_thread_hash, dsn_task_tracker_t tracker = default(dsn_task_tracker_t));
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void          dsn_rpc_call(dsn_address_t server, dsn_task_t rpc_call);
+        public static extern dsn_error_t   dsn_rpc_call(dsn_address_t server, dsn_task_t rpc_call);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern dsn_message_t dsn_rpc_call_wait(dsn_address_t server, dsn_message_t request); // returned msg must be explicitly msg_release_ref
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void          dsn_rpc_call_one_way(dsn_address_t server, dsn_message_t request);
+        public static extern dsn_error_t   dsn_rpc_call_one_way(dsn_address_t server, dsn_message_t request);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void          dsn_rpc_reply(dsn_message_t response, dsn_error_t err);
+        public static extern dsn_error_t   dsn_rpc_reply(dsn_message_t response, dsn_error_t err);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern dsn_message_t dsn_rpc_get_response(dsn_task_t rpc_call); // returned msg must be explicitly msg_release_ref
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void          dsn_rpc_enqueue_response(dsn_task_t rpc_call, dsn_error_t err, dsn_message_t response);
+        public static extern dsn_error_t   dsn_rpc_enqueue_response(dsn_task_t rpc_call, dsn_error_t err, dsn_message_t response);
 
         //------------------------------------------------------------------------------
         //
@@ -685,17 +685,17 @@ namespace dsn.dev.csharp
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern dsn_task_t   dsn_file_create_aio_task(dsn_task_code_t code, dsn_aio_handler_t cb, IntPtr param, int hash, dsn_task_tracker_t tracker = default(dsn_task_tracker_t));
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void         dsn_file_read(dsn_handle_t file, byte[] buffer, int count, UInt64 offset, dsn_task_t cb);
+        public static extern dsn_error_t  dsn_file_read(dsn_handle_t file, byte[] buffer, int count, UInt64 offset, dsn_task_t cb);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void         dsn_file_write(dsn_handle_t file, byte[] buffer, int count, UInt64 offset, dsn_task_t cb);
+        public static extern dsn_error_t  dsn_file_write(dsn_handle_t file, byte[] buffer, int count, UInt64 offset, dsn_task_t cb);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void         dsn_file_copy_remote_directory(dsn_address_t remote, string source_dir, string dest_dir, bool overwrite, dsn_task_t cb);
+        public static extern dsn_error_t  dsn_file_copy_remote_directory(dsn_address_t remote, string source_dir, string dest_dir, bool overwrite, dsn_task_t cb);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void         dsn_file_copy_remote_files(dsn_address_t remote, string source_dir, string[] source_files, string dest_dir, bool overwrite, dsn_task_t cb);
+        public static extern dsn_error_t  dsn_file_copy_remote_files(dsn_address_t remote, string source_dir, string[] source_files, string dest_dir, bool overwrite, dsn_task_t cb);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
         public static extern size_t       dsn_file_get_io_size(dsn_task_t cb_task);
         [DllImport(DSN_CORE_DLL, CallingConvention=CallingConvention.Cdecl, CharSet=CharSet.Ansi), SuppressUnmanagedCodeSecurity]
-        public static extern void         dsn_file_task_enqueue(dsn_task_t cb_task, dsn_error_t err, size_t size);
+        public static extern dsn_error_t  dsn_file_task_enqueue(dsn_task_t cb_task, dsn_error_t err, size_t size);
 
         //------------------------------------------------------------------------------
         //

--- a/src/dev/csharp/RpcStream.cs
+++ b/src/dev/csharp/RpcStream.cs
@@ -162,8 +162,9 @@ namespace dsn.dev.csharp
 
         private void PrepareWriteBuffer(int minSize)
         {
-            Native.dsn_msg_write_next(_msg.DangerousGetHandle(),
-                out _currentBuffer, out _currentBufferLength, (IntPtr)minSize);
+            Logging.dassert(Native.dsn_msg_write_next(_msg.DangerousGetHandle(),
+                out _currentBuffer, out _currentBufferLength, (IntPtr)minSize),
+                "dsn_msg_write_next failed");
 
             _currentWriteOffset = 0;
         }
@@ -172,7 +173,8 @@ namespace dsn.dev.csharp
         {
             if (_currentWriteOffset > 0)
             {
-                Native.dsn_msg_write_commit(_msg.DangerousGetHandle(), (IntPtr)_currentWriteOffset);
+                Logging.dassert(Native.dsn_msg_write_commit(_msg.DangerousGetHandle(), (IntPtr)_currentWriteOffset),
+                    "dsn_msg_write_commit failed");
             }
             _currentWriteOffset = 0;
             _currentBufferLength = IntPtr.Zero;
@@ -220,7 +222,8 @@ namespace dsn.dev.csharp
         public RpcReadStream(IntPtr msg, bool owner)
             : base(msg, owner, true)
         {
-            Native.dsn_msg_read_next(msg, out _buffer, out _length);
+            Logging.dassert(Native.dsn_msg_read_next(msg, out _buffer, out _length),
+                "dsn_msg_read_next failed");
             Native.dsn_msg_read_commit(msg, _length);
 
             _pos = 0;

--- a/src/dev/csharp/Serverlet.cs
+++ b/src/dev/csharp/Serverlet.cs
@@ -57,7 +57,8 @@ namespace dsn.dev.csharp
             Logging.dassert(_respStream.IsFlushed(),
                 "RpcWriteStream must be flushed after write in the same thread");
 
-            Native.dsn_rpc_reply(_respStream.DangerousGetHandle(), ErrorCode.ERR_OK);
+            var err = Native.dsn_rpc_reply(_respStream.DangerousGetHandle(), ErrorCode.ERR_OK);
+            Logging.dassert(err == ErrorCode.ERR_OK, "dsn_rpc_reply failed: " + new ErrorCode(err).ToString());
         }
 
         private RpcWriteStream _respStream;
@@ -142,7 +143,8 @@ namespace dsn.dev.csharp
             Logging.dassert(response.IsFlushed(),
                 "RpcWriteStream must be flushed after write in the same thread");
 
-            Native.dsn_rpc_reply(response.DangerousGetHandle(), ErrorCode.ERR_OK);
+            var err = Native.dsn_rpc_reply(response.DangerousGetHandle(), ErrorCode.ERR_OK);
+            Logging.dassert(err == ErrorCode.ERR_OK, "dsn_rpc_reply failed: " + new ErrorCode(err).ToString());
         }
 
         public string Name() { return _name; }

--- a/src/dev/utility/configuration.cpp
+++ b/src/dev/utility/configuration.cpp
@@ -404,6 +404,12 @@ void configuration::get_all_keys(const char* section, std::vector<const char*>& 
 {
     std::multimap<int, const char*> ordered_keys;
     keys.clear();
+    if (section == nullptr || section[0] == '\0')
+    {
+        fprintf(stderr, "ERROR: configuration section cannot be null or empty\n");
+        return;
+    }
+
     auto it = _configs.find(section);
     if (it != _configs.end())
     {
@@ -421,6 +427,37 @@ void configuration::get_all_keys(const char* section, std::vector<const char*>& 
 
 bool configuration::get_string_value_internal(const char* section, const char* key, const char* default_value, const char** ov, const char* dsptr)
 {
+    if (ov == nullptr)
+    {
+        fprintf(stderr, "ERROR: configuration output value cannot be null\n");
+        return false;
+    }
+
+    if (section == nullptr || section[0] == '\0')
+    {
+        fprintf(stderr, "ERROR: configuration section cannot be null or empty\n");
+        return false;
+    }
+
+    if (key == nullptr || key[0] == '\0')
+    {
+        fprintf(stderr, "ERROR: configuration key cannot be null or empty\n");
+        return false;
+    }
+
+    if (default_value == nullptr)
+    {
+        fprintf(stderr, "ERROR: configuration default value cannot be null\n");
+        *ov = nullptr;
+        return false;
+    }
+
+    if (dsptr == nullptr)
+    {
+        dsptr = "";
+    }
+
+    *ov = default_value;
     _lock.lock();
 
     std::map<std::string, conf*> *ps = nullptr;

--- a/src/plugins/apps.echo/echo.main.cpp
+++ b/src/plugins/apps.echo/echo.main.cpp
@@ -38,9 +38,12 @@
 static void dsn_app_registration_echo()
 {
     // register all possible service apps
-    dsn::register_app< ::dsn::example::echo_server_app>("server");
-    dsn::register_app< ::dsn::example::echo_client_app>("client");
-    dsn::register_app< ::dsn::example::echo_perf_test_client_app>("client.perf.echo");
+    dassert(dsn::register_app< ::dsn::example::echo_server_app>("server"),
+            "register server app failed");
+    dassert(dsn::register_app< ::dsn::example::echo_client_app>("client"),
+            "register client app failed");
+    dassert(dsn::register_app< ::dsn::example::echo_perf_test_client_app>("client.perf.echo"),
+            "register client.perf.echo app failed");
 }
 
 int main(int argc, char** argv)

--- a/src/plugins/apps.skv/simple_kv.main.cpp
+++ b/src/plugins/apps.skv/simple_kv.main.cpp
@@ -40,10 +40,15 @@
 static void dsn_app_registration_simple_kv()
 {
     // register all possible services
-    dsn::register_app_with_type_1_replication_support< ::dsn::replication::application::simple_kv_service_impl>("simple_kv");
+    dassert(dsn::register_app_with_type_1_replication_support<
+                ::dsn::replication::application::simple_kv_service_impl>("simple_kv"),
+            "register simple_kv type-1 replication app failed");
     
-    dsn::register_app< ::dsn::replication::application::simple_kv_client_app>("simple_kv.client");
-    dsn::register_app< ::dsn::replication::application::simple_kv_perf_test_client_app>("simple_kv.client.perf");
+    dassert(dsn::register_app< ::dsn::replication::application::simple_kv_client_app>("simple_kv.client"),
+            "register simple_kv.client app failed");
+    dassert(dsn::register_app< ::dsn::replication::application::simple_kv_perf_test_client_app>(
+                "simple_kv.client.perf"),
+            "register simple_kv.client.perf app failed");
 }
 
 # if 1

--- a/src/plugins/tools.common/profiler_command.cpp
+++ b/src/plugins/tools.common/profiler_command.cpp
@@ -580,7 +580,7 @@ namespace dsn {
                 }
 
                 char str[24];
-                ::dsn::utils::time_ms_to_string(dsn_now_ns() / 1000000, str);
+                ::dsn::utils::time_ms_to_string(dsn_now_ns() / 1000000, str, sizeof(str));
 
                 std::vector<nv_pair> data;
 
@@ -733,7 +733,7 @@ namespace dsn {
             else if (args[0] == "time")
             {
                 char str[24];
-                ::dsn::utils::time_ms_to_string(dsn_now_ns() / 1000000, str);
+                ::dsn::utils::time_ms_to_string(dsn_now_ns() / 1000000, str, sizeof(str));
                 ss << str;
                 return ss.str().c_str();
             }

--- a/src/plugins/tools.common/simple_logger.cpp
+++ b/src/plugins/tools.common/simple_logger.cpp
@@ -50,7 +50,7 @@ namespace dsn {
                 ts = dsn_now_ns();
 
             char str[24];
-            ::dsn::utils::time_ms_to_string(ts/1000000, str);
+            ::dsn::utils::time_ms_to_string(ts / 1000000, str, sizeof(str));
 
             int tid = ::dsn::utils::get_current_tid(); 
 

--- a/src/tests/idl/resources/repo/cpp/counter.main.cpp
+++ b/src/tests/idl/resources/repo/cpp/counter.main.cpp
@@ -20,9 +20,12 @@ void mysleep()
 void dsn_app_registration_counter()
 {
     // register all possible service apps
-    dsn::register_app< ::dsn::example::counter_server_app>("counter");
-    dsn::register_app< ::dsn::example::counter_client_app>("counter.client");
-    dsn::register_app< ::dsn::example::counter_perf_test_client_app>("counter.client.perf");
+    dassert(dsn::register_app< ::dsn::example::counter_server_app>("counter"),
+            "register counter app failed");
+    dassert(dsn::register_app< ::dsn::example::counter_client_app>("counter.client"),
+            "register counter.client app failed");
+    dassert(dsn::register_app< ::dsn::example::counter_perf_test_client_app>("counter.client.perf"),
+            "register counter.client.perf app failed");
 }
 
 # ifndef DSN_RUN_USE_SVCHOST

--- a/src/tools/cli/cli.main.cpp
+++ b/src/tools/cli/cli.main.cpp
@@ -38,7 +38,7 @@
 int main(int argc, char** argv)
 {
     // register all possible service apps
-    dsn::register_app< ::dsn::service::cli>("cli");
+    dassert(dsn::register_app< ::dsn::service::cli>("cli"), "register cli app failed");
 
     // specify what services and tools will run in config file, then run
     dsn_run_config("config.ini", true);


### PR DESCRIPTION
## Summary

Strengthen rDSN public API robustness by validating user/application-provided parameters before dereferencing or forwarding them.

This PR focuses on C/C++ public API boundaries and wrapper helpers, including task, RPC, file, app registration, clientlet, serialization, blob/binary IO, and utility APIs. Invalid inputs now fail explicitly with appropriate error codes, null returns, logging, or assertions depending on whether the API is a recoverable public boundary or an internal invariant-style helper.

## Key changes

- Add null/invalid parameter checks for public `dsn_*` C APIs.
- Make C++ wrapper helpers handle failed native API calls instead of assuming success.
- Keep invariant-style low-level helpers fail-fast with `dassert`, including blob, binary reader/writer, serialization, RPC streams, serverlet reply paths, and task helper operations.
- Make app registration return and propagate failure instead of silently ignoring registration errors.
- Normalize `dsn_error_t` vs `dsn::error_code` returns:
  - `dsn_error_t` APIs return `ERR_*.get()`.
  - `dsn::error_code` APIs return `ERR_*`.
- Update external submodule pointers after corresponding compatibility fixes were merged upstream.
- Add focused invalid-parameter coverage for the changed public API surfaces.

## Validation

Tested successfully on:
- macOS machine
- Ubuntu machine