### PR TITLE
Add missing standard header includes

### DIFF
--- a/include/dsn/cpp/blob.h
+++ b/include/dsn/cpp/blob.h
@@ -40,6 +40,8 @@
 # include <stdexcept>
 # include <vector>
 # include <cstring>
+# include <utility>
+# include <string>
 
 #ifdef DSN_USE_THRIFT_SERIALIZATION
 # include <thrift/protocol/TProtocol.h>

--- a/include/dsn/cpp/cli/cli_types.h
+++ b/include/dsn/cpp/cli/cli_types.h
@@ -8,6 +8,9 @@
 #define cli_TYPES_H
 
 #include <iosfwd>
+#include <cstdint>
+#include <string>
+#include <vector>
 
 #include <thrift/Thrift.h>
 #include <thrift/TApplicationException.h>

--- a/include/dsn/cpp/clientlet.h
+++ b/include/dsn/cpp/clientlet.h
@@ -39,6 +39,7 @@
 # include <dsn/cpp/task_helper.h>
 # include <dsn/cpp/function_traits.h>
 # include <utility>
+# include <chrono>
 
 namespace dsn
 { 

--- a/include/dsn/cpp/function_traits.h
+++ b/include/dsn/cpp/function_traits.h
@@ -35,6 +35,8 @@
 #pragma once
 
 #include <type_traits>
+#include <functional>
+#include <tuple>
 
 namespace dsn {
 template <typename T>

--- a/include/dsn/cpp/json_helper.h
+++ b/include/dsn/cpp/json_helper.h
@@ -43,6 +43,7 @@
 #include <string>
 #include <type_traits>
 #include <cctype>
+#include <utility>
 #include <dsn/utility/autoref_ptr.h>
 #include <dsn/cpp/auto_codes.h>
 #include <dsn/cpp/utils.h>

--- a/include/dsn/cpp/layer2_handler.h
+++ b/include/dsn/cpp/layer2_handler.h
@@ -37,6 +37,7 @@
 
 # include <dsn/service_api_cpp.h>
 # include <dsn/cpp/service_app.h>
+# include <cstring>
 
  /*
   base contract for the layer2 frameworks on server side

--- a/include/dsn/cpp/optional.h
+++ b/include/dsn/cpp/optional.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include <utility>
+
 namespace dsn
 {
 struct none_placeholder_t {};

--- a/include/dsn/cpp/perf_test_helper.h
+++ b/include/dsn/cpp/perf_test_helper.h
@@ -40,6 +40,7 @@
 # include <sstream>
 # include <atomic>
 # include <vector>
+# include <chrono>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/include/dsn/cpp/replicated_service_app.h
+++ b/include/dsn/cpp/replicated_service_app.h
@@ -36,6 +36,7 @@
 # pragma once
 
 # include <dsn/cpp/service_app.h>
+# include <cstring>
 
 namespace dsn 
 {

--- a/include/dsn/cpp/serialization.h
+++ b/include/dsn/cpp/serialization.h
@@ -38,6 +38,7 @@
 # include <string>
 # include <sstream>
 # include <stdexcept>
+# include <typeinfo>
 # include <dsn/cpp/serialization_helper/dsn_types.h>
 # include <dsn/cpp/rpc_stream.h>
 

--- a/include/dsn/cpp/serialization_helper/dsn.layer2_types.h
+++ b/include/dsn/cpp/serialization_helper/dsn.layer2_types.h
@@ -8,6 +8,10 @@
 #define dsn_layer2_TYPES_H
 
 #include <iosfwd>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <map>
 
 #include <thrift/Thrift.h>
 #include <thrift/TApplicationException.h>

--- a/include/dsn/cpp/serialization_helper/thrift_helper.h
+++ b/include/dsn/cpp/serialization_helper/thrift_helper.h
@@ -46,6 +46,7 @@
 # include <thrift/transport/TVirtualTransport.h>
 # include <thrift/TApplicationException.h>
 # include <cstdio>
+# include <cstring>
 # include <type_traits>
 
 using namespace ::apache::thrift::transport;

--- a/include/dsn/cpp/service_app.h
+++ b/include/dsn/cpp/service_app.h
@@ -40,6 +40,7 @@
 # include <dsn/cpp/address.h>
 # include <vector>
 # include <string>
+# include <cstring>
 
 namespace dsn 
 {

--- a/include/dsn/cpp/task_helper.h
+++ b/include/dsn/cpp/task_helper.h
@@ -48,6 +48,8 @@
 # include <set>
 # include <map>
 # include <thread>
+# include <utility>
+# include <chrono>
 # include <dsn/cpp/optional.h>
 
 namespace dsn 

--- a/include/dsn/tool-api/network.h
+++ b/include/dsn/tool-api/network.h
@@ -42,6 +42,7 @@
 # include <dsn/utility/exp_delay.h>
 # include <dsn/utility/dlib.h>
 # include <atomic>
+# include <utility>
 
 namespace dsn {
 

--- a/include/dsn/tool-api/perf_counter.h
+++ b/include/dsn/tool-api/perf_counter.h
@@ -42,6 +42,7 @@
 # include <memory>
 # include <sstream>
 # include <vector>
+# include <utility>
 
 namespace dsn {
 

--- a/include/dsn/tool-api/task.h
+++ b/include/dsn/tool-api/task.h
@@ -44,6 +44,7 @@
 # include <dsn/cpp/callocator.h>
 # include <dsn/cpp/auto_codes.h>
 # include <dsn/cpp/utils.h>
+# include <cstring>
 
 namespace dsn 
 {

--- a/include/dsn/utility/exp_delay.h
+++ b/include/dsn/utility/exp_delay.h
@@ -38,6 +38,7 @@
 # include <dsn/utility/singleton.h>
 # include <vector>
 # include <cassert>
+# include <cstring>
 
 namespace dsn
 {

--- a/include/dsn/utility/extensible_object.h
+++ b/include/dsn/utility/extensible_object.h
@@ -39,6 +39,7 @@
 # include <vector>
 # include <atomic>
 # include <cassert>
+# include <cstring>
 
 namespace dsn {
 /*!

--- a/include/dsn/utility/factory_store.h
+++ b/include/dsn/utility/factory_store.h
@@ -37,6 +37,7 @@
 
 # include <dsn/utility/singleton_store.h>
 # include <cstdio>
+# include <typeinfo>
 
 namespace dsn { 
     

--- a/include/dsn/utility/singleton_store.h
+++ b/include/dsn/utility/singleton_store.h
@@ -39,6 +39,7 @@
 # include <dsn/utility/synchronize.h>
 # include <map>
 # include <vector>
+# include <utility>
 
 namespace dsn { namespace utils {
 

--- a/src/core/src/address.cpp
+++ b/src/core/src/address.cpp
@@ -52,10 +52,6 @@
 # include <net/if.h>
 # include <unistd.h>
 
-# if defined(__FreeBSD__)
-# include <netinet/in.h>
-# endif
-
 # endif
 
 # include <dsn/utility/ports.h>
@@ -65,6 +61,7 @@
 # include "group_address.h"
 # include "uri_address.h"
 # include "c_api_guard.h"
+# include <cstring>
 
 namespace dsn
 {

--- a/src/core/src/address.test.cpp
+++ b/src/core/src/address.test.cpp
@@ -36,6 +36,7 @@
 # include <dsn/cpp/address.h>
 # include "group_address.h"
 # include <gtest/gtest.h>
+# include <cstring>
 
 using namespace ::dsn;
 

--- a/src/core/src/aio.perf.test.cpp
+++ b/src/core/src/aio.perf.test.cpp
@@ -33,6 +33,7 @@
  */
 
 #include <cinttypes>
+#include <chrono>
 #include <gtest/gtest.h>
 #include <dsn/service_api_cpp.h>
 #include <dsn/cpp/utils.h>

--- a/src/core/src/aio.test.cpp
+++ b/src/core/src/aio.test.cpp
@@ -38,6 +38,7 @@
 # include <dsn/cpp/utils.h>
 # include <gtest/gtest.h>
 # include <dsn/cpp/test_utils.h>
+# include <cstring>
 
 using namespace ::dsn;
 

--- a/src/core/src/app_manager.cpp
+++ b/src/core/src/app_manager.cpp
@@ -37,6 +37,7 @@
 # include "rpc_engine.h"
 # include <dsn/utility/singleton_store.h>
 # include "c_api_guard.h"
+# include <cstring>
 
 DSN_API bool dsn_register_app(dsn_app* app_type)
 {

--- a/src/core/src/command_manager.cpp
+++ b/src/core/src/command_manager.cpp
@@ -39,6 +39,8 @@
 # include <iostream>
 # include <thread>
 # include <sstream>
+# include <cstring>
+# include <chrono>
 # include <dsn/cpp/utils.h>
 # include <dsn/cpp/rpc_stream.h>
 # include "service_engine.h"

--- a/src/core/src/command_manager.test.cpp
+++ b/src/core/src/command_manager.test.cpp
@@ -36,6 +36,8 @@
 # include "../../tools/cli/cli.client.h"
 # include <dsn/tool-api/command.h>
 # include <gtest/gtest.h>
+# include <tuple>
+# include <chrono>
 
 using namespace ::dsn;
 

--- a/src/core/src/configuration.test.cpp
+++ b/src/core/src/configuration.test.cpp
@@ -38,6 +38,7 @@
 # include <gtest/gtest.h>
 # include <algorithm>
 # include <fstream>
+# include <cstring>
 
 using namespace ::dsn;
 

--- a/src/core/src/crc.h
+++ b/src/core/src/crc.h
@@ -1,6 +1,7 @@
 # pragma once
 
 # include <cstdint>
+# include <cstdio>
 
 namespace dsn { namespace utils {
 

--- a/src/core/src/global_config.cpp
+++ b/src/core/src/global_config.cpp
@@ -40,6 +40,7 @@
 # include <exception>
 # include <thread>
 # include <vector>
+# include <cstring>
 # include <dsn/cpp/utils.h>
 # include <dsn/tool-api/task_spec.h>
 # include <dsn/tool-api/network.h>

--- a/src/core/src/logger.perf.test.cpp
+++ b/src/core/src/logger.perf.test.cpp
@@ -38,6 +38,7 @@
 # include <dsn/utility/factory_store.h>
 # include <dsn/tool_api.h>
 # include <dsn/cpp/test_utils.h>
+# include <cstring>
 
 using namespace ::dsn;
 const char str[64] = "this is a logging test for log %010d @ thread %010d";

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -60,6 +60,8 @@
 # include <cstdio>
 # include <exception>
 # include <fstream>
+# include <cstring>
+# include <chrono>
 
 # if defined(_WIN32)
 # include <tlhelp32.h>

--- a/src/core/src/message_parser.cpp
+++ b/src/core/src/message_parser.cpp
@@ -37,6 +37,12 @@
 # include <dsn/service_api_c.h>
 # include <exception>
 # include <limits>
+# include <cstring>
+# include <cstdio>
+# include <cctype>
+# include <string>
+# include <vector>
+# include <unordered_map>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/core/src/network.cpp
+++ b/src/core/src/network.cpp
@@ -41,6 +41,8 @@
 # include <dsn/utility/factory_store.h>
 # include "message_parser_manager.h"
 # include "rpc_engine.h"
+# include <cstring>
+# include <utility>
 
 # if defined(__TITLE__)
 # undef __TITLE__

--- a/src/core/src/perf_counter.test.cpp
+++ b/src/core/src/perf_counter.test.cpp
@@ -37,6 +37,7 @@
 #include <thread>
 #include <cmath>
 #include <vector>
+#include <chrono>
 
 using namespace dsn;
 using namespace dsn::tools;

--- a/src/core/src/perf_counters.cpp
+++ b/src/core/src/perf_counters.cpp
@@ -42,6 +42,8 @@
 # include "service_engine.h"
 # include "perf_counters.h"
 # include "c_api_guard.h"
+# include <cstring>
+# include <tuple>
 
 DSN_API dsn_handle_t dsn_perf_counter_create(const char* section, const char* name, dsn_perf_counter_type_t type, const char* description)
 {

--- a/src/core/src/priority_queue.test.cpp
+++ b/src/core/src/priority_queue.test.cpp
@@ -37,6 +37,7 @@
 # include <gtest/gtest.h>
 # include <atomic>
 # include <thread>
+# include <chrono>
 
 using namespace ::dsn::utils;
 

--- a/src/core/src/rpc.perf.test.cpp
+++ b/src/core/src/rpc.perf.test.cpp
@@ -35,6 +35,7 @@
 #include <gtest/gtest.h>
 #include <dsn/cpp/test_utils.h>
 #include <dsn/service_api_cpp.h>
+#include <chrono>
 
 void rpc_testcase(uint64_t block_size, size_t concurrency)
 {

--- a/src/core/src/rpc.test.cpp
+++ b/src/core/src/rpc.test.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 #include <string>
 #include <queue>
+#include <chrono>
 
 typedef std::function<void(error_code, dsn_message_t, dsn_message_t)> rpc_reply_handler;
 

--- a/src/core/src/rpc_engine.cpp
+++ b/src/core/src/rpc_engine.cpp
@@ -53,6 +53,7 @@
 # include <dsn/tool-api/task_queue.h>
 # include <dsn/cpp/serialization.h>
 # include <set>
+# include <chrono>
 # include <dsn/cpp/layer2_handler.h>
 
 # if defined(__TITLE__)

--- a/src/core/src/rpc_engine.h
+++ b/src/core/src/rpc_engine.h
@@ -41,6 +41,7 @@
 # include <dsn/tool-api/global_config.h>
 # include <dsn/utility/configuration.h>
 # include <atomic>
+# include <utility>
 
 namespace dsn {
 

--- a/src/core/src/rpc_message.corrupt.test.cpp
+++ b/src/core/src/rpc_message.corrupt.test.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <chrono>
 #include <dsn/cpp/test_utils.h>
 
 //this only works with the fault injector

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -39,6 +39,8 @@
 # include <dsn/tool-api/message_parser.h>
 # include <cctype> // for isprint()
 # include <exception>
+# include <cstring>
+# include <utility>
 
 # include "task_engine.h"
 # include "transient_memory.h"

--- a/src/core/src/rpc_message.test.cpp
+++ b/src/core/src/rpc_message.test.cpp
@@ -38,6 +38,7 @@
 # include <dsn/tool-api/rpc_message.h>
 # include <gtest/gtest.h>
 # include "transient_memory.h"
+# include <cstring>
 
 using namespace ::dsn;
 

--- a/src/core/src/semaphore.test.cpp
+++ b/src/core/src/semaphore.test.cpp
@@ -37,6 +37,7 @@
 # include <gtest/gtest.h>
 # include <atomic>
 # include <thread>
+# include <chrono>
 
 TEST(core, Semaphore)
 {

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -59,6 +59,7 @@
 # include "library_utils.h"
 # include "c_api_guard.h"
 # include <fstream>
+# include <cstring>
 
 # if defined(_WIN32)
 # include <tlhelp32.h>

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -40,6 +40,8 @@
 # include <gtest/gtest.h>
 # include <string>
 # include <thread>
+# include <cstring>
+# include <chrono>
 # include "service_engine.h"
 # include <dsn/cpp/test_utils.h>
 

--- a/src/core/src/service_engine.h
+++ b/src/core/src/service_engine.h
@@ -40,6 +40,7 @@
 # include <dsn/tool-api/global_config.h>
 # include <dsn/cpp/auto_codes.h>
 # include <sstream>
+# include <cstring>
 # include <dsn/utility/synchronize.h>
 # include "app_manager.h"
 

--- a/src/core/src/task.cpp
+++ b/src/core/src/task.cpp
@@ -46,6 +46,7 @@
 # include "service_engine.h"
 # include "disk_engine.h"
 # include "rpc_engine.h"
+# include <cstring>
 
 
 # ifdef __TITLE__

--- a/src/core/src/task_queue.perf.test.cpp
+++ b/src/core/src/task_queue.perf.test.cpp
@@ -38,6 +38,7 @@
 #include <dsn/cpp/test_utils.h>
 #include <mutex>
 #include <condition_variable>
+#include <chrono>
 
 //worker = 1
 DEFINE_THREAD_POOL_CODE(THREAD_POOL_TEST_TASK_QUEUE_1);

--- a/src/core/src/task_spec.cpp
+++ b/src/core/src/task_spec.cpp
@@ -41,6 +41,7 @@
 # include <sstream>
 # include <vector>
 # include <thread>
+# include <cstring>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/core/src/task_worker.cpp
+++ b/src/core/src/task_worker.cpp
@@ -37,6 +37,8 @@
 # include "task_engine.h"
 # include <sstream>
 # include <errno.h>
+# include <cstring>
+# include <chrono>
 
 # ifdef _WIN32
 

--- a/src/core/src/transient_memory.cpp
+++ b/src/core/src/transient_memory.cpp
@@ -37,6 +37,8 @@
 
 # include <cstddef>
 # include <cstdint>
+# include <cstdlib>
+# include <memory>
 
 # if defined(__TITLE__)
 # undef __TITLE__

--- a/src/core/src/uri_address.cpp
+++ b/src/core/src/uri_address.cpp
@@ -43,6 +43,8 @@
 # include <dsn/tool-api/task.h>
 # include <dsn/cpp/utils.h>
 # include <cstdint>
+# include <cstring>
+# include <utility>
 
 namespace dsn
 {

--- a/src/core/src/utils.test.cpp
+++ b/src/core/src/utils.test.cpp
@@ -42,6 +42,8 @@
 # include <limits>
 # include <sstream>
 # include <string>
+# include <cstring>
+# include <utility>
 # if defined(_WIN32)
 # include <basetsd.h>
 # else

--- a/src/dev/cpp/dsn.layer2_types.cpp
+++ b/src/dev/cpp/dsn.layer2_types.cpp
@@ -8,6 +8,10 @@
 
 #include <algorithm>
 #include <ostream>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <map>
 
 #include <thrift/TToString.h>
 

--- a/src/dev/cpp/file_utils.cpp
+++ b/src/dev/cpp/file_utils.cpp
@@ -37,6 +37,7 @@
 # include <dsn/cpp/utils.h>
 # include <sys/stat.h>
 # include <errno.h>
+# include <cstring>
 
 # ifdef _WIN32
 

--- a/src/dev/cpp/perf_test_helper.cpp
+++ b/src/dev/cpp/perf_test_helper.cpp
@@ -34,6 +34,9 @@
  */
 # include <dsn/cpp/perf_test_helper.h>
 # include <fstream>
+# include <cstring>
+# include <thread>
+# include <chrono>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/dev/cpp/utils.cpp
+++ b/src/dev/cpp/utils.cpp
@@ -48,6 +48,7 @@
 # include <chrono>
 # include <cstring>
 # include <stdexcept>
+# include <ctime>
 # include <sys/types.h>
 # include <sys/stat.h>
 # include <random>

--- a/src/dev/utility/configuration.cpp
+++ b/src/dev/utility/configuration.cpp
@@ -39,6 +39,8 @@
 # include <errno.h>
 # include <iostream>
 # include <algorithm>
+# include <cstring>
+# include <utility>
 
 namespace dsn {
 

--- a/src/dev/utility/join_point.cpp
+++ b/src/dev/utility/join_point.cpp
@@ -36,6 +36,7 @@
 # include <dsn/utility/join_point.h>
 # include <cassert>
 # include <cstdio>
+# include <cstring>
 
 namespace dsn
 {

--- a/src/plugins/apps.echo/echo.app.example.h
+++ b/src/plugins/apps.echo/echo.app.example.h
@@ -37,6 +37,8 @@
 # include "echo.client.perf.h"
 # include "echo.server.h"
 # include <cstdint>
+# include <chrono>
+# include <iostream>
 # include <dsn/cpp/utils.h>
 
 namespace dsn { namespace example {

--- a/src/plugins/apps.echo/echo.client.h
+++ b/src/plugins/apps.echo/echo.client.h
@@ -35,6 +35,10 @@
 # pragma once
 # include "echo.code.definition.h"
 # include <iostream>
+# include <cstdint>
+# include <utility>
+# include <string>
+# include <chrono>
 
 
 namespace dsn { namespace example {

--- a/src/plugins/apps.echo/echo.client.perf.h
+++ b/src/plugins/apps.echo/echo.client.perf.h
@@ -35,6 +35,8 @@
 # pragma once
 
 # include "echo.client.h"
+# include <string>
+# include <vector>
 
 namespace dsn { namespace example {
 class echo_perf_test_client

--- a/src/plugins/apps.echo/echo.main.cpp
+++ b/src/plugins/apps.echo/echo.main.cpp
@@ -34,6 +34,7 @@
  */
 // apps
 # include "echo.app.example.h"
+# include <string>
 
 static void dsn_app_registration_echo()
 {

--- a/src/plugins/apps.echo/echo.server.h
+++ b/src/plugins/apps.echo/echo.server.h
@@ -33,6 +33,7 @@
 # pragma once
 # include "echo.code.definition.h"
 # include <iostream>
+# include <string>
 
 namespace dsn { namespace example {
 class echo_service

--- a/src/plugins/apps.skv/simple_kv.app.example.h
+++ b/src/plugins/apps.skv/simple_kv.app.example.h
@@ -37,6 +37,12 @@
 # include "simple_kv.client.2.h"
 # include "simple_kv.client.perf.h"
 # include "simple_kv.server.h"
+# include <cstdint>
+# include <memory>
+# include <string>
+# include <tuple>
+# include <chrono>
+# include <iostream>
 
 # define TRANSPARENT_LAYER2_CLIENT
 

--- a/src/plugins/apps.skv/simple_kv.client.2.h
+++ b/src/plugins/apps.skv/simple_kv.client.2.h
@@ -2,6 +2,10 @@
 # include "simple_kv.code.definition.h"
 # include "simple_kv.types.h"
 # include <iostream>
+# include <cstdint>
+# include <utility>
+# include <string>
+# include <chrono>
 
 namespace dsn { namespace replication { namespace application {
 class simple_kv_client2

--- a/src/plugins/apps.skv/simple_kv.client.perf.h
+++ b/src/plugins/apps.skv/simple_kv.client.perf.h
@@ -35,6 +35,10 @@
 
 # pragma once
 # include "simple_kv.client.2.h"
+# include <cstdint>
+# include <string>
+# include <sstream>
+# include <vector>
 
 namespace dsn { namespace replication { namespace application {
 

--- a/src/plugins/apps.skv/simple_kv.server.h
+++ b/src/plugins/apps.skv/simple_kv.server.h
@@ -37,6 +37,8 @@
 # include "simple_kv.code.definition.h"
 # include "simple_kv.types.h"
 # include <iostream>
+# include <cstdint>
+# include <string>
 
 namespace dsn { namespace replication { namespace application { 
 class simple_kv_service 

--- a/src/plugins/apps.skv/simple_kv.server.impl.cpp
+++ b/src/plugins/apps.skv/simple_kv.server.impl.cpp
@@ -38,6 +38,8 @@
 #include <algorithm>
 #include <fstream>
 #include <sstream>
+#include <cstring>
+#include <utility>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/apps.skv/simple_kv_types.cpp
+++ b/src/plugins/apps.skv/simple_kv_types.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <ostream>
+#include <utility>
 
 #include <thrift/TToString.h>
 

--- a/src/plugins/apps.skv/simple_kv_types.h
+++ b/src/plugins/apps.skv/simple_kv_types.h
@@ -8,6 +8,8 @@
 #define simple_kv_TYPES_H
 
 #include <iosfwd>
+#include <cstdint>
+#include <string>
 
 #include <thrift/Thrift.h>
 #include <thrift/TApplicationException.h>

--- a/src/plugins/dist.uri.resolver/partition_resolver_simple.cpp
+++ b/src/plugins/dist.uri.resolver/partition_resolver_simple.cpp
@@ -35,6 +35,8 @@
 
 # include "partition_resolver_simple.h"
 # include <dsn/cpp/utils.h>
+# include <utility>
+# include <chrono>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/dist.uri.resolver/partition_resolver_simple.h
+++ b/src/plugins/dist.uri.resolver/partition_resolver_simple.h
@@ -37,6 +37,7 @@
 
 # include <dsn/tool-api/partition_resolver.h>
 # include <dsn/cpp/zlocks.h>
+# include <deque>
 
 namespace dsn
 {

--- a/src/plugins/tools.common/asio_net_provider.cpp
+++ b/src/plugins/tools.common/asio_net_provider.cpp
@@ -37,6 +37,12 @@
 #include "asio_rpc_session.h"
 
 #include <exception>
+#include <cstring>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <limits>
+#include <thread>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/asio_rpc_session.cpp
+++ b/src/plugins/tools.common/asio_rpc_session.cpp
@@ -34,6 +34,10 @@
  */
 
 # include "asio_rpc_session.h"
+# include <cstdint>
+# include <memory>
+# include <vector>
+# include <exception>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/dsn_message_parser.cpp
+++ b/src/plugins/tools.common/dsn_message_parser.cpp
@@ -35,6 +35,8 @@
 
 # include "dsn_message_parser.h"
 # include <dsn/service_api_c.h>
+# include <cstring>
+# include <cinttypes>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/empty_aio_provider.cpp
+++ b/src/plugins/tools.common/empty_aio_provider.cpp
@@ -35,6 +35,7 @@
 
 
 # include "empty_aio_provider.h"
+# include <cstddef>
 
 namespace dsn {
     namespace tools {

--- a/src/plugins/tools.common/fault_injector.cpp
+++ b/src/plugins/tools.common/fault_injector.cpp
@@ -37,6 +37,9 @@
 #include "fault_injector.h"
 #include <dsn/service_api_c.h>
 #include <cstddef>
+#include <string>
+#include <thread>
+#include <chrono>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/http_message_parser.cpp
+++ b/src/plugins/tools.common/http_message_parser.cpp
@@ -40,6 +40,8 @@
 # include <dsn/cpp/utils.h>
 # include <vector>
 # include <iomanip>
+# include <cstring>
+# include <utility>
 # include "http_message_parser.h"
 # include <dsn/cpp/serialization.h>
 

--- a/src/plugins/tools.common/lockp.std.test.cpp
+++ b/src/plugins/tools.common/lockp.std.test.cpp
@@ -35,6 +35,7 @@
 
 #include "lockp.std.h"
 #include <gtest/gtest.h>
+#include <thread>
 
 using namespace dsn;
 using namespace dsn::tools;

--- a/src/plugins/tools.common/native_aio_provider.linux.cpp
+++ b/src/plugins/tools.common/native_aio_provider.linux.cpp
@@ -38,6 +38,9 @@
 
 # include <fcntl.h>
 # include <cstdlib>
+# include <cstdint>
+# include <cerrno>
+# include <thread>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/native_aio_provider.posix.cpp
+++ b/src/plugins/tools.common/native_aio_provider.posix.cpp
@@ -41,6 +41,9 @@
 # include <aio.h>
 # include <fcntl.h>
 # include <cstdlib>
+# include <cstring>
+# include <cstdint>
+# include <cerrno>
 # if defined(__APPLE__)
 # include <thread>
 # endif

--- a/src/plugins/tools.common/native_aio_provider.win.cpp
+++ b/src/plugins/tools.common/native_aio_provider.win.cpp
@@ -41,6 +41,8 @@
 #include <sys/stat.h>
 #include <io.h>
 #include <stdio.h>
+#include <cstdint>
+#include <thread>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/profiler.cpp
+++ b/src/plugins/tools.common/profiler.cpp
@@ -70,6 +70,9 @@ START<======== queue(server) ======ENQUEUE <===================== net(reply) ===
 #include "profiler_header.h"
 #include <dsn/tool-api/command.h>
 #include <dsn/tool-api/perf_counter.h>
+#include <algorithm>
+#include <cinttypes>
+#include <iomanip>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/profiler_command.cpp
+++ b/src/plugins/tools.common/profiler_command.cpp
@@ -43,6 +43,8 @@
 #include "profiler_header.h"
 #include <dsn/cpp/json_helper.h>
 #include <climits>
+#include <cstring>
+#include <cmath>
 #include <dsn/cpp/utils.h>
 
 namespace dsn {

--- a/src/plugins/tools.common/profiler_header.h
+++ b/src/plugins/tools.common/profiler_header.h
@@ -38,6 +38,13 @@
 
 #pragma once
 #include <iomanip>
+#include <cstring>
+#include <cstdint>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <map>
+#include <atomic>
 #include "shared_io_service.h"
 
 namespace dsn {

--- a/src/plugins/tools.common/profiler_output.cpp
+++ b/src/plugins/tools.common/profiler_output.cpp
@@ -42,6 +42,8 @@
 #include <iomanip>
 #include <iostream>
 #include <algorithm>
+#include <string>
+#include <sstream>
 #include "profiler.h"
 #include "profiler_header.h"
 

--- a/src/plugins/tools.common/simple_logger.cpp
+++ b/src/plugins/tools.common/simple_logger.cpp
@@ -37,6 +37,11 @@
 # include <sstream>
 # include <cerrno>
 # include <cstring>
+# include <cstdint>
+# include <cstdarg>
+# include <cinttypes>
+# include <string>
+# include <vector>
 
 namespace dsn {
     namespace tools {

--- a/src/plugins/tools.common/simple_perf_counter.cpp
+++ b/src/plugins/tools.common/simple_perf_counter.cpp
@@ -42,6 +42,13 @@
 
 # include "simple_perf_counter.h"
 # include "shared_io_service.h"
+# include <cstring>
+# include <cstdint>
+# include <cstdlib>
+# include <memory>
+# include <functional>
+# include <utility>
+# include <atomic>
 
 namespace dsn {
     namespace tools {

--- a/src/plugins/tools.common/simple_perf_counter_v2_atomic.cpp
+++ b/src/plugins/tools.common/simple_perf_counter_v2_atomic.cpp
@@ -39,6 +39,12 @@
 
 # include "simple_perf_counter_v2_atomic.h"
 # include "shared_io_service.h"
+# include <cstdint>
+# include <cstdlib>
+# include <memory>
+# include <functional>
+# include <utility>
+# include <atomic>
 
 namespace dsn {
     namespace tools {

--- a/src/plugins/tools.common/simple_perf_counter_v2_fast.cpp
+++ b/src/plugins/tools.common/simple_perf_counter_v2_fast.cpp
@@ -39,6 +39,12 @@
 
 # include "simple_perf_counter_v2_fast.h"
 # include "shared_io_service.h"
+# include <cstdint>
+# include <cstdlib>
+# include <memory>
+# include <functional>
+# include <utility>
+# include <atomic>
 
 namespace dsn {
     namespace tools {

--- a/src/plugins/tools.common/simple_task_queue.cpp
+++ b/src/plugins/tools.common/simple_task_queue.cpp
@@ -34,6 +34,9 @@
  */
 
 # include "simple_task_queue.h"
+# include <cstdio>
+# include <memory>
+# include <thread>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/thrift_message_parser.cpp
+++ b/src/plugins/tools.common/thrift_message_parser.cpp
@@ -41,6 +41,8 @@
 # include <dsn/service_api_c.h>
 # include <dsn/cpp/serialization_helper/thrift_helper.h>
 # include <dsn/utility/ports.h>
+# include <cstring>
+# include <utility>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.common/tracer.cpp
+++ b/src/plugins/tools.common/tracer.cpp
@@ -36,6 +36,8 @@
 
 # include "tracer.h"
 # include <dsn/tool-api/command.h>
+# include <cstdio>
+# include <cinttypes>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.emulator/diske.sim.cpp
+++ b/src/plugins/tools.emulator/diske.sim.cpp
@@ -34,6 +34,7 @@
  */
 
 #include "diske.sim.h"
+#include <cstdint>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.emulator/env.sim.cpp
+++ b/src/plugins/tools.emulator/env.sim.cpp
@@ -35,6 +35,7 @@
 
 #include "env.sim.h"
 #include "scheduler.h"
+#include <cstdint>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.emulator/network.sim.cpp
+++ b/src/plugins/tools.emulator/network.sim.cpp
@@ -39,6 +39,7 @@
 # include <dsn/utility/singleton_store.h>
 # include <dsn/tool-api/node_scoper.h>
 # include "network.sim.h" 
+# include <cstring>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.emulator/scheduler.cpp
+++ b/src/plugins/tools.emulator/scheduler.cpp
@@ -40,6 +40,7 @@
 # include "env.sim.h"
 # include <algorithm>
 # include <set>
+# include <chrono>
 
 # ifdef __TITLE__
 # undef __TITLE__

--- a/src/plugins/tools.emulator/task_engine.sim.cpp
+++ b/src/plugins/tools.emulator/task_engine.sim.cpp
@@ -35,6 +35,8 @@
 
 #include "task_engine.sim.h"
 #include "scheduler.h"
+#include <cstdint>
+#include <map>
 
 namespace dsn { namespace tools {
 

--- a/src/plugins/tools.nfs/nfs_client.h
+++ b/src/plugins/tools.nfs/nfs_client.h
@@ -35,6 +35,9 @@
 # pragma once
 # include "nfs_code_definition.h"
 # include <iostream>
+# include <cstdint>
+# include <utility>
+# include <chrono>
 
 
 namespace dsn { namespace service {

--- a/src/plugins/tools.nfs/nfs_client_impl.cpp
+++ b/src/plugins/tools.nfs/nfs_client_impl.cpp
@@ -36,6 +36,8 @@
 # include <dsn/cpp/utils.h>
 # include <dsn/tool-api/nfs.h>
 # include <queue>
+# include <utility>
+# include <chrono>
 
 namespace dsn {
     namespace service {

--- a/src/plugins/tools.nfs/nfs_node_impl.cpp
+++ b/src/plugins/tools.nfs/nfs_node_impl.cpp
@@ -36,6 +36,7 @@
 # include "nfs_node_simple.h"
 # include "nfs_client_impl.h"
 # include "nfs_server_impl.h"
+# include <memory>
 
 namespace dsn {
     namespace service {

--- a/src/plugins/tools.nfs/nfs_server_impl.cpp
+++ b/src/plugins/tools.nfs/nfs_server_impl.cpp
@@ -34,6 +34,11 @@
  */
 # include "nfs_server_impl.h"
 # include <cstdlib>
+# include <cstring>
+# include <utility>
+# include <cerrno>
+# include <cinttypes>
+# include <vector>
 # include <sys/stat.h>
 
 namespace dsn {

--- a/src/plugins/tools.nfs/nfs_server_impl.h
+++ b/src/plugins/tools.nfs/nfs_server_impl.h
@@ -35,6 +35,10 @@
 # pragma once
 # include "nfs_server.h"
 # include "nfs_client_impl.h"
+# include <cstdint>
+# include <string>
+# include <unordered_map>
+# include <chrono>
 
 namespace dsn {
     namespace service {

--- a/src/plugins/tools.nfs/nfs_types.cpp
+++ b/src/plugins/tools.nfs/nfs_types.cpp
@@ -8,6 +8,10 @@
 
 #include <algorithm>
 #include <ostream>
+#include <cstdint>
+#include <utility>
+#include <string>
+#include <vector>
 
 #include <thrift/TToString.h>
 

--- a/src/tests/idl/idl_test.pb.cc
+++ b/src/tests/idl/idl_test.pb.cc
@@ -5,6 +5,7 @@
 #include "idl_test.pb.h"
 
 #include <algorithm>
+#include <utility>
 
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/port.h>

--- a/src/tests/idl/idl_test_types.h
+++ b/src/tests/idl/idl_test_types.h
@@ -8,6 +8,11 @@
 #define idl_test_TYPES_H
 
 #include <iosfwd>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
 
 #include <thrift/Thrift.h>
 #include <thrift/TApplicationException.h>

--- a/src/tools/cli/cli.client.h
+++ b/src/tools/cli/cli.client.h
@@ -36,6 +36,7 @@
 # pragma once
 # include <dsn/cpp/cli.h>
 # include <iostream>
+# include <chrono>
 
 
 namespace dsn {

--- a/src/tools/cli/cli_app.cpp
+++ b/src/tools/cli/cli_app.cpp
@@ -39,6 +39,7 @@
 # include <cstdint>
 # include <dsn/cpp/utils.h>
 # include <iostream>
+# include <tuple>
 
 namespace dsn {
     namespace service {

--- a/src/tools/cli/cli_app.h
+++ b/src/tools/cli/cli_app.h
@@ -38,6 +38,7 @@
 
 # include <dsn/cpp/serverlet.h>
 # include "cli.client.h"
+# include <chrono>
 
 namespace dsn {
     namespace service {

--- a/tutorial/counter.replication/counter.server.impl.cpp
+++ b/tutorial/counter.replication/counter.server.impl.cpp
@@ -38,6 +38,7 @@
 #include <dsn/cpp/utils.h>
 #include <fstream>
 #include <sstream>
+#include <cstring>
 
 # ifdef __TITLE__
 # undef __TITLE__


### PR DESCRIPTION
## What

Add direct `#include`s for standard-library headers that are used in these
files but were only being pulled in indirectly through other headers.

## Why

Several source and header files reference standard-library symbols
(e.g. `std::string`, `std::vector`, `std::map`, `std::chrono`, fixed-width
integer types, `memcpy`, threading and stream utilities) without directly
including the header that declares them. They currently compile only because
those headers happen to be included transitively. Modern C++ standard libraries
have trimmed such transitive includes, so these files can fail to build unless
each translation unit includes what it actually uses.

## What's in this change

- Add the missing standard headers directly, grouped with each file's existing
  standard-library includes.
- Where a `.cpp` and its paired `.h` share the same name, keep the include in
  the header (which the `.cpp` already includes) rather than duplicating it.

Pure include hygiene — no functional or behavioral changes.