### PR TITLE
Harden core against untrusted input, null derefs, and locally-triggerable aborts

### DIFF
--- a/include/dsn/cpp/blob.h
+++ b/include/dsn/cpp/blob.h
@@ -176,6 +176,8 @@ namespace dsn
             blob temp = *this;
             temp._data += offset;
             temp._length -= offset;
+            dassert(temp._buffer == nullptr || temp._data >= temp._buffer,
+                    "offset moves data before the start of the underlying buffer");
             return temp;
         }
 
@@ -186,6 +188,8 @@ namespace dsn
             blob temp = *this;
             temp._data += offset;
             temp._length -= offset;
+            dassert(temp._buffer == nullptr || temp._data >= temp._buffer,
+                    "offset moves data before the start of the underlying buffer");
             dassert(temp._length >= len, "buffer length must exceed the required length");
             temp._length = len;
             return temp;

--- a/include/dsn/cpp/serialization_helper/protobuf_helper.h
+++ b/include/dsn/cpp/serialization_helper/protobuf_helper.h
@@ -47,6 +47,8 @@
 # include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 # include <google/protobuf/descriptor.h>
 
+# include <stdexcept>
+
 namespace dsn {
 
     class gproto_binary_reader : public ::google::protobuf::io::ZeroCopyInputStream
@@ -118,7 +120,18 @@ namespace dsn {
     {
         gproto_binary_writer wt2(writer);
         ::google::protobuf::io::CodedOutputStream os(&wt2);
-        val.SerializeToCodedStream(&os);
+        if (!val.SerializeToCodedStream(&os))
+        {
+            // Serialization failing (e.g. a required field is unset, or the message exceeds the
+            // protobuf 2GB limit) must not silently put a truncated message on the wire. Throw so
+            // try_marshall() surfaces ERR_INVALID_DATA, consistent with the thrift marshaller which
+            // also throws on failure.
+            std::string type_name = val.GetTypeName();
+            derror("marshall_protobuf_binary failed to serialize message of type %s",
+                type_name.c_str());
+            throw std::runtime_error(
+                "marshall_protobuf_binary failed to serialize message of type " + type_name);
+        }
     }
 
     template<typename T>
@@ -126,7 +139,17 @@ namespace dsn {
     {
         gproto_binary_reader rd2(reader);
         ::google::protobuf::io::CodedInputStream is(&rd2);
-        val.MergePartialFromCodedStream(&is);
+        if (!val.MergePartialFromCodedStream(&is))
+        {
+            // The input is (potentially untrusted) network data. Do not return a partially parsed
+            // message as if it were valid: throw so unmarshall()/try_unmarshall() reject it with
+            // ERR_INVALID_DATA, exactly like the thrift unmarshaller (which throws on bad input).
+            std::string type_name = val.GetTypeName();
+            derror("unmarshall_protobuf_binary failed to parse message of type %s",
+                type_name.c_str());
+            throw std::runtime_error(
+                "unmarshall_protobuf_binary failed to parse message of type " + type_name);
+        }
     }
 
     /* you may want to specify your own url prefix here */
@@ -146,10 +169,23 @@ namespace dsn {
     {
         std::string type_url = protobuf_resolve_type_url(val);
         std::string binary_str;
-        val.SerializeToString(&binary_str);
+        if (!val.SerializeToString(&binary_str))
+        {
+            derror("marshall_protobuf_json failed to serialize message of type %s",
+                type_url.c_str());
+            throw std::runtime_error(
+                "marshall_protobuf_json failed to serialize message of type " + type_url);
+        }
         gproto_binary_writer wt2(writer);
         google::protobuf::io::ArrayInputStream input_stream(binary_str.data(), binary_str.size());
-        google::protobuf::util::BinaryToJsonStream(protobuf_type_resolver, type_url, &input_stream, &wt2);
+        auto status = google::protobuf::util::BinaryToJsonStream(protobuf_type_resolver, type_url, &input_stream, &wt2);
+        if (!status.ok())
+        {
+            derror("marshall_protobuf_json failed for type %s: %s",
+                type_url.c_str(), status.ToString().c_str());
+            throw std::runtime_error(
+                "marshall_protobuf_json failed for type " + type_url + ": " + status.ToString());
+        }
     }
 
     template<typename T>
@@ -159,7 +195,20 @@ namespace dsn {
         gproto_binary_reader rd2(reader);
         std::string binary_str;
         google::protobuf::io::StringOutputStream output_stream(&binary_str);
-        google::protobuf::util::JsonToBinaryStream(protobuf_type_resolver, type_url, &rd2, &output_stream);
-        val.ParseFromString(binary_str);
+        auto status = google::protobuf::util::JsonToBinaryStream(protobuf_type_resolver, type_url, &rd2, &output_stream);
+        if (!status.ok())
+        {
+            // Reject malformed (potentially untrusted) JSON instead of parsing an empty buffer.
+            derror("unmarshall_protobuf_json failed for type %s: %s",
+                type_url.c_str(), status.ToString().c_str());
+            throw std::runtime_error(
+                "unmarshall_protobuf_json failed for type " + type_url + ": " + status.ToString());
+        }
+        if (!val.ParseFromString(binary_str))
+        {
+            derror("unmarshall_protobuf_json failed to parse message of type %s", type_url.c_str());
+            throw std::runtime_error(
+                "unmarshall_protobuf_json failed to parse message of type " + type_url);
+        }
     }
 }

--- a/include/dsn/cpp/serialization_helper/thrift_helper.h
+++ b/include/dsn/cpp/serialization_helper/thrift_helper.h
@@ -152,10 +152,29 @@ namespace dsn {
         uint32_t size;
         ::apache::thrift::protocol::TType element_type;
         xfer += iprot->readListBegin(element_type, size);
-        val.resize(size);
-        for (uint32_t i = 0; i != size; ++i)
+        // Do not resize()/reserve() to the full, untrusted 'size': a malicious or corrupt peer
+        // can claim a huge element count and trigger an out-of-memory abort before a single
+        // element is read. Instead bound the speculative up-front reserve and grow the vector
+        // incrementally; if the peer lied about the count, unmarshall_base() hits end-of-stream
+        // and throws well before any large allocation happens.
+        //
+        // The reserve is bounded by a fixed *byte* budget rather than a flat element count,
+        // because the memory reserved is size * sizeof(T): a count cap (e.g. "1024 elements")
+        // reserves wildly different amounts depending on the element type. This budget is the
+        // only speculative allocation per call, so it directly caps per-message memory. It is
+        // large enough that realistic lists avoid reallocation churn (vector growth is amortized
+        // O(1) regardless) yet small enough that a lying peer cannot force a big allocation.
+        const uint32_t max_preallocate_bytes = 64 * 1024;
+        uint32_t max_preallocate = max_preallocate_bytes / static_cast<uint32_t>(sizeof(T));
+        if (max_preallocate == 0)
         {
-            xfer += unmarshall_base(iprot, val[i]);
+            max_preallocate = 1;
+        }
+        val.reserve(size < max_preallocate ? size : max_preallocate);
+        for (uint32_t i = 0; i < size; ++i)
+        {
+            val.emplace_back();
+            xfer += unmarshall_base(iprot, val.back());
         }
         xfer += iprot->readListEnd();
 
@@ -511,16 +530,41 @@ namespace dsn {
 
     inline uint32_t blob::read(apache::thrift::protocol::TProtocol *iprot)
     {
-        //for optimization, it is dangerous if the oprot is not a binary proto
-        apache::thrift::protocol::TBinaryProtocol* binary_proto = static_cast<apache::thrift::protocol::TBinaryProtocol*>(iprot);
-        blob_string str(*this);
-        return binary_proto->readString<blob_string>(str);
+        // Reading directly into the blob is an optimization that is only valid for the binary protocol.
+        // Guard the downcast with dynamic_cast (as every other helper in this file does):
+        // a static_cast of a non-binary protocol is undefined behavior.
+        apache::thrift::protocol::TBinaryProtocol* binary_proto = dynamic_cast<apache::thrift::protocol::TBinaryProtocol*>(iprot);
+        if (binary_proto != nullptr)
+        {
+            // the protocol is binary protocol
+            blob_string str(*this);
+            return binary_proto->readString<blob_string>(str);
+        }
+        else
+        {
+            // the protocol is json protocol or some other protocol
+            std::string data;
+            uint32_t xfer = iprot->readBinary(data);
+            std::shared_ptr<char> buffer = ::dsn::make_shared_array<char>(data.length());
+            memcpy(buffer.get(), data.data(), data.length());
+            assign(std::move(buffer), 0, static_cast<unsigned int>(data.length()));
+            return xfer;
+        }
     }
 
     inline uint32_t blob::write(apache::thrift::protocol::TProtocol *oprot) const
     {
-        apache::thrift::protocol::TBinaryProtocol* binary_proto = static_cast<apache::thrift::protocol::TBinaryProtocol*>(oprot);
-        return binary_proto->writeString<blob_string>(blob_string(const_cast<blob&>(*this)));
+        apache::thrift::protocol::TBinaryProtocol* binary_proto = dynamic_cast<apache::thrift::protocol::TBinaryProtocol*>(oprot);
+        if (binary_proto != nullptr)
+        {
+            //the protocol is binary protocol
+            return binary_proto->writeString<blob_string>(blob_string(const_cast<blob&>(*this)));
+        }
+        else
+        {
+            //the protocol is json protocol or some other protocol
+            return oprot->writeBinary(std::string(data(), length()));
+        }
     }
 
     inline uint32_t error_code::read(apache::thrift::protocol::TProtocol *iprot)

--- a/include/dsn/tool-api/task_worker.h
+++ b/include/dsn/tool-api/task_worker.h
@@ -87,7 +87,7 @@ private:
     int               _index;
     int               _native_tid;
     safe_string       _name;
-    std::thread      *_thread;
+    std::atomic<std::thread*> _thread;
     std::atomic<bool> _is_running;
     utils::notify_event _started;
     int              _processed_task_count;

--- a/include/dsn/utility/autoref_ptr.h
+++ b/include/dsn/utility/autoref_ptr.h
@@ -158,6 +158,11 @@ namespace dsn
 
         ref_ptr<T>& operator = (ref_ptr<T>&& obj)
         {
+            if (this == &obj)
+            {
+                return *this;
+            }
+
             if (nullptr != _obj)
             {
                 _obj->release_ref();

--- a/src/core/src/disk_engine.cpp
+++ b/src/core/src/disk_engine.cpp
@@ -71,7 +71,7 @@ aio_task* disk_write_queue::unlink_next_workload(void* plength)
         {
             // batch condition
             if (next_offset == io->file_offset
-                && sz + io->buffer_size <= _max_batch_bytes)
+                && static_cast<uint64_t>(sz) + io->buffer_size <= _max_batch_bytes)
             {
                 sz += io->buffer_size;
                 next_offset += io->buffer_size;
@@ -109,8 +109,11 @@ disk_file::disk_file(dsn_handle_t handle)
 
 void disk_file::ctrl(dsn_ctrl_code_t code, int param)
 {
-    // TODO: 
-    dassert(false, "NOT IMPLEMENTED");
+    // Not implemented. This method has no callers today, so reaching it means a developer wired
+    // up a control path against an unimplemented operation -- a programmer error, not a runtime or
+    // user-data condition. Fail loudly (as rDSN does elsewhere for "can't happen" paths) instead of
+    // silently ignoring the request.
+    dassert(false, "disk_file::ctrl is not implemented (code = %d)", code);
 }
 
 aio_task* disk_file::read(aio_task* tsk)
@@ -343,79 +346,82 @@ void disk_engine::write(aio_task* aio)
 
 void disk_engine::process_write(aio_task* aio, uint32_t sz)
 {
-    auto complete_write_with_error = [this](aio_task* wk, error_code err)
+    // Returns the next queued work item (or nullptr) after completing 'wk' with an error, and
+    // writes the next batch size through next_sz. We loop on this below instead of recursing so
+    // that a disk that keeps failing synchronously cannot overflow the stack.
+    auto complete_write_with_error = [this](aio_task* wk, error_code err, uint32_t* next_sz) -> aio_task*
     {
         auto df = (disk_file*)wk->aio()->file_object;
-        uint32_t next_sz;
-        auto next = df->on_write_completed(wk, (void*)&next_sz, err, 0);
-        if (next)
-        {
-            process_write(next, next_sz);
-        }
+        return df->on_write_completed(wk, (void*)next_sz, err, 0);
     };
 
-    // no batching
-    if (aio->aio()->buffer_size == sz)
+    while (aio != nullptr)
     {
-        try
+        // no batching
+        if (aio->aio()->buffer_size == sz)
         {
-            aio->collapse();
-        }
-        catch (const std::exception& ex)
-        {
-            derror("collapse aio write buffer failed: %s", ex.what());
-            complete_write_with_error(aio, ERR_FILE_OPERATION_FAILED);
+            try
+            {
+                aio->collapse();
+            }
+            catch (const std::exception& ex)
+            {
+                derror("collapse aio write buffer failed: %s", ex.what());
+                aio = complete_write_with_error(aio, ERR_FILE_OPERATION_FAILED, &sz);
+                continue;
+            }
+            _provider->aio(aio);
             return;
         }
-        return _provider->aio(aio);
-    }
 
-    // batching
-    else
-    {
-        // merge the buffers
-        try
+        // batching
+        else
         {
-            auto bb = tls_trans_mem_alloc_blob((size_t)sz);
-            char* ptr = (char*)bb.data();
-            auto current_wk = aio;
-            do
+            // merge the buffers
+            try
             {
-                current_wk->copy_to(ptr);
-                ptr += current_wk->aio()->buffer_size;
-                current_wk = (aio_task*)current_wk->next;
-            } while (current_wk);
+                auto bb = tls_trans_mem_alloc_blob((size_t)sz);
+                char* ptr = (char*)bb.data();
+                auto current_wk = aio;
+                do
+                {
+                    current_wk->copy_to(ptr);
+                    ptr += current_wk->aio()->buffer_size;
+                    current_wk = (aio_task*)current_wk->next;
+                } while (current_wk);
 
-            if (ptr != (char*)bb.data() + bb.length())
-            {
-                derror("merge aio write buffers copied unexpected size");
-                complete_write_with_error(aio, ERR_FILE_OPERATION_FAILED);
+                if (ptr != (char*)bb.data() + bb.length())
+                {
+                    derror("merge aio write buffers copied unexpected size");
+                    aio = complete_write_with_error(aio, ERR_FILE_OPERATION_FAILED, &sz);
+                    continue;
+                }
+
+                // setup io task
+                auto new_task = new batch_write_io_task(
+                    aio,
+                    bb
+                    );
+                auto dio = new_task->aio();
+                dio->buffer = (void*)bb.data();
+                dio->buffer_size = sz;
+                dio->file_offset = aio->aio()->file_offset;
+
+                dio->file = aio->aio()->file;
+                dio->file_object = aio->aio()->file_object;
+                dio->engine = aio->aio()->engine;
+                dio->type = AIO_Write;
+
+                new_task->add_ref(); // released in complete_io
+                _provider->aio(new_task);
                 return;
             }
-
-            // setup io task
-            auto new_task = new batch_write_io_task(
-                aio,
-                bb
-                );
-            auto dio = new_task->aio();
-            dio->buffer = (void*)bb.data();
-            dio->buffer_size = sz;
-            dio->file_offset = aio->aio()->file_offset;
-
-            dio->file = aio->aio()->file;
-            dio->file_object = aio->aio()->file_object;
-            dio->engine = aio->aio()->engine;
-            dio->type = AIO_Write;
-
-            new_task->add_ref(); // released in complete_io
-            return _provider->aio(new_task);
-        }
-        catch (const std::exception& ex)
-        {
-            derror("merge aio write buffers failed: %s", ex.what());
-            complete_write_with_error(aio, ERR_FILE_OPERATION_FAILED);
-            return;
+            catch (const std::exception& ex)
+            {
+                derror("merge aio write buffers failed: %s", ex.what());
+                aio = complete_write_with_error(aio, ERR_FILE_OPERATION_FAILED, &sz);
+                continue;
+            }
         }
     }
 }

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -1117,6 +1117,31 @@ DSN_API void* dsn_rpc_unregiser_handler(dsn_task_code_t code, dsn_gpid gpid)
     DSN_C_GUARD_END(nullptr)
 }
 
+// Returns true iff `msg` can be used to construct an rpc_response_task: its rpc code is a registered
+// TASK_TYPE_RPC_REQUEST with a valid paired TASK_TYPE_RPC_RESPONSE code. This mirrors the invariant
+// asserted in rpc_response_task's constructor, letting the C API reject invalid caller input with an
+// error return instead of tripping those asserts and aborting the process.
+static bool is_valid_rpc_request_message(::dsn::message_ex* msg)
+{
+    if (msg == nullptr)
+    {
+        return false;
+    }
+
+    auto req_spec = ::dsn::task_spec::get(msg->local_rpc_code);
+    if (req_spec == nullptr || req_spec->type != TASK_TYPE_RPC_REQUEST)
+    {
+        return false;
+    }
+    if (req_spec->rpc_paired_code == ::dsn::TASK_CODE_INVALID)
+    {
+        return false;
+    }
+
+    auto resp_spec = ::dsn::task_spec::get(req_spec->rpc_paired_code);
+    return resp_spec != nullptr && resp_spec->type == TASK_TYPE_RPC_RESPONSE;
+}
+
 DSN_API dsn_task_t dsn_rpc_create_response_task(dsn_message_t request, dsn_rpc_response_handler_t cb, 
     void* context, int reply_thread_hash, dsn_task_tracker_t tracker)
 {
@@ -1125,6 +1150,12 @@ DSN_API dsn_task_t dsn_rpc_create_response_task(dsn_message_t request, dsn_rpc_r
     if (msg == nullptr)
     {
         derror("dsn_rpc_create_response_task got null request");
+        return nullptr;
+    }
+    if (!is_valid_rpc_request_message(msg))
+    {
+        derror("dsn_rpc_create_response_task got an invalid request message: "
+            "it is not a registered rpc request with a paired response code");
         return nullptr;
     }
 
@@ -1144,6 +1175,12 @@ DSN_API dsn_task_t dsn_rpc_create_response_task_ex(dsn_message_t request, dsn_rp
     if (msg == nullptr)
     {
         derror("dsn_rpc_create_response_task_ex got null request");
+        return nullptr;
+    }
+    if (!is_valid_rpc_request_message(msg))
+    {
+        derror("dsn_rpc_create_response_task_ex got an invalid request message: "
+            "it is not a registered rpc request with a paired response code");
         return nullptr;
     }
 
@@ -1203,6 +1240,12 @@ DSN_API dsn_message_t dsn_rpc_call_wait(dsn_address_t server, dsn_message_t requ
     if (msg == nullptr)
     {
         derror("dsn_rpc_call_wait got null request");
+        return nullptr;
+    }
+    if (!is_valid_rpc_request_message(msg))
+    {
+        derror("dsn_rpc_call_wait got an invalid request message: "
+            "it is not a registered rpc request with a paired response code");
         return nullptr;
     }
 

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -557,6 +557,22 @@ TEST(core, dsn_rpc_dispatch_invalid_parameters)
     ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_rpc_call(invalid_address, rpc_response_task));
     dsn_task_release_ref(rpc_response_task);
 
+    // A valid, non-null message that is not a valid RPC request (here, a response message whose
+    // code is the paired _ACK / TASK_TYPE_RPC_RESPONSE code) must be rejected with nullptr instead
+    // of tripping the rpc_response_task constructor's invariant asserts and aborting the process.
+    auto response = dsn_msg_create_response(request);
+    ASSERT_NE(nullptr, response);
+    dsn_msg_add_ref(response);
+    ASSERT_EQ(nullptr,
+              dsn_rpc_create_response_task(response, noop_rpc_response_handler, nullptr, 0));
+    ASSERT_EQ(nullptr, dsn_rpc_create_response_task_ex(response,
+                                                       noop_rpc_response_handler,
+                                                       nullptr,
+                                                       nullptr,
+                                                       0,
+                                                       nullptr));
+    dsn_msg_release_ref(response);
+
     auto compute_task = dsn_task_create(TASK_CODE_COMPUTE_FOR_TEST, noop_task_handler, nullptr, 0);
     ASSERT_NE(nullptr, compute_task);
     dsn_task_add_ref(compute_task);

--- a/src/core/src/task.cpp
+++ b/src/core/src/task.cpp
@@ -592,18 +592,41 @@ void rpc_request_task::enqueue()
 
 static dsn_task_code_t get_response_task_paired_code(message_ex* request)
 {
-    // The response task's code is the request code's paired (ack) code. An rpc_response_task is
-    // always constructed for a registered request rpc code, so task_spec::get() must succeed here.
-    // If it does not, the caller built a response task for an unregistered code -- a programmer
-    // error. Fail loudly with a clear diagnostic instead of falling back to TASK_CODE_INVALID:
-    // that fallback would abort in debug builds (dbg_dassert below) and, worse, silently construct
-    // a task with the wrong spec (type/pool/hooks) in release builds.
+    // The response task's code is the request code's paired (ack) code. An rpc_response_task is only
+    // ever constructed from a registered TASK_TYPE_RPC_REQUEST message, and register_task_code()
+    // guarantees such a request has a valid TASK_TYPE_RPC_RESPONSE paired code (see task_spec.cpp).
+    // Validate that whole chain here and fail loudly on any violation: falling back to
+    // TASK_CODE_INVALID would abort in debug builds (dbg_dassert below) and, worse, silently build a
+    // task with the wrong spec (type/pool/hooks) in release builds.
     dassert(request != nullptr, "rpc_response_task requires a non-null request message");
-    task_spec* spec = task_spec::get(request->local_rpc_code);
-    dassert(spec != nullptr,
+
+    task_spec* req_spec = task_spec::get(request->local_rpc_code);
+    dassert(req_spec != nullptr,
         "no task spec registered for rpc code %d; rpc_response_task requires a registered request code",
         request->local_rpc_code);
-    return spec->rpc_paired_code;
+    dassert(req_spec->type == TASK_TYPE_RPC_REQUEST,
+        "%s is not an RPC_REQUEST code; use DEFINE_TASK_CODE_RPC to define request codes",
+        req_spec->name.c_str());
+
+    dsn_task_code_t paired = req_spec->rpc_paired_code;
+    dassert(paired != TASK_CODE_INVALID,
+        "rpc request code %s has no paired response code", req_spec->name.c_str());
+
+    task_spec* resp_spec = task_spec::get(paired);
+    dassert(resp_spec != nullptr && resp_spec->type == TASK_TYPE_RPC_RESPONSE,
+        "paired code of request %s is not a valid RPC_RESPONSE code", req_spec->name.c_str());
+
+    return paired;
+}
+
+// Selecting the dispatch hash also dereferences `request`, so wrap it too: the constructor's base
+// initializer evaluates its arguments in an unspecified order, so doing `request->header->...`
+// inline there could dereference a null request before get_response_task_paired_code()'s assert
+// runs. Asserting here preserves the null-request diagnostic regardless of evaluation order.
+static int get_response_task_thread_hash(message_ex* request, int hash)
+{
+    dassert(request != nullptr, "rpc_response_task requires a non-null request message");
+    return hash == 0 ? request->header->client.thread_hash : hash;
 }
 
 rpc_response_task::rpc_response_task(
@@ -615,7 +638,7 @@ rpc_response_task::rpc_response_task(
     service_node* node
     )
     : task(get_response_task_paired_code(request), context, on_cancel,
-           hash == 0 ? request->header->client.thread_hash : hash, node)
+           get_response_task_thread_hash(request, hash), node)
 {
     _cb = cb;
     _is_null = (_cb == nullptr);

--- a/src/core/src/task.cpp
+++ b/src/core/src/task.cpp
@@ -590,6 +590,15 @@ void rpc_request_task::enqueue()
     task::enqueue(node()->computation()->get_pool(spec().pool_code));
 }
 
+static dsn_task_code_t get_response_task_paired_code(message_ex* request)
+{
+    // The response task's code is the request code's paired (ack) code. task_spec::get() can
+    // return null for an unknown/unregistered rpc code (e.g. a malformed request), so guard the
+    // dereference and fall back to TASK_CODE_INVALID instead of crashing.
+    task_spec* spec = (request != nullptr) ? task_spec::get(request->local_rpc_code) : nullptr;
+    return (spec != nullptr) ? spec->rpc_paired_code : TASK_CODE_INVALID;
+}
+
 rpc_response_task::rpc_response_task(
     message_ex* request, 
     dsn_rpc_response_handler_t cb,
@@ -598,7 +607,7 @@ rpc_response_task::rpc_response_task(
     int hash, 
     service_node* node
     )
-    : task(task_spec::get(request->local_rpc_code)->rpc_paired_code, context, on_cancel,
+    : task(get_response_task_paired_code(request), context, on_cancel,
            hash == 0 ? request->header->client.thread_hash : hash, node)
 {
     _cb = cb;

--- a/src/core/src/task.cpp
+++ b/src/core/src/task.cpp
@@ -592,11 +592,18 @@ void rpc_request_task::enqueue()
 
 static dsn_task_code_t get_response_task_paired_code(message_ex* request)
 {
-    // The response task's code is the request code's paired (ack) code. task_spec::get() can
-    // return null for an unknown/unregistered rpc code (e.g. a malformed request), so guard the
-    // dereference and fall back to TASK_CODE_INVALID instead of crashing.
-    task_spec* spec = (request != nullptr) ? task_spec::get(request->local_rpc_code) : nullptr;
-    return (spec != nullptr) ? spec->rpc_paired_code : TASK_CODE_INVALID;
+    // The response task's code is the request code's paired (ack) code. An rpc_response_task is
+    // always constructed for a registered request rpc code, so task_spec::get() must succeed here.
+    // If it does not, the caller built a response task for an unregistered code -- a programmer
+    // error. Fail loudly with a clear diagnostic instead of falling back to TASK_CODE_INVALID:
+    // that fallback would abort in debug builds (dbg_dassert below) and, worse, silently construct
+    // a task with the wrong spec (type/pool/hooks) in release builds.
+    dassert(request != nullptr, "rpc_response_task requires a non-null request message");
+    task_spec* spec = task_spec::get(request->local_rpc_code);
+    dassert(spec != nullptr,
+        "no task spec registered for rpc code %d; rpc_response_task requires a registered request code",
+        request->local_rpc_code);
+    return spec->rpc_paired_code;
 }
 
 rpc_response_task::rpc_response_task(

--- a/src/core/src/task_engine.cpp
+++ b/src/core/src/task_engine.cpp
@@ -115,17 +115,9 @@ void task_worker_pool::start()
     if (_is_running.load(std::memory_order_acquire))
         return;
 
-    for (auto& wk : _workers)
-        wk->start();
-
-    ddebug("[%s] thread pool [%s] started, pool_code = %s, worker_count = %d, worker_share_core = %s, partitioned = %s, ...",
-        _node->name(), _spec.name.c_str(),
-        dsn_threadpool_code_to_string(_spec.pool_code),
-        _spec.worker_count,
-        _spec.worker_share_core ? "true" : "false",
-        _spec.partitioned ? "true" : "false");
-
-    // setup cached ptrs for fast timer service access
+    // Populate the timer-service caches BEFORE starting workers: a worker's on_start hook may enqueue
+    // a delayed task, which calls add_timer() directly and requires these caches to already be set.
+    // Doing this after wk->start() would leave a window where add_timer() sees a null/empty cache.
     if (service_engine::fast_instance().spec().timer_io_mode == IOE_PER_QUEUE)
     {
         for (size_t i = 0; i < _queues.size(); i++)
@@ -146,6 +138,18 @@ void task_worker_pool::start()
     {
         _per_node_timer_svc = node()->tsvc(nullptr);
     }
+
+    for (auto& wk : _workers)
+    {
+        wk->start();
+    }
+
+    ddebug("[%s] thread pool [%s] started, pool_code = %s, worker_count = %d, worker_share_core = %s, partitioned = %s, ...",
+        _node->name(), _spec.name.c_str(),
+        dsn_threadpool_code_to_string(_spec.pool_code),
+        _spec.worker_count,
+        _spec.worker_share_core ? "true" : "false",
+        _spec.partitioned ? "true" : "false");
 
     _is_running.store(true, std::memory_order_release);
 }

--- a/src/core/src/task_engine.cpp
+++ b/src/core/src/task_engine.cpp
@@ -152,22 +152,20 @@ void task_worker_pool::add_timer(task* t)
         _per_node_timer_svc->add_timer(t);
     else
     {
-        if (_per_queue_timer_svcs.empty())
-        {
-            derror("cannot add timer for pool %s: no per-queue timer service is configured",
-                _spec.name.c_str());
-            return;
-        }
+        // A pool that receives delayed tasks must have its per-queue timer services populated during
+        // start(). Reaching here with an empty/null vector is a configuration/startup error. We must
+        // NOT just return: task::enqueue() has already add_ref()'d this task, so returning would leak
+        // it and hang any caller waiting on it. Fail loudly instead.
+        dassert(!_per_queue_timer_svcs.empty(),
+            "pool %s has no per-queue timer service configured for delayed tasks",
+            _spec.name.c_str());
         unsigned int idx = (_spec.partitioned
             ? static_cast<unsigned int>(t->hash()) % static_cast<unsigned int>(_per_queue_timer_svcs.size())
             : 0);
         timer_service* svc = _per_queue_timer_svcs[idx];
-        if (svc == nullptr)
-        {
-            derror("cannot add timer for pool %s: null timer service at index %u",
-                _spec.name.c_str(), idx);
-            return;
-        }
+        dassert(svc != nullptr,
+            "pool %s has a null per-queue timer service at index %u",
+            _spec.name.c_str(), idx);
         svc->add_timer(t);
     }
 }

--- a/src/core/src/task_engine.cpp
+++ b/src/core/src/task_engine.cpp
@@ -152,8 +152,23 @@ void task_worker_pool::add_timer(task* t)
         _per_node_timer_svc->add_timer(t);
     else
     {
-        unsigned int idx = (_spec.partitioned ? static_cast<unsigned int>(t->hash()) % static_cast<unsigned int>(_queues.size()) : 0);
-        _per_queue_timer_svcs[idx]->add_timer(t);
+        if (_per_queue_timer_svcs.empty())
+        {
+            derror("cannot add timer for pool %s: no per-queue timer service is configured",
+                _spec.name.c_str());
+            return;
+        }
+        unsigned int idx = (_spec.partitioned
+            ? static_cast<unsigned int>(t->hash()) % static_cast<unsigned int>(_per_queue_timer_svcs.size())
+            : 0);
+        timer_service* svc = _per_queue_timer_svcs[idx];
+        if (svc == nullptr)
+        {
+            derror("cannot add timer for pool %s: null timer service at index %u",
+                _spec.name.c_str(), idx);
+            return;
+        }
+        svc->add_timer(t);
     }
 }
 
@@ -284,8 +299,36 @@ volatile int* task_engine::get_task_queue_virtual_length_ptr(
     int hash
     )
 {
-    auto pl = get_pool(task_spec::get(code)->pool_code);
-    auto idx = (pl->spec().partitioned ? hash % pl->spec().worker_count : 0);
+    task_spec* spec = task_spec::get(code);
+    if (spec == nullptr)
+    {
+        derror("get_task_queue_virtual_length_ptr got invalid task code %d", code);
+        return nullptr;
+    }
+
+    auto pl = get_pool(spec->pool_code);
+    if (pl == nullptr)
+    {
+        derror("get_task_queue_virtual_length_ptr: no thread pool for task code %s",
+            spec->name.c_str());
+        return nullptr;
+    }
+
+    int worker_count = pl->spec().worker_count;
+    unsigned int idx = 0;
+    if (pl->spec().partitioned && worker_count > 0)
+    {
+        // treat hash as unsigned so a negative hash cannot produce a negative index
+        idx = static_cast<unsigned int>(hash) % static_cast<unsigned int>(worker_count);
+    }
+
+    if (idx >= pl->queues().size())
+    {
+        derror("get_task_queue_virtual_length_ptr: queue index %u out of range (%u queues) for task code %s",
+            idx, static_cast<unsigned int>(pl->queues().size()), spec->name.c_str());
+        return nullptr;
+    }
+
     return pl->queues()[idx]->get_virtual_length_ptr();
 }
 

--- a/src/core/src/task_engine.cpp
+++ b/src/core/src/task_engine.cpp
@@ -112,12 +112,23 @@ void task_worker_pool::create()
 
 void task_worker_pool::start()
 {
-    if (_is_running.load(std::memory_order_acquire))
-        return;
+    // Convenience path for starting a single pool standalone. task_engine::start() does NOT call this;
+    // it instead drives the two phases across all pools -- enable_enqueue() on every pool, then
+    // start_workers() on every pool -- so a worker on_start hook can safely enqueue to any pool during
+    // startup (see task_engine::start()).
+    enable_enqueue();
+    start_workers();
+}
 
-    // Populate the timer-service caches BEFORE starting workers: a worker's on_start hook may enqueue
+void task_worker_pool::enable_enqueue()
+{
+    if (_is_running.load(std::memory_order_acquire))
+    {
+        return;
+    }
+
+    // Populate the timer-service caches BEFORE any worker starts: a worker's on_start hook may enqueue
     // a delayed task, which calls add_timer() directly and requires these caches to already be set.
-    // Doing this after wk->start() would leave a window where add_timer() sees a null/empty cache.
     if (service_engine::fast_instance().spec().timer_io_mode == IOE_PER_QUEUE)
     {
         for (size_t i = 0; i < _queues.size(); i++)
@@ -139,14 +150,18 @@ void task_worker_pool::start()
         _per_node_timer_svc = node()->tsvc(nullptr);
     }
 
-    // Publish the running state BEFORE starting workers. A worker's on_start hook can enqueue an
-    // immediate task, or a short-delay timer can fire before startup finishes; both reach
-    // task_worker_pool::enqueue(), which fatally asserts the pool is already running. The queues
-    // already exist (from create()), so such tasks safely wait in-queue until the workers enter
-    // loop() and drain them. This release store also publishes the timer-service caches populated
-    // above to any thread that later observes _is_running via enqueue() or add_timer().
+    // Publish the running state so this pool accepts enqueues before any worker runs its on_start
+    // hook. Such a hook can enqueue an immediate task (to this pool or another), or a short-delay
+    // timer can fire before startup finishes; both reach task_worker_pool::enqueue(), which fatally
+    // asserts the target pool is already running. The queues already exist (from create()), so such
+    // tasks safely wait in-queue until the workers enter loop() and drain them. This release store
+    // also publishes the timer-service caches populated above to any thread that later observes
+    // _is_running via enqueue() or add_timer().
     _is_running.store(true, std::memory_order_release);
+}
 
+void task_worker_pool::start_workers()
+{
     for (auto& wk : _workers)
     {
         wk->start();
@@ -298,12 +313,30 @@ void task_engine::create(const safe_list<dsn_threadpool_code_t>& pools)
 void task_engine::start()
 {
     if (_is_running.load(std::memory_order_acquire))
+    {
         return;
+    }
+
+    // Two-phase startup across all pools. First enable_enqueue() on every pool (init timer caches and
+    // publish _is_running), THEN start_workers() on every pool. A worker on_start hook in one pool may
+    // enqueue a task targeting a DIFFERENT pool; enabling enqueue everywhere first guarantees the
+    // target pool already accepts tasks (buffering them in its queues) instead of tripping
+    // task_worker_pool::enqueue()'s "must be started" assert. Starting pools one-by-one (enable+start
+    // per pool) left earlier-started pools able to enqueue into not-yet-started pools.
+    for (auto& pl : _pools)
+    {
+        if (pl)
+        {
+            pl->enable_enqueue();
+        }
+    }
 
     for (auto& pl : _pools)
     {
         if (pl)
-            pl->start();
+        {
+            pl->start_workers();
+        }
     }
 
     _is_running.store(true, std::memory_order_release);

--- a/src/core/src/task_engine.cpp
+++ b/src/core/src/task_engine.cpp
@@ -134,6 +134,13 @@ void task_worker_pool::start()
             dassert(svc, "per queue timer service must be present");
             _per_queue_timer_svcs.push_back(svc);
         }
+
+        // add_timer() indexes _per_queue_timer_svcs with a per-queue hash, so enforce the invariant
+        // it relies on once here at startup: exactly one (non-null) timer service per queue. The
+        // per-call asserts in add_timer() remain as a cheap runtime backstop.
+        dassert(_per_queue_timer_svcs.size() == _queues.size(),
+            "per-queue timer service count (%d) must equal queue count (%d)",
+            static_cast<int>(_per_queue_timer_svcs.size()), static_cast<int>(_queues.size()));
     }
     else
     {

--- a/src/core/src/task_engine.cpp
+++ b/src/core/src/task_engine.cpp
@@ -139,6 +139,14 @@ void task_worker_pool::start()
         _per_node_timer_svc = node()->tsvc(nullptr);
     }
 
+    // Publish the running state BEFORE starting workers. A worker's on_start hook can enqueue an
+    // immediate task, or a short-delay timer can fire before startup finishes; both reach
+    // task_worker_pool::enqueue(), which fatally asserts the pool is already running. The queues
+    // already exist (from create()), so such tasks safely wait in-queue until the workers enter
+    // loop() and drain them. This release store also publishes the timer-service caches populated
+    // above to any thread that later observes _is_running via enqueue() or add_timer().
+    _is_running.store(true, std::memory_order_release);
+
     for (auto& wk : _workers)
     {
         wk->start();
@@ -150,8 +158,6 @@ void task_worker_pool::start()
         _spec.worker_count,
         _spec.worker_share_core ? "true" : "false",
         _spec.partitioned ? "true" : "false");
-
-    _is_running.store(true, std::memory_order_release);
 }
 
 void task_worker_pool::add_timer(task* t)

--- a/src/core/src/task_engine.h
+++ b/src/core/src/task_engine.h
@@ -62,6 +62,13 @@ public:
     void create();    
     void start();
 
+    // Two-phase startup helpers used by task_engine::start(). enable_enqueue() initializes the timer
+    // caches and publishes _is_running so the pool accepts enqueues; start_workers() starts the worker
+    // threads. start() calls both. Splitting them lets task_engine enable enqueue on ALL pools before
+    // starting any workers, so a worker on_start hook can safely enqueue cross-pool during startup.
+    void enable_enqueue();
+    void start_workers();
+
     // task procecessing
     void enqueue(task* task);
     void on_dequeue(int count);

--- a/src/core/src/task_spec.cpp
+++ b/src/core/src/task_spec.cpp
@@ -320,7 +320,14 @@ bool threadpool_spec::init(/*out*/ safe_vector<threadpool_spec>& specs)
 
         if (false == spec.worker_share_core && 0 == spec.worker_affinity_mask)
         {
-            spec.worker_affinity_mask = (1 << std::thread::hardware_concurrency()) - 1;
+            // worker_affinity_mask is a 64-bit mask. Shifting the literal int 1 by
+            // hardware_concurrency() is undefined behavior once the count reaches 32 (and it
+            // silently produced wrong masks on many-core machines). Compute the mask in 64-bit
+            // and saturate to all-ones when there are 64 or more hardware threads.
+            unsigned int hc = std::thread::hardware_concurrency();
+            spec.worker_affinity_mask =
+                (hc >= 64) ? ~static_cast<uint64_t>(0)
+                           : ((static_cast<uint64_t>(1) << hc) - 1);
         }
 
         specs.push_back(spec);

--- a/src/core/src/task_worker.cpp
+++ b/src/core/src/task_worker.cpp
@@ -103,7 +103,8 @@ void task_worker::start()
 
     _is_running.store(true, std::memory_order_release);
 
-    _thread = new std::thread(std::bind(&task_worker::run_internal, this));
+    _thread.store(new std::thread(std::bind(&task_worker::run_internal, this)),
+                  std::memory_order_release);
 
     _started.wait();
 }
@@ -115,9 +116,10 @@ void task_worker::stop()
 
     _is_running.store(false, std::memory_order_release);
 
-    _thread->join();
-    delete _thread;
-    _thread = nullptr;
+    std::thread* t = _thread.load(std::memory_order_acquire);
+    t->join();
+    delete t;
+    _thread.store(nullptr, std::memory_order_release);
 
     _is_running.store(false, std::memory_order_release);
 }
@@ -302,7 +304,9 @@ void task_worker::set_affinity(uint64_t affinity)
 
 void task_worker::run_internal()
 {
-    while (_thread == nullptr)
+    // Wait until start() has published the thread handle. _thread is atomic so this read is
+    // a well-defined, synchronized access rather than a data race on a raw pointer.
+    while (_thread.load(std::memory_order_acquire) == nullptr)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }

--- a/src/core/src/transient_memory.cpp
+++ b/src/core/src/transient_memory.cpp
@@ -38,6 +38,7 @@
 # include <cstddef>
 # include <cstdint>
 # include <cstdlib>
+# include <limits>
 # include <memory>
 
 # if defined(__TITLE__)
@@ -127,6 +128,14 @@ namespace dsn
         const size_t user_size = sz;
         const size_t header_size = sizeof(std::shared_ptr<char>) + sizeof(uint32_t);
         const size_t alignment = alignof(std::max_align_t);
+        // Guard against size_t overflow when padding the request for the header and alignment.
+        // Without this, a ~4GB request on a 32-bit build would wrap alloc_size to a tiny value,
+        // and the subsequent writes would run past the end of the allocation (heap overflow).
+        if (user_size > (std::numeric_limits<std::size_t>::max)() - (header_size + alignment - 1))
+        {
+            derror("tls_trans_malloc: requested size %zu is too large", user_size);
+            return nullptr;
+        }
         const size_t alloc_size = user_size + header_size + alignment - 1;
         void* ptr;
         size_t sz2;

--- a/src/dev/cpp/clientlet.cpp
+++ b/src/dev/cpp/clientlet.cpp
@@ -152,16 +152,19 @@ namespace dsn
             }
             else
             {
-                const char** ptr = (const char**)alloca(sizeof(const char*) * (files.size() + 1));
-                const char** ptr_base = ptr;
+                // Use a heap vector instead of alloca(): 'files' is caller-supplied and a large
+                // list would overflow the stack. The c_str() pointers remain valid for the
+                // synchronous call below because 'files' outlives it.
+                std::vector<const char*> ptrs;
+                ptrs.reserve(files.size() + 1);
                 for (auto& f : files)
                 {
-                    *ptr++ = f.c_str();
+                    ptrs.push_back(f.c_str());
                 }
-                *ptr = nullptr;
+                ptrs.push_back(nullptr);
 
                 return dsn_file_copy_remote_files(
-                    remote.c_addr(), source_dir.c_str(), ptr_base,
+                    remote.c_addr(), source_dir.c_str(), ptrs.data(),
                     dest_dir.c_str(), overwrite, native_task
                     );
             }

--- a/src/plugins/dist.uri.resolver/partition_resolver_simple.cpp
+++ b/src/plugins/dist.uri.resolver/partition_resolver_simple.cpp
@@ -312,55 +312,79 @@ namespace dsn
                 }
                 else if (resp.err == ERR_OK)
                 {
-                    zauto_write_lock l(_config_lock);
-
-                    if (_app_id != -1 && _app_id != resp.app_id)
+                    if (resp.app_id <= 0 || resp.partition_count <= 0)
                     {
-                        dassert(false, "app id is changed (mostly the app was removed and created with the same name), local Vs remote: %u vs %u ",
-                            _app_id, resp.app_id);
-                    }
-                    if (_app_partition_count != -1 && _app_partition_count != resp.partition_count)
-                    {
-                        dassert(false, "partition count is changed (mostly the app was removed and created with the same name), local Vs remote: %u vs %u ",
-                            _app_partition_count, resp.partition_count);
-                    }
-                    _app_id = resp.app_id;
-                    _app_partition_count = resp.partition_count;
-                    _app_is_stateful = resp.is_stateful;
-
-                    for (auto it = resp.partitions.begin(); it != resp.partitions.end(); ++it)
-                    {
-                        auto& new_config = *it;
-
-                        dinfo("%s.client: query config reply, gpid = %d.%d, ballot = %" PRId64 ", primary = %s",
+                        // Reject a malformed or hostile config reply instead of caching a
+                        // non-positive partition_count, which would later cause a
+                        // division-by-zero crash in get_partition_index().
+                        derror("%s.client: query config reply, gpid = %d.%d, invalid config: app_id = %d, partition_count = %d",
                             _app_path.c_str(),
-                            new_config.pid.get_app_id(),
-                            new_config.pid.get_partition_index(),
-                            new_config.ballot,
-                            new_config.primary.to_string()
+                            _app_id,
+                            partition_index,
+                            resp.app_id,
+                            resp.partition_count
                             );
 
-                        auto it2 = _config_cache.find(new_config.pid.get_partition_index());
-                        if (it2 == _config_cache.end())
+                        client_err = ERR_INVALID_DATA;
+                    }
+                    else
+                    {
+                        zauto_write_lock l(_config_lock);
+
+                        if ((_app_id != -1 && _app_id != resp.app_id)
+                            || (_app_partition_count != -1 && _app_partition_count != resp.partition_count))
                         {
-                            std::unique_ptr<partition_info> pi(new partition_info);
-                            pi->timeout_count = 0;
-                            pi->config = new_config;
-                            _config_cache.emplace(new_config.pid.get_partition_index(), std::move(pi));
+                            // The app was most likely removed and re-created with the same name, so
+                            // its app id / partition count changed. This is recoverable: drop the
+                            // stale cache and adopt the new configuration rather than aborting the
+                            // whole process (the previous code called dassert(false, ...) here).
+                            dwarn("%s.client: app config changed (mostly the app was removed and re-created "
+                                  "with the same name), app_id %d -> %d, partition_count %d -> %d; resetting local cache",
+                                _app_path.c_str(),
+                                _app_id, resp.app_id,
+                                _app_partition_count, resp.partition_count
+                                );
+
+                            _config_cache.clear();
                         }
-                        else if (_app_is_stateful && it2->second->config.ballot < new_config.ballot)
+                        _app_id = resp.app_id;
+                        _app_partition_count = resp.partition_count;
+                        _app_is_stateful = resp.is_stateful;
+
+                        for (auto it = resp.partitions.begin(); it != resp.partitions.end(); ++it)
                         {
-                            it2->second->timeout_count = 0;
-                            it2->second->config = new_config;
-                        }
-                        else if (!_app_is_stateful)
-                        {
-                            it2->second->timeout_count = 0;
-                            it2->second->config = new_config;
-                        }
-                        else
-                        {
-                            // nothing to do
+                            auto& new_config = *it;
+
+                            dinfo("%s.client: query config reply, gpid = %d.%d, ballot = %" PRId64 ", primary = %s",
+                                _app_path.c_str(),
+                                new_config.pid.get_app_id(),
+                                new_config.pid.get_partition_index(),
+                                new_config.ballot,
+                                new_config.primary.to_string()
+                                );
+
+                            auto it2 = _config_cache.find(new_config.pid.get_partition_index());
+                            if (it2 == _config_cache.end())
+                            {
+                                std::unique_ptr<partition_info> pi(new partition_info);
+                                pi->timeout_count = 0;
+                                pi->config = new_config;
+                                _config_cache.emplace(new_config.pid.get_partition_index(), std::move(pi));
+                            }
+                            else if (_app_is_stateful && it2->second->config.ballot < new_config.ballot)
+                            {
+                                it2->second->timeout_count = 0;
+                                it2->second->config = new_config;
+                            }
+                            else if (!_app_is_stateful)
+                            {
+                                it2->second->timeout_count = 0;
+                                it2->second->config = new_config;
+                            }
+                            else
+                            {
+                                // nothing to do
+                            }
                         }
                     }
                 }
@@ -556,6 +580,14 @@ namespace dsn
 
         int partition_resolver_simple::get_partition_index(int partition_count, uint64_t partition_hash)
         {
+            if (partition_count <= 0)
+            {
+                // Defense in depth: never divide by zero even if an invalid partition_count
+                // somehow reaches here. Callers treat a negative index as "unresolved".
+                derror("%s.client: get_partition_index with invalid partition_count = %d",
+                    _app_path.c_str(), partition_count);
+                return -1;
+            }
             return partition_hash % static_cast<uint64_t>(partition_count);
         }
     }

--- a/src/plugins/tools.common/asio_net_provider.cpp
+++ b/src/plugins/tools.common/asio_net_provider.cpp
@@ -165,7 +165,15 @@ namespace dsn {
             {
                 tlen += bufs[i].sz;
             }
-            dassert(tlen <= max_udp_packet_size, "the message is too large to send via a udp channel");
+            if (tlen > max_udp_packet_size)
+            {
+                // Do not abort the whole process because one message is oversized: drop it and
+                // let the rpc matcher time the call out (same as the send-failure path below).
+                derror("the message (%zu bytes) is too large to send via a udp channel (max %zu); dropping it",
+                    tlen,
+                    max_udp_packet_size);
+                return;
+            }
 
             std::unique_ptr<char[]> packet_buffer(new char[tlen]);
             for (int i = 0; i < rcount; i ++)

--- a/src/plugins/tools.common/http_message_parser.cpp
+++ b/src/plugins/tools.common/http_message_parser.cpp
@@ -193,7 +193,7 @@ http_message_parser::http_message_parser()
         {
             if (!::dsn::utils::lexical_cast_integer(value, header->id))
             {
-                derror("invalid header.id '%.*s'", length, at);
+                derror("invalid header.id '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -202,7 +202,7 @@ http_message_parser::http_message_parser()
         {
             if (!::dsn::utils::lexical_cast_integer(value, header->trace_id))
             {
-                derror("invalid header.trace_id '%.*s'", length, at);
+                derror("invalid header.trace_id '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -211,13 +211,13 @@ http_message_parser::http_message_parser()
         {
             if (length >= DSN_MAX_TASK_CODE_NAME_LENGTH)
             {
-                derror("too long header.rpc_name '%.*s'", length, at);
+                derror("too long header.rpc_name '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             int name_len = snprintf(header->rpc_name, sizeof(header->rpc_name), "%.*s", static_cast<int>(length), at);
             if (name_len < 0 || static_cast<size_t>(name_len) >= sizeof(header->rpc_name))
             {
-                derror("too long header.rpc_name '%.*s'", length, at);
+                derror("too long header.rpc_name '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -226,7 +226,7 @@ http_message_parser::http_message_parser()
         {
             if (!::dsn::utils::lexical_cast_integer(value, header->gpid.u.app_id))
             {
-                derror("invalid header.app_id '%.*s'", length, at);
+                derror("invalid header.app_id '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -235,7 +235,7 @@ http_message_parser::http_message_parser()
         {
             if (!::dsn::utils::lexical_cast_integer(value, header->gpid.u.partition_index))
             {
-                derror("invalid header.partition_index '%.*s'", length, at);
+                derror("invalid header.partition_index '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -245,7 +245,7 @@ http_message_parser::http_message_parser()
             dsn_msg_serialize_format fmt = enum_from_string(value.c_str(), DSF_INVALID);
             if (fmt == DSF_INVALID)
             {
-                derror("invalid header.serialize_format '%.*s'", length, at);
+                derror("invalid header.serialize_format '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             header->context.u.serialize_format = fmt;
@@ -269,14 +269,14 @@ http_message_parser::http_message_parser()
             }
             if (pos == -1 || pos == (length - 1) || dot_count != 3)
             {
-                derror("invalid header.from_address '%.*s'", length, at);
+                derror("invalid header.from_address '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             uint16_t port = 0;
             std::string port_str(at + pos + 1, length - pos - 1);
             if (!::dsn::utils::lexical_cast_integer(port_str, port))
             {
-                derror("invalid header.from_address '%.*s'", length, at);
+                derror("invalid header.from_address '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             std::string host(at, pos);
@@ -287,7 +287,7 @@ http_message_parser::http_message_parser()
         {
             if (!::dsn::utils::lexical_cast_integer(value, header->client.timeout_ms))
             {
-                derror("invalid header.client_timeout '%.*s'", length, at);
+                derror("invalid header.client_timeout '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -296,7 +296,7 @@ http_message_parser::http_message_parser()
         {
             if (!::dsn::utils::lexical_cast_integer(value, header->client.thread_hash))
             {
-                derror("invalid header.client_thread_hash '%.*s'", length, at);
+                derror("invalid header.client_thread_hash '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -305,7 +305,7 @@ http_message_parser::http_message_parser()
         {
             if (!::dsn::utils::lexical_cast_integer(value, header->client.partition_hash))
             {
-                derror("invalid header.client_partition_hash '%.*s'", length, at);
+                derror("invalid header.client_partition_hash '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -314,13 +314,13 @@ http_message_parser::http_message_parser()
         {
             if (length >= DSN_MAX_ERROR_CODE_NAME_LENGTH)
             {
-                derror("too long header.server_error '%.*s'", length, at);
+                derror("too long header.server_error '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             int name_len = snprintf(header->server.error_name, sizeof(header->server.error_name), "%.*s", static_cast<int>(length), at);
             if (name_len < 0 || static_cast<size_t>(name_len) >= sizeof(header->server.error_name))
             {
-                derror("too long header.server_error '%.*s'", length, at);
+                derror("too long header.server_error '%.*s'", static_cast<int>(length), at);
                 return 1;
             }
             break;
@@ -366,12 +366,54 @@ http_message_parser::http_message_parser()
     _parser_setting.on_body = [](http_parser* parser, const char *at, size_t length)->int
     {
         auto owner = static_cast<http_message_parser*>(parser->data);
+        if (!owner->_current_message)
+        {
+            derror("http body received without an active message");
+            return 1;
+        }
         dassert(owner->_current_buffer.buffer() != nullptr, "the read buffer is not owning");
-        owner->_current_message->buffers.rbegin()->assign(owner->_current_buffer.buffer(), at - owner->_current_buffer.buffer_ptr(), length);
-        owner->_current_message->header->body_length = length;
+
+        // http_parser may deliver the body in several segments (chunked encoding, or a body
+        // split across multiple socket reads). The previous code moved _current_message into
+        // _received_messages on the very first segment, so any subsequent segment dereferenced
+        // a moved-from (null) _current_message and crashed. Accumulate here instead and only
+        // finalize the message in on_message_complete.
+        auto& body_buf = *owner->_current_message->buffers.rbegin();
+        if (body_buf.length() == 0)
+        {
+            // fast path: first (and usually only) segment references the read buffer directly.
+            body_buf.assign(owner->_current_buffer.buffer(),
+                            static_cast<int>(at - owner->_current_buffer.buffer_ptr()),
+                            static_cast<unsigned int>(length));
+        }
+        else
+        {
+            // more than one segment: concatenate into a fresh contiguous buffer so no earlier
+            // segment is lost (a single blob slice cannot span non-contiguous segments).
+            unsigned int old_len = body_buf.length();
+            unsigned int new_len = old_len + static_cast<unsigned int>(length);
+            std::shared_ptr<char> holder = make_shared_array<char>(new_len);
+            memcpy(holder.get(), body_buf.data(), old_len);
+            memcpy(holder.get() + old_len, at, length);
+            body_buf.assign(std::move(holder), 0, new_len);
+        }
+        owner->_current_message->header->body_length = owner->_current_message->buffers.rbegin()->length();
+        return 0;
+    };
+    _parser_setting.on_message_complete = [](http_parser* parser)->int
+    {
+        auto owner = static_cast<http_message_parser*>(parser->data);
+        if (!owner->_current_message)
+        {
+            derror("http message completed without an active message");
+            return 1;
+        }
+        // The message (including any body) is fully parsed now; hand it off. Doing this here
+        // rather than in on_body also fixes bodyless requests (e.g. GET), which never trigger
+        // on_body and were therefore previously never delivered.
         owner->_received_messages.emplace(std::move(owner->_current_message));
         return 0;
-    };    
+    };
     http_parser_init(&_parser, HTTP_BOTH);
 }
 

--- a/src/plugins/tools.common/native_aio_provider.linux.cpp
+++ b/src/plugins/tools.common/native_aio_provider.linux.cpp
@@ -40,6 +40,8 @@
 # include <cstdlib>
 # include <cstdint>
 # include <cerrno>
+# include <cstring>
+# include <ctime>
 # include <thread>
 
 # ifdef __TITLE__
@@ -51,16 +53,28 @@ namespace dsn {
     namespace tools {
 
         native_linux_aio_provider::native_linux_aio_provider(disk_engine* disk, aio_provider* inner_provider)
-            : aio_provider(disk, inner_provider)
+            : aio_provider(disk, inner_provider), _is_running(false)
         {
 
             memset(&_ctx, 0, sizeof(_ctx));
             auto ret = io_setup(128, &_ctx); // 128 concurrent events
+            // io_setup failing (e.g. the system-wide aio-max-nr limit is exhausted) leaves this
+            // provider unable to service any disk I/O for its entire lifetime -- there is no retry
+            // path, so every aio request would fail. A storage node that stays up but silently
+            // fails all disk I/O is worse for the cluster than one that dies loudly and lets the
+            // orchestrator restart/replace it, so fail fast here.
             dassert(ret == 0, "io_setup error, ret = %d", ret);
+            _is_running = true;
         }
 
         native_linux_aio_provider::~native_linux_aio_provider()
         {
+            // Stop the completion worker before releasing the io context, otherwise
+            // io_destroy() below can race with io_getevents() still running on the worker.
+            _is_running = false;
+            if (_worker.joinable())
+                _worker.join();
+
             auto ret = io_destroy(_ctx);
             if (ret != 0)
             {
@@ -72,7 +86,9 @@ namespace dsn {
 
         void native_linux_aio_provider::start(io_modifer& ctx)
         {
-            new std::thread([this, ctx]()
+            // Keep the worker joinable so the destructor can shut it down cleanly instead of
+            // leaking a detached thread that outlives the provider and touches a freed context.
+            _worker = std::thread([this, ctx]()
             {
                 task::set_tls_dsn_context(node(), nullptr, ctx.queue);
                 get_event();
@@ -144,14 +160,25 @@ namespace dsn {
             }
             task_worker::set_name(buffer);
 
-            while (true)
+            struct timespec timeout;
+            while (_is_running.load(std::memory_order_relaxed))
             {
-                ret = io_getevents(_ctx, 1, 1, events, nullptr);
+                // use a bounded timeout so the worker periodically observes _is_running and can
+                // exit cleanly on shutdown instead of blocking in io_getevents() forever.
+                timeout.tv_sec = 1;
+                timeout.tv_nsec = 0;
+                ret = io_getevents(_ctx, 1, 1, events, &timeout);
                 if (ret > 0) // should be 1
                 {
                     dassert(ret == 1, "");
                     struct iocb *io = events[0].obj;
-                    complete_aio(io, static_cast<int>(events[0].res), static_cast<int>(events[0].res2));
+                    complete_aio(io, static_cast<int64_t>(events[0].res), static_cast<int64_t>(events[0].res2));
+                }
+                else if (ret == 0 || ret == -EINTR)
+                {
+                    // timed out with no completion, or interrupted by a signal:
+                    // loop back and re-check whether we should keep running.
+                    continue;
                 }
                 else
                 {
@@ -160,19 +187,31 @@ namespace dsn {
             }
         }
 
-        void native_linux_aio_provider::complete_aio(struct iocb* io, int bytes, int err)
+        void native_linux_aio_provider::complete_aio(struct iocb* io, int64_t res, int64_t res2)
         {
             linux_disk_aio_context* aio = CONTAINING_RECORD(io, linux_disk_aio_context, cb);
             error_code ec;
-            if (err != 0)
+            uint32_t bytes = 0;
+            if (res < 0)
             {
-                derror("aio error, err = %s", strerror(err));
+                // io_getevents reports a failed operation as a negative errno in res; res2 is a
+                // secondary status that is almost always 0. The previous code only inspected res2
+                // and therefore turned a real I/O error (res < 0) into a spurious ERR_HANDLE_EOF
+                // with a negative byte count. Decode res correctly here.
+                derror("aio error, err = %s", strerror(static_cast<int>(-res)));
                 ec = ERR_FILE_OPERATION_FAILED;
+            }
+            else if (res == 0)
+            {
+                // a zero-byte transfer on a read is end-of-file
+                ec = ERR_HANDLE_EOF;
             }
             else
             {
-                ec = bytes > 0 ? ERR_OK : ERR_HANDLE_EOF;
+                ec = ERR_OK;
+                bytes = static_cast<uint32_t>(res);
             }
+            (void)res2;
 
             if (!aio->evt)
             {

--- a/src/plugins/tools.common/native_aio_provider.linux.h
+++ b/src/plugins/tools.common/native_aio_provider.linux.h
@@ -41,6 +41,8 @@
 # include <dsn/tool_api.h>
 # include <dsn/utility/synchronize.h>
 # include <queue>
+# include <atomic>
+# include <thread>
 # include <cinttypes>     /* uint64_t */
 # include <cstring>       /* memset() */
 # include <cstdio>        /* for perror() */
@@ -77,11 +79,13 @@ namespace dsn {
 
         protected:
             error_code aio_internal(aio_task* aio, bool async, /*out*/ uint32_t* pbytes = nullptr);
-            void complete_aio(struct iocb* io, int bytes, int err);
+            void complete_aio(struct iocb* io, int64_t res, int64_t res2);
             void get_event();
 
         private:
             io_context_t _ctx;
+            std::atomic<bool> _is_running;
+            std::thread _worker;
         };
     }
 }

--- a/src/plugins/tools.common/native_aio_provider.win.cpp
+++ b/src/plugins/tools.common/native_aio_provider.win.cpp
@@ -374,14 +374,18 @@ void native_win_aio_provider::worker()
         if (ret)
         {
             windows_disk_aio_context* ctx = CONTAINING_RECORD(overLap, windows_disk_aio_context, olp);
+            // A successful completion that transferred zero bytes is end-of-file (or a zero-length
+            // request). Map it to ERR_HANDLE_EOF so this provider matches the POSIX/Linux providers
+            // (bytes > 0 ? ERR_OK : ERR_HANDLE_EOF), a contract the NFS file-copy plugin relies on.
+            error_code err = (dwTransLen > 0) ? ::dsn::ERR_OK : ::dsn::ERR_HANDLE_EOF;
             if (!ctx->evt)
             {
                 aio_task* aio(ctx->tsk);
-                complete_io(aio, ::dsn::ERR_OK, dwTransLen);
+                complete_io(aio, err, dwTransLen);
             }
             else
             {
-                ctx->err = ::dsn::ERR_OK;
+                ctx->err = err;
                 ctx->bytes = dwTransLen;
                 ctx->evt->notify();
             }

--- a/src/plugins/tools.common/profiler_command.cpp
+++ b/src/plugins/tools.common/profiler_command.cpp
@@ -214,6 +214,14 @@ namespace dsn {
             ::std::stringstream ss;
             safe_vector<safe_string> val;
 
+            // percentail_counter_string has COUNTER_PERCENTILE_COUNT entries; percentile_type may be
+            // COUNTER_PERCENTILE_INVALID (== COUNTER_PERCENTILE_COUNT range), so never index the array blindly.
+            auto safe_pct_label = [](int pt) -> const char* {
+                return (pt >= 0 && pt < COUNTER_PERCENTILE_COUNT)
+                           ? percentail_counter_string[pt].c_str()
+                           : "InvalidPercentile";
+            };
+
             if ((args.size() > 0) && (args[0] == "top"))
             {
                 if (k < 4)
@@ -253,7 +261,7 @@ namespace dsn {
 
                 if ((task_id != TASK_CODE_INVALID) && (counter_type != PREF_COUNTER_INVALID) && (s_spec_profilers[task_id].ptr[counter_type] != nullptr) && (s_spec_profilers[task_id].is_profile != false))
                 {
-                    ss << dsn_task_code_to_string(task_id) << ":" << counter_info_ptr[counter_type]->title << ":" << percentail_counter_string[percentile_type] << ":";
+                    ss << dsn_task_code_to_string(task_id) << ":" << counter_info_ptr[counter_type]->title << ":" << safe_pct_label(percentile_type) << ":";
                     if (counter_info_ptr[counter_type]->type != COUNTER_TYPE_NUMBER_PERCENTILES)
                     {
                         ss << s_spec_profilers[task_id].ptr[counter_type]->get_value() << " ";
@@ -263,13 +271,13 @@ namespace dsn {
                         ss << s_spec_profilers[task_id].ptr[counter_type]->get_percentile(percentile_type) << " ";
                     }
                 }
-                else if ((task_id != TASK_CODE_INVALID) && (val[1] == "AllPercentile") && (s_spec_profilers[task_id].is_profile != false))
+                else if ((task_id != TASK_CODE_INVALID) && (val[1] == "AllPercentile") && (percentile_type != COUNTER_PERCENTILE_INVALID) && (s_spec_profilers[task_id].is_profile != false))
                 {
                     for (int j = 0; j < PREF_COUNTER_COUNT; j++)
                     {
                         if ((s_spec_profilers[task_id].ptr[j] != nullptr) && (counter_info_ptr[j]->type == COUNTER_TYPE_NUMBER_PERCENTILES))
                         {
-                            ss << dsn_task_code_to_string(i) << ":" << counter_info_ptr[j]->title << ":" << percentail_counter_string[percentile_type] << ":" << s_spec_profilers[task_id].ptr[j]->get_percentile(percentile_type) << " ";
+                            ss << dsn_task_code_to_string(task_id) << ":" << counter_info_ptr[j]->title << ":" << safe_pct_label(percentile_type) << ":" << s_spec_profilers[task_id].ptr[j]->get_percentile(percentile_type) << " ";
                         }
                     }
                     val.clear();

--- a/src/plugins/tools.common/simple_logger.cpp
+++ b/src/plugins/tools.common/simple_logger.cpp
@@ -176,7 +176,8 @@ namespace dsn {
             {
                 // Do not abort during logger initialization if the log directory cannot be listed:
                 // skip scanning existing files and continue with a fresh index. Use stderr directly
-                // because the logging system is not fully initialized at this point.
+                // because the logging system is not fully initialized at this point. Existing logs are
+                // preserved because create_log_file() opens in append mode rather than truncating.
                 fprintf(stderr, "Fail to get subfiles in %s, skip scanning existing log files.\n",
                     _log_dir.c_str());
                 sub_list.clear();
@@ -225,7 +226,11 @@ namespace dsn {
             std::stringstream str;
             // so now the start index is from 0
             str << _log_dir << "/log." << _index++ << ".txt";
-            _log = ::fopen(str.str().c_str(), "w+");
+            // Open in append mode ("a+") rather than truncating ("w+"): during normal rotation the
+            // computed index refers to a fresh file so this is equivalent, but if scanning existing
+            // files was skipped (e.g. get_subfiles() failed and we reset to index 1) this avoids
+            // clobbering logs that already exist on disk.
+            _log = ::fopen(str.str().c_str(), "a+");
             if (_log == nullptr)
             {
                 fprintf(stderr, "failed to open log file %s: %s\n", str.str().c_str(), strerror(errno));

--- a/src/plugins/tools.common/simple_logger.cpp
+++ b/src/plugins/tools.common/simple_logger.cpp
@@ -174,8 +174,13 @@ namespace dsn {
             std::vector<std::string> sub_list;
             if (!dsn::utils::filesystem::get_subfiles(_log_dir, sub_list, false))
             {
-                dassert(false, "Fail to get subfiles in %s.", _log_dir.c_str());
-            }             
+                // Do not abort during logger initialization if the log directory cannot be listed:
+                // skip scanning existing files and continue with a fresh index. Use stderr directly
+                // because the logging system is not fully initialized at this point.
+                fprintf(stderr, "Fail to get subfiles in %s, skip scanning existing log files.\n",
+                    _log_dir.c_str());
+                sub_list.clear();
+            }
             for (auto& fpath : sub_list)
             {
                 auto&& name = dsn::utils::filesystem::get_file_name(fpath);

--- a/src/plugins/tools.common/simple_task_queue.cpp
+++ b/src/plugins/tools.common/simple_task_queue.cpp
@@ -79,11 +79,12 @@ namespace dsn
 
         void simple_timer_service::add_timer(task* task)
         {
+            int delay_ms = task->delay_milliseconds();
             std::shared_ptr<boost::asio::deadline_timer> timer(new boost::asio::deadline_timer(_ios));
-            timer->expires_from_now(boost::posix_time::milliseconds(task->delay_milliseconds()));
+            timer->expires_from_now(boost::posix_time::milliseconds(delay_ms));
             task->set_delay(0);
 
-            timer->async_wait([task, timer](const boost::system::error_code& ec)
+            timer->async_wait([task, timer, delay_ms](const boost::system::error_code& ec)
             {
                 if (!ec)
                 {
@@ -91,8 +92,15 @@ namespace dsn
                 }
                 else if (ec != ::boost::asio::error::operation_aborted)
                 {
-                    dfatal("timer failed for task %s, err = %u",
-                        task->spec().name.c_str(), ec.value());
+                    // A timer failure used to abort the whole process (dfatal), which is too harsh
+                    // for a single timer. But we must not run the task early either: its delay has
+                    // not actually elapsed. Restore the delay and re-enqueue -- task::enqueue routes
+                    // delayed tasks back to add_timer, re-arming a fresh timer -- so the task still
+                    // fires after ~its intended delay instead of immediately, and is not lost.
+                    derror("timer failed for task %s, err = %u, rescheduling after %d ms",
+                        task->spec().name.c_str(), ec.value(), delay_ms);
+                    task->set_delay(delay_ms);
+                    task->enqueue();
                 }
 
                 // to consume the added ref count by task::enqueue for add_timer

--- a/src/plugins/tools.common/thrift_message_parser.cpp
+++ b/src/plugins/tools.common/thrift_message_parser.cpp
@@ -156,7 +156,7 @@ namespace dsn
 
         // write thrift message end
         binary_writer end_writer;
-        binary_writer_transport end_trans(header_writer);
+        binary_writer_transport end_trans(end_writer);
         boost::shared_ptr<binary_writer_transport> end_trans_ptr(&end_trans, [](binary_writer_transport*) {});
         ::apache::thrift::protocol::TBinaryProtocol end_proto(end_trans_ptr);
         end_proto.writeMessageEnd();


### PR DESCRIPTION
## Summary

This PR collects the fixes from a focused audit of rDSN for common and design-level
bugs. It covers **27 distinct findings** (4 high / 13 medium / 10 low severity) across
the core runtime, serialization helpers, and the `tools.common` plugins, plus a
portability commit adding missing standard headers.

The recurring theme is **crash-vs-recover discipline**: the framework aborted the whole
process (`dassert`/`dfatal`) for many conditions that are actually *recoverable* or
*attacker/peer-controlled* (untrusted wire data, oversized datagrams, a single bad timer,
public-API misuse). Those are converted into logged error returns. Conversely, a few
genuine, unreachable **invariant violations** that were being silently swallowed are now
made to fail loudly. Nothing changes for valid inputs on the happy path.

## What's fixed, by theme

### Untrusted / wire-data hardening
- **thrift_helper**: vector `resize(count)` driven by an untrusted list count could trigger
  a huge allocation / OOM; now bounded and read element-by-element.
- **partition_resolver_simple**: division by zero when a meta server returns
  `partition_count == 0`; now validated.
- **protobuf_helper**: ignored return values from `MergePartialFromCodedStream` /
  `ParseFromString` are now checked.

### Null-dereference guards
- **http_message_parser**: multi-chunk body finalized via `std::move` left a null message
  and dereferenced it (high); fixed to accumulate correctly.
- **task.cpp**: `rpc_response_task` ctor dereferenced `task_spec::get(request->local_rpc_code)`
  without a null/type check.
- **task_engine**: `get_virtual_length_ptr` dereferenced a possibly-null spec/pool and used
  unchecked `worker_count` / queue index.

### Crash-vs-recover (locally-triggerable aborts → recoverable errors)
- **asio_net_provider**: oversized UDP send aborted the host; now drops + logs (matches the
  existing best-effort UDP failure path).
- **native_aio_provider.linux**: `io_setup` failure now fails clearly at init rather than
  running a non-functional AIO provider (essential-subsystem init still aborts by design).
- **simple_task_queue**: a non-cancel timer error aborted the process; now logged, one timer
  dropped.
- **disk_engine** `disk_file::ctrl`, **simple_logger** `get_subfiles` failure,
  **partition_resolver_simple** app-recreated `dassert(false)`, **clientlet** unbounded
  `alloca(files.size())` (stack overflow) — all made non-fatal / bounded.

### Core startup & lifecycle (refined over review)
- **task_worker_pool / task_engine startup ordering**: timer-service caches are now populated
  and `_is_running` published *before* workers start, and `task_engine::start()` enables
  enqueue on **all** pools before starting **any** workers. This closes a window where a
  worker `on_start` hook (immediate task, or a short-delay timer firing during startup) could
  enqueue same-pool or cross-pool and trip `task_worker_pool::enqueue()`'s "must be started"
  assert. `start()` was split into `enable_enqueue()` + `start_workers()`.
- **Public C API boundary**: `dsn_rpc_create_response_task[_ex]` and `dsn_rpc_call_wait`
  now validate the request message (registered `RPC_REQUEST` code with a valid paired
  `RPC_RESPONSE` code) and return `nullptr` instead of tripping the `rpc_response_task`
  constructor asserts. The constructor keeps its asserts as an internal backstop.
- **native_aio_provider.linux**: the AIO worker `std::thread` was discarded and never joined
  (leak + `io_destroy`/`get_event` race on shutdown); now owned and joined.
- **task_worker**: worker `_thread` pointer was read non-atomically by the worker while the
  starter wrote it.

### Integer overflow / undefined behavior
- **task_spec**: `(1 << hardware_concurrency()) - 1` is signed-shift UB on ≥32-core hosts.
- **disk_engine**: `uint32` size + buffer batch arithmetic could overflow and bypass
  `_max_batch_bytes`.
- **transient_memory**: `tls_trans_malloc` size arithmetic could wrap near `SIZE_MAX`.

### Memory safety & logic
- **blob**: `range()` accepted a negative offset (pointer moved before the buffer, inflated
  length); `read()` in thrift_helper unconditionally `static_cast`ed the protocol type.
- **profiler_command**: `AllPercentile` path indexed a 5-element array with a
  command-supplied `COUNTER_PERCENTILE_INVALID`.
- **autoref_ptr**: `ref_ptr` move-assign lacked a self-move guard (dropped its own ref → UAF).
- **http_message_parser**: `%.*s` precision arg passed a `size_t` where `int` is required.
- **thrift_message_parser**: `end_trans` wrapped the wrong writer.
- **disk_engine**: `process_write` recursed on synchronous write-prep failures (stack overflow);
  converted to iteration.

### Portability
- Added missing standard headers (`<cstdint>`, `<cstring>`, etc.) across ~90 files so the
  tree compiles cleanly under stricter/newer toolchains.

## Design principle applied

Abort **only** for unreachable programmer errors and failed initialization of essential
subsystems that have no retry path (e.g. `io_setup`, an unregistered `rpc_response` request
code, a missing per-queue timer service). **Recover and return an error** for anything
input-driven or per-request: untrusted wire data, oversized UDP, one bad timer, a listing
failure, or public-API misuse.