### PR TITLE
Harden core JSON decoding, singleton init, and startup arg parsing against faults

### DIFF
--- a/include/dsn/cpp/json_helper.h
+++ b/include/dsn/cpp/json_helper.h
@@ -272,9 +272,13 @@ inline void json_decode(dsn::json::string_tokenizer& in, dsn::gpid& pid)
     json_decode(in, gpid_message);
     dsn_global_partition_id c_gpid;
     c_gpid.value = 0;
-    dassert(sscanf(gpid_message.c_str(), "%d.%d", &c_gpid.u.app_id, &c_gpid.u.partition_index) == 2,
-            "invalid gpid format: %s",
-            gpid_message.c_str());
+    if (sscanf(gpid_message.c_str(), "%d.%d", &c_gpid.u.app_id, &c_gpid.u.partition_index) != 2)
+    {
+        // malformed gpid from (untrusted/corrupt) input: report through the
+        // exception channel that the top-level decode() already handles, instead
+        // of aborting the process via dassert.
+        throw std::runtime_error("json parse error: invalid gpid format");
+    }
     pid = dsn::gpid(c_gpid);
 }
 
@@ -286,7 +290,22 @@ inline void json_decode(dsn::json::string_tokenizer& in, dsn::rpc_address& addre
 {
     std::string rpc_address_string;
     json_decode(in, rpc_address_string);
-    address.from_string_ipv4(rpc_address_string.c_str());
+    // An unset/invalid address is legitimately encoded as "invalid address"
+    // (see dsn_address_to_string); accept that marker and leave the address
+    // invalid so e.g. a partition with no primary round-trips correctly. Any
+    // other string that fails to parse is malformed input: report it through the
+    // exception channel the top-level decode() handles, instead of silently
+    // storing an invalid address that a later invariant check (e.g. the
+    // secondaries assert in initialize_node_state) would abort on.
+    address.set_invalid();
+    if (rpc_address_string == "invalid address")
+    {
+        return;
+    }
+    if (!address.from_string_ipv4(rpc_address_string.c_str()))
+    {
+        throw std::runtime_error("json parse error: invalid rpc_address");
+    }
 }
 
 inline void json_encode(std::stringstream& out, const dsn::partition_configuration& config);

--- a/include/dsn/cpp/json_helper.h
+++ b/include/dsn/cpp/json_helper.h
@@ -41,6 +41,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <stdexcept>
 #include <type_traits>
 #include <cctype>
 #include <utility>
@@ -145,7 +146,11 @@ public:
 public:
     string_tokenizer(const char* b, unsigned offset, unsigned len): buffer(b), pos(offset), length(len)
     {
-        dassert(pos<length, "");
+        // an offset beyond the buffer end is a programming error; an offset that
+        // equals the length (empty or fully-consumed buffer) is tolerated so that
+        // corrupt/empty input surfaces as a parse failure (thrown below) rather
+        // than a process abort here.
+        dassert(pos <= length, "invalid json tokenizer offset %u (length %u)", pos, length);
     }
     string_tokenizer(const dsn::blob& source, unsigned from): string_tokenizer(source.data(), from, source.length()) {}
     string_tokenizer(const dsn::blob& source): string_tokenizer(source.data(), 0, source.length()) {}
@@ -160,7 +165,9 @@ public:
             ++pos, ++j;
         if (token[j]!=0)
         {
-            dassert(false, "invalid buffer:%s at pos %d", buffer, pos);
+            // malformed input: report through the exception channel that the
+            // top-level decode() already handles, instead of aborting.
+            throw std::runtime_error("json parse error: unexpected token");
         }
     }
     void expect_token(char token)
@@ -170,14 +177,16 @@ public:
             ++pos;
         else
         {
-            dassert(false, "invalid buffer:%s at pos %d", buffer, pos);
+            throw std::runtime_error("json parse error: unexpected token");
         }
     }
     char peek_next() const
     {
-        int i = pos;
+        unsigned i = pos;
         while (i<length && isblank(buffer[i])) ++i;
-        return buffer[i];
+        // guard against reading past the end of the buffer on truncated input;
+        // returning a non-splitter sentinel lets the caller's decode throw.
+        return i<length ? buffer[i] : '\0';
     }
     void walk_until(char token)
     {
@@ -186,7 +195,7 @@ public:
             return;
         else
         {
-            dassert(false, "invalid buffer:%s at pos %d", buffer, pos);
+            throw std::runtime_error("json parse error: unterminated token");
         }
     }
     void walk_until_json_splitter()

--- a/include/dsn/cpp/json_helper.h
+++ b/include/dsn/cpp/json_helper.h
@@ -302,7 +302,14 @@ inline void json_decode(dsn::json::string_tokenizer& in, dsn::rpc_address& addre
     {
         return;
     }
-    if (!address.from_string_ipv4(rpc_address_string.c_str()))
+    // from_string_ipv4() returns true even when the host cannot be converted: it
+    // splits host:port and calls assign_ipv4(), which stores
+    // dsn_ipv4_from_host(host) -- and that yields 0 for a malformed/unresolvable
+    // host (e.g. "999.999.999.999:12345") or an empty host (":12345"). The result
+    // is a non-invalid 0.0.0.0:port that would slip past the is_invalid() checks
+    // downstream. A genuine serialized node address is never 0.0.0.0, so treat a
+    // false return OR a zero ip as malformed input and reject it.
+    if (!address.from_string_ipv4(rpc_address_string.c_str()) || address.ip() == 0)
     {
         throw std::runtime_error("json parse error: invalid rpc_address");
     }

--- a/include/dsn/utility/singleton.h
+++ b/include/dsn/utility/singleton.h
@@ -59,16 +59,27 @@ public:
                 }
             }
 
+            // Release _l on every exit path -- including when T's constructor
+            // throws (e.g. std::bad_alloc under memory pressure). Otherwise the
+            // lock stays held forever and any later instance() call spins on _l
+            // for good. That is especially dangerous for a re-entrant call on
+            // this same thread -- e.g. the failure is reported through a path
+            // that logs, and logging itself calls instance() -- which would
+            // self-deadlock. The guard turns the failure into a clean, retryable
+            // throw (fail-stop) instead of a hang.
+            struct unlocker
+            {
+                std::atomic<int>& l;
+                ~unlocker() { l.store(0, std::memory_order_release); }
+            } unlock_guard{_l};
+
             // re-check and assign
             instance = _instance.load(std::memory_order_acquire);
             if (nullptr == instance)
             {
                 instance = new T();
                 _instance.store(instance, std::memory_order_release);
-            }            
-
-            // unlock
-            _l.store(0, std::memory_order_release);
+            }
         }
         return *instance;
     }

--- a/src/core/src/disk_engine.cpp
+++ b/src/core/src/disk_engine.cpp
@@ -349,7 +349,7 @@ void disk_engine::process_write(aio_task* aio, uint32_t sz)
     // Returns the next queued work item (or nullptr) after completing 'wk' with an error, and
     // writes the next batch size through next_sz. We loop on this below instead of recursing so
     // that a disk that keeps failing synchronously cannot overflow the stack.
-    auto complete_write_with_error = [this](aio_task* wk, error_code err, uint32_t* next_sz) -> aio_task*
+    auto complete_write_with_error = [](aio_task* wk, error_code err, uint32_t* next_sz) -> aio_task*
     {
         auto df = (disk_file*)wk->aio()->file_object;
         return df->on_write_completed(wk, (void*)next_sz, err, 0);

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -634,9 +634,23 @@ bool run(
                 if (::dsn::safe_string("apps.") + argskvs.front() == sp.config_section)
                 {
                     if (argskvs.size() < 2)
+                    {
                         create_it = true;
+                    }
                     else
-                        create_it = (std::stoi(argskvs.back().c_str()) == sp.index);
+                    {
+                        int app_index = 0;
+                        if (!::dsn::utils::lexical_cast_integer<int>(
+                                std::string(argskvs.back().c_str()), app_index))
+                        {
+                            fprintf(stderr,
+                                "Invalid app index '%s' in app_list for %s, expected an integer.\n",
+                                argskvs.back().c_str(),
+                                sp.config_section.c_str());
+                            return false;
+                        }
+                        create_it = (app_index == sp.index);
+                    }
                     break;
                 }
             }

--- a/src/core/src/singleton.test.cpp
+++ b/src/core/src/singleton.test.cpp
@@ -1,0 +1,118 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ * 
+ * -=- Robust Distributed System Nucleus (rDSN) -=- 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Description:
+ *     Unit-test for dsn::utils::singleton, focusing on the guarantee that the
+ *     internal initialization lock is released when T's constructor throws
+ *     (e.g. std::bad_alloc under memory pressure), so instance() fails-stop and
+ *     stays retryable instead of dead-spinning on the lock forever.
+ *
+ * Revision history:
+ *     2026-07-02, first version
+ */
+
+# include <dsn/utility/singleton.h>
+# include <gtest/gtest.h>
+# include <stdexcept>
+
+namespace {
+
+// A well-behaved singleton used to check the normal (no-throw) path.
+struct good_singleton : public dsn::utils::singleton<good_singleton>
+{
+    good_singleton() : value(42) {}
+    int value;
+
+    static int lock_state() { return _l.load(std::memory_order_acquire); }
+};
+
+// A singleton whose constructor throws on demand, to simulate a failure during
+// "new T()". lock_state() exposes the otherwise-internal spinlock so the test
+// can prove the RAII unlock guard released it even on the throwing path.
+struct throwing_singleton : public dsn::utils::singleton<throwing_singleton>
+{
+    throwing_singleton()
+    {
+        if (s_should_throw)
+        {
+            throw std::runtime_error("simulated constructor failure");
+        }
+    }
+
+    static bool s_should_throw;
+
+    static int lock_state() { return _l.load(std::memory_order_acquire); }
+};
+
+bool throwing_singleton::s_should_throw = true;
+
+} // anonymous namespace
+
+TEST(core, singleton_basic)
+{
+    ASSERT_FALSE(good_singleton::is_instance_created());
+
+    good_singleton& a = good_singleton::instance();
+    EXPECT_EQ(42, a.value);
+    EXPECT_TRUE(good_singleton::is_instance_created());
+
+    // instance() is idempotent: same object, lock released after construction.
+    good_singleton& b = good_singleton::instance();
+    EXPECT_EQ(&a, &b);
+    EXPECT_EQ(&a, &good_singleton::fast_instance());
+    EXPECT_EQ(0, good_singleton::lock_state());
+}
+
+TEST(core, singleton_ctor_throw_releases_lock)
+{
+    // Fresh state: nothing built, lock free.
+    ASSERT_FALSE(throwing_singleton::is_instance_created());
+    ASSERT_EQ(0, throwing_singleton::lock_state());
+
+    // 1) The constructor throws -> instance() must propagate the exception
+    //    (fail-stop), not swallow it and not hang.
+    throwing_singleton::s_should_throw = true;
+    EXPECT_THROW(throwing_singleton::instance(), std::runtime_error);
+
+    // 2) The RAII unlock guard must have released the internal spinlock even
+    //    though the constructor threw. Use ASSERT (non-local return) so that a
+    //    regression which leaks the lock stops the test HERE, instead of letting
+    //    the retry below dead-spin forever on the busy-wait lock.
+    ASSERT_EQ(0, throwing_singleton::lock_state());
+
+    // 3) No half-built instance was published.
+    EXPECT_FALSE(throwing_singleton::is_instance_created());
+
+    // 4) A subsequent call succeeds: the failure was cleanly retryable, proving
+    //    there is no permanent deadlock.
+    throwing_singleton::s_should_throw = false;
+    throwing_singleton* built = nullptr;
+    EXPECT_NO_THROW(built = &throwing_singleton::instance());
+    EXPECT_NE(nullptr, built);
+    EXPECT_TRUE(throwing_singleton::is_instance_created());
+    EXPECT_EQ(0, throwing_singleton::lock_state());
+}


### PR DESCRIPTION
## Summary

Core-runtime robustness hardening found via `libfiu` fault injection, plus the
submodule pointer bump for the meta-server hardening in
`linmajia/rDSN.dist.service` (see companion PR). Focus: untrusted/corrupt input and
allocation failures should surface as recoverable errors, not `terminate()` /
`dsn_coredump` / `SIGABRT`.

## Changes

### 1. JSON decoders report malformed input instead of aborting
`json_helper.h`: the `string_tokenizer` and value decoders (`gpid`, `rpc_address`,
etc.) now raise exceptions on malformed input, which the top-level `decode()` already
converts to a clean failure — instead of `dassert` / `dsn_coredump` on corrupt or
untrusted data.

### 2. Reject unresolvable / malformed `rpc_address` in JSON
`from_string_ipv4()` returns `true` even when the host can't be resolved (yielding a
non-invalid `0.0.0.0:port`). The decoder now rejects a `false` return **or** a zero
IP as malformed, so a corrupt `secondaries`/`primary` value can't slip past the later
`is_invalid()` invariant checks.

### 3. Exception-safe singleton initialization
`singleton.h`: a throwing constructor during lazy init no longer leaves a corrupt
half-initialized instance. Added `singleton.test.cpp` unit tests that simulate
exceptions thrown during `new T()`.

### 4. Reject malformed `-app_list` index instead of aborting startup
`main.cpp`: parsing the `name@index` instance index used throwing `std::stoi`
(uncaught `std::invalid_argument` / `std::out_of_range` → `terminate()` on a bad
`-app_list`; also silently accepted a garbage tail like `3xyz`). Now uses the
codebase's non-throwing `lexical_cast_integer<int>()` with a clear error and graceful
exit.

### 5. macOS build fix
`disk_engine.cpp`: remove an unused lambda capture that broke the macOS
`-Werror,-Wunused-lambda-capture` build.

### 6. Submodule bump
`src/plugins_ext/rDSN.dist.service`: `a564c61 → ca52e98 `.