### PR TITLE
Harden startup paths and unify diagnostic output onto the logger

### DIFF
--- a/include/dsn/c/app_model.h
+++ b/include/dsn/c/app_model.h
@@ -108,7 +108,10 @@ typedef void*       (*dsn_app_create)(
     \param argc  as in traditional main(argc, argv)
     \param argv  as in traditional main(argc, argv)
 
-    \return error code for app start
+    \return ERR_OK on success. On the standard launch path (nativerun/simulator),
+            returning a non-ERR_OK code is treated as a fatal start failure and
+            causes the process to exit (fail-stop). Note the mimic launch path
+            (dsn_mimic_app) never invokes this callback.
  */
 typedef dsn_error_t(*dsn_app_start)(
     void*  app,

--- a/include/dsn/cpp/config_helper.h
+++ b/include/dsn/cpp/config_helper.h
@@ -72,7 +72,7 @@
     }\
     else {\
     if (!type::is_exist(v.c_str())) {\
-        fprintf(stderr, "invalid enum configuration '[%s] %s = %s'\n", section, #fld, v.c_str()); \
+        derror("invalid enum configuration '[%s] %s = %s'", section, #fld, v.c_str()); \
         return false; \
             }\
             else \
@@ -93,7 +93,7 @@
     else {\
     auto v2 = enum_from_string(v.c_str(), invalid_enum);\
     if (v2 == invalid_enum) {\
-        fprintf(stderr, "invalid enum configuration '[%s] %s = %s'\n", section, #fld, v.c_str()); \
+        derror("invalid enum configuration '[%s] %s = %s'", section, #fld, v.c_str()); \
         return false; \
             }\
             else \
@@ -110,7 +110,7 @@
     ::dsn::utils::split_args(vv.c_str(), lv, ','); \
     for (auto& v : lv) {\
         if (!type::is_exist(v.c_str())) {\
-            fprintf(stderr, "invalid enum configuration '[%s] %s = %s'\n", section, #fld, v.c_str()); \
+            derror("invalid enum configuration '[%s] %s = %s'", section, #fld, v.c_str()); \
             return false; \
                 } \
                 else \
@@ -149,7 +149,7 @@
         for (auto& s : lv) { \
             int parsed = 0; \
             if (!::dsn::utils::lexical_cast_integer<int>(s, parsed)) { \
-                fprintf(stderr, "invalid integer configuration '[%s] %s = %s'\n", section, #fld, s.c_str()); \
+                derror("invalid integer configuration '[%s] %s = %s'", section, #fld, s.c_str()); \
                 return false; \
             } \
             val.fld.push_back(parsed); \

--- a/include/dsn/tool-api/logging_provider.h
+++ b/include/dsn/tool-api/logging_provider.h
@@ -37,6 +37,7 @@
 
 # include <dsn/service_api_c.h>
 # include <stdarg.h>
+# include <cstdio>
 
 namespace dsn {
 
@@ -62,6 +63,11 @@ public:
     virtual void dsn_logv(const char *file, const char *function, const int line, dsn_log_level_t log_level, const char* title, const char* fmt, va_list args) = 0;
 
     virtual void flush() = 0;
+
+    // print the unified log-line header (level char, timestamp, and thread/task
+    // context) to the given stream. shared by all logging providers and by the
+    // no-provider fallback in dsn_logv so the on-screen log format stays consistent.
+    DSN_API static void print_header(FILE* fp, dsn_log_level_t log_level);
 };
 
 /*@}*/

--- a/include/dsn/utility/configuration.h
+++ b/include/dsn/utility/configuration.h
@@ -38,6 +38,7 @@
 
 # include <memory>
 # include <dsn/cpp/utils.h>
+# include <dsn/utility/logging.h>
 # include <vector>
 # include <map>
 # include <cerrno>
@@ -151,11 +152,9 @@ template<> inline double configuration::get_value<double>(const char* section, c
     {
         if (_warning)
         {
-            fprintf(stderr, "WARNING: configuration '[%s] %s' is not defined, default value is '%lf'\n",
-                section,
+            dutil_warn("configuration '[%s] %s' is not defined, default value is '%lf'", section,
                 key,
-                default_value
-                );
+                default_value);
         }
         
         return default_value;
@@ -168,9 +167,7 @@ template<> inline double configuration::get_value<double>(const char* section, c
             return result;
         }
 
-        fprintf(stderr,
-                "WARNING: configuration '[%s] %s' has invalid value '%s', default value is '%lf'\n",
-                section,
+        dutil_warn("configuration '[%s] %s' has invalid value '%s', default value is '%lf'", section,
                 key,
                 value,
                 default_value);
@@ -188,11 +185,9 @@ template<> inline long long configuration::get_value<long long>(const char* sect
     {
         if (_warning)
         {
-            fprintf(stderr, "WARNING: configuration '[%s] %s' is not defined, default value is '%lld'\n",
-                section,
+            dutil_warn("configuration '[%s] %s' is not defined, default value is '%lld'", section,
                 key,
-                default_value
-                );
+                default_value);
         }
 
         return default_value;
@@ -204,22 +199,18 @@ template<> inline long long configuration::get_value<long long>(const char* sect
             unsigned long long v = 0;
             if (sscanf(value, "0x%llx", &v) != 1)
             {
-                fprintf(stderr, "WARNING: configuration '[%s] %s' has invalid hex value '%s', default value is '%lld'\n",
-                    section,
+                dutil_warn("configuration '[%s] %s' has invalid hex value '%s', default value is '%lld'", section,
                     key,
                     value,
-                    default_value
-                    );
+                    default_value);
                 return default_value;
             }
             if (v > static_cast<unsigned long long>((std::numeric_limits<long long>::max)()))
             {
-                fprintf(stderr, "WARNING: configuration '[%s] %s' has out-of-range hex value '%s', default value is '%lld'\n",
-                    section,
+                dutil_warn("configuration '[%s] %s' has out-of-range hex value '%s', default value is '%lld'", section,
                     key,
                     value,
-                    default_value
-                    );
+                    default_value);
                 return default_value;
             }
             return static_cast<long long>(v);
@@ -229,12 +220,10 @@ template<> inline long long configuration::get_value<long long>(const char* sect
             long long v = 0;
             if (!::dsn::utils::lexical_cast_integer<long long>(value, v))
             {
-                fprintf(stderr, "WARNING: configuration '[%s] %s' has invalid integer value '%s', default value is '%lld'\n",
-                    section,
+                dutil_warn("configuration '[%s] %s' has invalid integer value '%s', default value is '%lld'", section,
                     key,
                     value,
-                    default_value
-                    );
+                    default_value);
                 return default_value;
             }
             return v;
@@ -251,11 +240,9 @@ template<> inline long configuration::get_value<long>(const char* section, const
     {
         if (_warning)
         {
-            fprintf(stderr, "WARNING: configuration '[%s] %s' is not defined, default value is '%ld'\n",
-                section,
+            dutil_warn("configuration '[%s] %s' is not defined, default value is '%ld'", section,
                 key,
-                default_value
-                );
+                default_value);
         }
         return default_value;
     }
@@ -266,22 +253,18 @@ template<> inline long configuration::get_value<long>(const char* section, const
             unsigned long v = 0;
             if (sscanf(value, "0x%lx", &v) != 1)
             {
-                fprintf(stderr, "WARNING: configuration '[%s] %s' has invalid hex value '%s', default value is '%ld'\n",
-                    section,
+                dutil_warn("configuration '[%s] %s' has invalid hex value '%s', default value is '%ld'", section,
                     key,
                     value,
-                    default_value
-                    );
+                    default_value);
                 return default_value;
             }
             if (v > static_cast<unsigned long>((std::numeric_limits<long>::max)()))
             {
-                fprintf(stderr, "WARNING: configuration '[%s] %s' has out-of-range hex value '%s', default value is '%ld'\n",
-                    section,
+                dutil_warn("configuration '[%s] %s' has out-of-range hex value '%s', default value is '%ld'", section,
                     key,
                     value,
-                    default_value
-                    );
+                    default_value);
                 return default_value;
             }
             return static_cast<long>(v);
@@ -291,12 +274,10 @@ template<> inline long configuration::get_value<long>(const char* section, const
             long v = 0;
             if (!::dsn::utils::lexical_cast_integer<long>(value, v))
             {
-                fprintf(stderr, "WARNING: configuration '[%s] %s' has invalid integer value '%s', default value is '%ld'\n",
-                    section,
+                dutil_warn("configuration '[%s] %s' has invalid integer value '%s', default value is '%ld'", section,
                     key,
                     value,
-                    default_value
-                    );
+                    default_value);
                 return default_value;
             }
             return v;
@@ -344,11 +325,9 @@ template<> inline bool configuration::get_value<bool>(const char* section, const
     {
         if (_warning)
         {
-            fprintf(stderr, "WARNING: configuration '[%s] %s' is not defined, default value is '%s'\n",
-                section,
+            dutil_warn("configuration '[%s] %s' is not defined, default value is '%s'", section,
                 key,
-                default_value ? "true" : "false"
-                );
+                default_value ? "true" : "false");
         }
         return default_value;
     }

--- a/include/dsn/utility/factory_store.h
+++ b/include/dsn/utility/factory_store.h
@@ -36,6 +36,7 @@
 # pragma once
 
 # include <dsn/utility/singleton_store.h>
+# include <dsn/utility/logging.h>
 # include <cstdio>
 # include <typeinfo>
 
@@ -169,11 +170,11 @@ namespace dsn {
     private:
         static void report_error(const char* name, ::dsn::provider_type type)
         {
-            fprintf(stderr, "cannot find factory '%s' with factory type %s\n", name, type == PROVIDER_TYPE_MAIN ? "provider" : "aspect");
+            dutil_error("cannot find factory '%s' with factory type %s", name, type == PROVIDER_TYPE_MAIN ? "provider" : "aspect");
 
             std::vector<std::string> keys;
             singleton_store<std::string, factory_entry>::instance().get_all_keys(keys);
-            fprintf(stderr, "\tthe following %u factories are registered for '%s':\n", 
+            dutil_error("\tthe following %u factories are registered for '%s':",
                 static_cast<int>(keys.size()),
                 typeid(TResult).name()
                 );
@@ -181,9 +182,9 @@ namespace dsn {
             {
                 factory_entry entry;
                 singleton_store<std::string, factory_entry>::instance().get(*it, entry);        
-                fprintf(stderr, "\t\t%s (type: %s)\n", it->c_str(), entry.type == PROVIDER_TYPE_MAIN ? "provider" : "aspect");
+                dutil_error("\t\t%s (type: %s)", it->c_str(), entry.type == PROVIDER_TYPE_MAIN ? "provider" : "aspect");
             }
-            fprintf(stderr, "\tPlease specify the correct factory name in your tool_app or in configuration file\n");
+            dutil_error("\tPlease specify the correct factory name in your tool_app or in configuration file");
         }
 
     private:

--- a/include/dsn/utility/logging.h
+++ b/include/dsn/utility/logging.h
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ * 
+ * -=- Robust Distributed System Nucleus (rDSN) -=- 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Description:
+ *     A very small logging facade for the foundational (utility) layer.
+ *
+ *     The utility layer sits *below* dsn.core in the library dependency graph
+ *     (dsn.core links dsn.dev.utility, not the other way around), so utility
+ *     code cannot call the real logger (dsn_logv / dinfo/dwarn/derror) directly
+ *     without creating a reverse library dependency. Historically it therefore
+ *     hard-wired diagnostics to fprintf(stderr), which both bypasses the
+ *     configured logger and scatters an un-replaceable sink across the code.
+ *
+ *     This facade fixes that: low-level components log through dutil_info /
+ *     dutil_warn / dutil_error, which forward to a pluggable sink. dsn.core
+ *     installs a sink (set_logging_sink) that routes everything to dsn_logv, so
+ *     utility diagnostics flow through the same configurable, replaceable logger
+ *     as the rest of rDSN. Until a sink is installed (very early bootstrap, or
+ *     when the utility library is used standalone) the default is stderr, so
+ *     stdout stays clean for machine-readable program output.
+ *
+ * Revision history:
+ *     2026-07-07, unify rDSN diagnostics onto the logger, first version
+ */
+
+# pragma once
+
+# include <dsn/utility/dlib.h>
+# include <cstdarg>
+
+namespace dsn {
+namespace utils {
+
+// Low-level logging severities. These deliberately mirror the core
+// dsn_log_level_t values one-to-one (INFORMATION=0 .. FATAL=4) so the core sink
+// can map them with a plain cast, while keeping the utility layer free of any
+// dependency on the C logging API header.
+enum log_level_t
+{
+    LOG_LEVEL_UTIL_INFORMATION = 0,
+    LOG_LEVEL_UTIL_DEBUG,
+    LOG_LEVEL_UTIL_WARNING,
+    LOG_LEVEL_UTIL_ERROR,
+    LOG_LEVEL_UTIL_FATAL
+};
+
+// A sink that dsn.core installs so utility-layer diagnostics are routed through
+// the real, replaceable process logger. The message is already formatted.
+typedef void (*logging_sink)(
+    log_level_t level, const char* file, const char* function, int line, const char* msg);
+
+// Install (or clear, with nullptr) the sink. Intended to be called once during
+// core initialization, before worker threads start; not synchronized against
+// concurrent logging.
+extern DSN_API void set_logging_sink(logging_sink sink);
+
+// Format and emit a single diagnostic. Routed to the installed sink, or to
+// stderr when none is installed.
+extern DSN_API void logv(
+    log_level_t level, const char* file, const char* function, int line, const char* fmt, va_list args);
+extern DSN_API void logf(
+    log_level_t level, const char* file, const char* function, int line, const char* fmt, ...);
+
+}} // namespace dsn::utils
+
+// Convenience macros for the utility layer. Named dutil_* so they never collide
+// with the core dinfo/ddebug/dwarn/derror/dfatal macros, which the utility layer
+// must not use (that would pull in the logger it sits below).
+# define dutil_logf(level, ...) \
+    ::dsn::utils::logf((level), __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+# define dutil_info(...)  dutil_logf(::dsn::utils::LOG_LEVEL_UTIL_INFORMATION, __VA_ARGS__)
+# define dutil_debug(...) dutil_logf(::dsn::utils::LOG_LEVEL_UTIL_DEBUG,       __VA_ARGS__)
+# define dutil_warn(...)  dutil_logf(::dsn::utils::LOG_LEVEL_UTIL_WARNING,     __VA_ARGS__)
+# define dutil_error(...) dutil_logf(::dsn::utils::LOG_LEVEL_UTIL_ERROR,       __VA_ARGS__)
+# define dutil_fatal(...) dutil_logf(::dsn::utils::LOG_LEVEL_UTIL_FATAL,       __VA_ARGS__)

--- a/src/core/src/command_manager.cpp
+++ b/src/core/src/command_manager.cpp
@@ -402,7 +402,7 @@ namespace dsn {
 
     void command_manager::run_console()
     {
-        std::cout << "dsn cli begin ... (type 'help' + Enter to learn more)" << std::endl;
+        std::cerr << "dsn cli begin ... (type 'help' + Enter to learn more)" << std::endl;
         std::cout << ">";
 
         std::string cmdline;

--- a/src/core/src/configuration.test.cpp
+++ b/src/core/src/configuration.test.cpp
@@ -46,48 +46,48 @@ TEST(core, configuration)
 {
     configuration_ptr c;
 
-    printf("load not_exist_config_file\n");
+    fprintf(stdout, "load not_exist_config_file\n");
     c.reset(new configuration());
     ASSERT_FALSE(c->load("not_exist_config_file"));
 
-    printf("load config-empty.ini\n");
+    fprintf(stdout, "load config-empty.ini\n");
     c.reset(new configuration());
     ASSERT_FALSE(c->load("config-empty.ini"));
 
-    printf("load config-sample.ini with bad arguments\n");
+    fprintf(stdout, "load config-sample.ini with bad arguments\n");
     c.reset(new configuration());
     ASSERT_FALSE(c->load("config-sample.ini", "a="));
 
-    printf("load config-no-section.ini\n");
+    fprintf(stdout, "load config-no-section.ini\n");
     c.reset(new configuration());
     ASSERT_FALSE(c->load("config-no-section.ini"));
 
-    printf("load config-null-section.ini\n");
+    fprintf(stdout, "load config-null-section.ini\n");
     c.reset(new configuration());
     ASSERT_FALSE(c->load("config-null-section.ini"));
 
-    printf("load config-dup-section.ini\n");
+    fprintf(stdout, "load config-dup-section.ini\n");
     c.reset(new configuration());
     // we now allow duplicated section (as for include and overwrite)
     ASSERT_TRUE(c->load("config-dup-section.ini"));
 
-    printf("load config-unmatch-section.ini\n");
+    fprintf(stdout, "load config-unmatch-section.ini\n");
     c.reset(new configuration());
     ASSERT_FALSE(c->load("config-unmatch-section.ini"));
 
-    printf("load config-bad-section.ini\n");
+    fprintf(stdout, "load config-bad-section.ini\n");
     c.reset(new configuration());
     ASSERT_FALSE(c->load("config-bad-section.ini"));
 
-    printf("load config-no-key.ini\n");
+    fprintf(stdout, "load config-no-key.ini\n");
     c.reset(new configuration());
     ASSERT_FALSE(c->load("config-no-key.ini"));
 
-    printf("load config-dup-key.ini\n");
+    fprintf(stdout, "load config-dup-key.ini\n");
     c.reset(new configuration());
     ASSERT_TRUE(c->load("config-dup-key.ini"));
 
-    printf("load config-sample.ini\n");
+    fprintf(stdout, "load config-sample.ini\n");
     c.reset(new configuration());
     ASSERT_TRUE(c->load("config-sample.ini", "replace=replace_value"));
     bool old = c->set_warning(true);
@@ -196,7 +196,7 @@ TEST(core, configuration)
     c->dump(out);
     out.close();
 
-    printf("load config-sample-dump.ini\n");
+    fprintf(stdout, "load config-sample-dump.ini\n");
     c.reset(new configuration());
     ASSERT_TRUE(c->load(dump_file.c_str()));
     c->get_all_sections(sections);

--- a/src/core/src/crc.h
+++ b/src/core/src/crc.h
@@ -272,29 +272,29 @@ template<typename uintxx_t, uintxx_t uPoly> struct crc_generator
 
         InitializeTables ();
 
-        printf ("%s %s::_uX2N[sizeof (%s::_uX2N) / sizeof (%s::_uX2N[0])] = {", pTypeName, pClassName, pClassName, pClassName);
+        fprintf(stdout, "%s %s::_uX2N[sizeof (%s::_uX2N) / sizeof (%s::_uX2N[0])] = {", pTypeName, pClassName, pClassName, pClassName);
         for (i = w = 0; i < sizeof (_uX2N) / sizeof (_uX2N[0]); ++i)
         {
             if (i != 0)
-                printf (",");
+                fprintf(stdout, ",");
             if (w == 0)
-                printf ("\n   ");
-            printf (" 0x%0*llx", static_cast<int> (sizeof (uintxx_t) * 2), (uint64_t) _uX2N[i]);
+                fprintf(stdout, "\n   ");
+            fprintf(stdout, " 0x%0*llx", static_cast<int> (sizeof (uintxx_t) * 2), (uint64_t) _uX2N[i]);
             w = (w + sizeof (uintxx_t)) & 31;
         }
-        printf ("\n};\n\n");
+        fprintf(stdout, "\n};\n\n");
 
-        printf ("%s %s::_crc_table[sizeof (%s::_crc_table) / sizeof (%s::_crc_table[0])] = {", pTypeName, pClassName, pClassName, pClassName);
+        fprintf(stdout, "%s %s::_crc_table[sizeof (%s::_crc_table) / sizeof (%s::_crc_table[0])] = {", pTypeName, pClassName, pClassName, pClassName);
         for (i = w = 0; i < sizeof (_crc_table) / sizeof (_crc_table[0]); ++i)
         {
             if (i != 0)
-                printf (",");
+                fprintf(stdout, ",");
             if (w == 0)
-                printf ("\n   ");
-            printf (" 0x%0*llx", static_cast<int> (sizeof (uintxx_t) * 2), (uint64_t) _crc_table[i]);
+                fprintf(stdout, "\n   ");
+            fprintf(stdout, " 0x%0*llx", static_cast<int> (sizeof (uintxx_t) * 2), (uint64_t) _crc_table[i]);
             w = (w + sizeof (uintxx_t)) & 31;
         }
-        printf ("\n};\n\n");
+        fprintf(stdout, "\n};\n\n");
     };
 };
 

--- a/src/core/src/global_config.cpp
+++ b/src/core/src/global_config.cpp
@@ -61,7 +61,7 @@ static bool read_all_config_keys(const char* section, std::vector<const char*>& 
     int key_count = dsn_config_get_all_keys(section, nullptr, &key_capacity);
     if (key_count < 0)
     {
-        fprintf(stderr, "failed to read config keys from section [%s]\n", section);
+        derror("failed to read config keys from section [%s]", section);
         return false;
     }
 
@@ -77,7 +77,7 @@ static bool read_all_config_keys(const char* section, std::vector<const char*>& 
     }
     catch (const std::exception& ex)
     {
-        fprintf(stderr, "failed to allocate config keys for section [%s]: %s\n", section, ex.what());
+        derror("failed to allocate config keys for section [%s]: %s", section, ex.what());
         return false;
     }
 
@@ -85,15 +85,13 @@ static bool read_all_config_keys(const char* section, std::vector<const char*>& 
     int actual_key_count = dsn_config_get_all_keys(section, keys.data(), &key_capacity);
     if (actual_key_count < 0)
     {
-        fprintf(stderr, "failed to read config keys from section [%s]\n", section);
+        derror("failed to read config keys from section [%s]", section);
         return false;
     }
 
     if (actual_key_count > key_capacity)
     {
-        fprintf(stderr,
-                "config keys in section [%s] changed while reading: capacity = %d, actual = %d\n",
-                section,
+        derror("config keys in section [%s] changed while reading: capacity = %d, actual = %d", section,
                 key_capacity,
                 actual_key_count);
         return false;
@@ -120,7 +118,7 @@ static bool build_client_network_confs(
     {
         if (key == nullptr)
         {
-            fprintf(stderr, "config section [%s] has null key\n", section);
+            derror("config section [%s] has null key", section);
             return false;
         }
 
@@ -150,9 +148,7 @@ static bool build_client_network_confs(
 
             if (vs.size() != 2)
             {
-                fprintf(stderr, "invalid client network specification '%s', should be '$network-factory,$msg-buffer-size'\n",
-                    v.c_str()
-                    );
+                derror("invalid client network specification '%s', should be '$network-factory,$msg-buffer-size'", v.c_str());
                 return false;
             }
             
@@ -161,7 +157,7 @@ static bool build_client_network_confs(
             if (!::dsn::utils::lexical_cast_integer<int>(*vs.rbegin(), ns.message_buffer_block_size) ||
                 (ns.message_buffer_block_size <= 0))
             {
-                fprintf(stderr, "invalid message buffer size specified: '%s'\n", vs.rbegin()->c_str());
+                derror("invalid message buffer size specified: '%s'", vs.rbegin()->c_str());
                 return false;
             }
 
@@ -169,7 +165,7 @@ static bool build_client_network_confs(
         }
         else
         {
-            fprintf(stderr, "invalid rpc channel type: %s\n", k2.c_str());
+            derror("invalid rpc channel type: %s", k2.c_str());
             return false;
         }
     }
@@ -208,7 +204,7 @@ static bool build_server_network_confs(
     {
         if (key == nullptr)
         {
-            fprintf(stderr, "config section [%s] has null key\n", section);
+            derror("config section [%s] has null key", section);
             return false;
         }
 
@@ -224,14 +220,14 @@ static bool build_server_network_confs(
         utils::split_args(k2.c_str(), ks, '.');
         if (ks.size() != 2)
         {
-            fprintf(stderr, "invalid network server config '%s', should be like 'network.server.12345.RPC_CHANNEL_TCP' instead\n", k.c_str());
+            derror("invalid network server config '%s', should be like 'network.server.12345.RPC_CHANNEL_TCP' instead", k.c_str());
             return false;
         }
 
         uint16_t port = 0;
         if (!::dsn::utils::lexical_cast_integer<uint16_t>(*ks.begin(), port))
         {
-            fprintf(stderr, "invalid network server port specified: '%s'\n", ks.begin()->c_str());
+            derror("invalid network server port specified: '%s'", ks.begin()->c_str());
             return false;
         }
         auto k3 = *ks.rbegin();
@@ -240,9 +236,9 @@ static bool build_server_network_confs(
         {
             if (port != 0)
             {
-                fprintf(stderr, "invalid network server configuration '%s'\n", k.c_str());
-                fprintf(stderr, "port must be zero in [apps..default]\n");
-                fprintf(stderr, " e.g., network.server.0.RPC_CHANNEL_TCP = NET_HDR_DSN, dsn::tools::asio_network_provider,65536\n");
+                derror("invalid network server configuration '%s'", k.c_str());
+                derror("port must be zero in [apps..default]");
+                derror(" e.g., network.server.0.RPC_CHANNEL_TCP = NET_HDR_DSN, dsn::tools::asio_network_provider,65536");
                 return false;
             }
         }
@@ -273,9 +269,7 @@ static bool build_server_network_confs(
 
             if (vs.size() != 2)
             {
-                fprintf(stderr, "invalid server network specification '%s', should be '$network-factory,$msg-buffer-size'\n",
-                    v.c_str()
-                    );
+                derror("invalid server network specification '%s', should be '$network-factory,$msg-buffer-size'", v.c_str());
                 return false;
             }
 
@@ -284,7 +278,7 @@ static bool build_server_network_confs(
             if (!::dsn::utils::lexical_cast_integer<int>(*vs.rbegin(), ns.message_buffer_block_size) ||
                 (ns.message_buffer_block_size <= 0))
             {
-                fprintf(stderr, "invalid message buffer size specified: '%s'\n", vs.rbegin()->c_str());
+                derror("invalid message buffer size specified: '%s'", vs.rbegin()->c_str());
                 return false;
             }
 
@@ -292,7 +286,7 @@ static bool build_server_network_confs(
         }
         else
         {
-            fprintf(stderr, "invalid rpc channel type: %s\n", k3.c_str());
+            derror("invalid rpc channel type: %s", k3.c_str());
             return false;
         }
     }
@@ -462,7 +456,7 @@ bool service_spec::init_app_specs()
     int mimic_type_len = snprintf(dapp.type_name, sizeof(dapp.type_name), "%s", mimic_app_role_name);
     if (mimic_type_len < 0 || static_cast<size_t>(mimic_type_len) >= sizeof(dapp.type_name))
     {
-        fprintf(stderr, "mimic app type name is too long\n");
+        derror("mimic app type name is too long");
         return false;
     }
     dapp.layer1.create = mimic_app_create;
@@ -497,7 +491,7 @@ bool service_spec::init_app_specs()
             auto type = dsn_config_get_value_string("apps.mimic", "type", "", "app type, must be " mimic_app_role_name);
             if (strcmp(type, mimic_app_role_name) != 0)
             {
-                fprintf(stderr, "invalid config value '%s' for [apps.mimic] type", type);
+                derror("invalid config value '%s' for [apps.mimic] type", type);
                 return false;
             }
         }
@@ -540,7 +534,7 @@ bool service_spec::init_app_specs()
             dsn_app* role;
             if (!store.get(app.type.c_str(), role))
             {
-                fprintf(stderr, "service type '%s' not registered\n", app.type.c_str());
+                derror("service type '%s' not registered", app.type.c_str());
                 return false;
             }
 
@@ -554,7 +548,7 @@ bool service_spec::init_app_specs()
                 int len = snprintf(buf, sizeof(buf), "%u", i);
                 if (len < 0 || static_cast<size_t>(len) >= sizeof(buf))
                 {
-                    fprintf(stderr, "failed to format app index %d\n", i);
+                    derror("failed to format app index %d", i);
                     return false;
                 }
                 app.name = (app.count > 1 ? (app.role_name + buf) : app.role_name);

--- a/src/core/src/logging.cpp
+++ b/src/core/src/logging.cpp
@@ -41,6 +41,7 @@
 # include "service_engine.h"
 # include <dsn/cpp/auto_codes.h>
 # include <cstdio>
+# include <cinttypes>
 
 DSN_API dsn_log_level_t dsn_log_start_level = dsn_log_level_t::LOG_LEVEL_INFORMATION;
 
@@ -97,6 +98,66 @@ DSN_API dsn_log_level_t dsn_log_get_start_level()
     return dsn_log_start_level;
 }
 
+// shared, unified log-line header used by all logging providers (screen_logger,
+// simple_logger, ...) and by the no-provider fallback in dsn_logv below, so that
+// the on-screen log format stays consistent across all of them.
+void dsn::logging_provider::print_header(FILE* fp, dsn_log_level_t log_level)
+{
+    static char s_level_char[] = "IDWEF";
+
+    uint64_t ts = 0;
+    if (::dsn::tools::is_engine_ready())
+    {
+        ts = dsn_now_ns();
+    }
+
+    char str[24];
+    ::dsn::utils::time_ms_to_string(ts / 1000000, str, sizeof(str));
+
+    int tid = ::dsn::utils::get_current_tid();
+
+    fprintf(fp, "%c%s (%" PRIu64 " %04x) ", s_level_char[log_level], str, ts, tid);
+
+    auto t = ::dsn::task::get_current_task_id();
+    auto worker = ::dsn::task::get_current_worker2();
+    if (t)
+    {
+        if (nullptr != worker)
+        {
+            fprintf(fp, "%6s.%7s%d.%016" PRIx64 ": ",
+                ::dsn::task::get_current_node_name(),
+                worker->pool_spec().name.c_str(),
+                worker->index(),
+                t);
+        }
+        else
+        {
+            fprintf(fp, "%6s.%7s.%05d.%016" PRIx64 ": ",
+                ::dsn::task::get_current_node_name(),
+                "io-thrd",
+                tid,
+                t);
+        }
+    }
+    else
+    {
+        if (nullptr != worker)
+        {
+            fprintf(fp, "%6s.%7s%u: ",
+                ::dsn::task::get_current_node_name(),
+                worker->pool_spec().name.c_str(),
+                worker->index());
+        }
+        else
+        {
+            fprintf(fp, "%6s.%7s.%05d: ",
+                ::dsn::task::get_current_node_name(),
+                "io-thrd",
+                tid);
+        }
+    }
+}
+
 DSN_API void dsn_logv(const char *file, const char *function, const int line, dsn_log_level_t log_level, const char* title, const char* fmt, va_list args)
 {
     if (file == nullptr)
@@ -136,9 +197,14 @@ DSN_API void dsn_logv(const char *file, const char *function, const int line, ds
     }
     else
     {
-        printf("%s:%d:%s():", title, line, function);
-        vprintf(fmt, args);
-        printf("\n");
+        // no logging provider is installed yet (e.g. during early bootstrap before
+        // init_before_toollets creates it); write diagnostics to stderr so that stdout
+        // stays clean for machine-readable program output (metrics, cli results, etc.),
+        // reusing the shared provider header so the log format stays consistent.
+        ::dsn::logging_provider::print_header(stderr, log_level);
+        fprintf(stderr, "%s:%d:%s(): ", title, line, function);
+        vfprintf(stderr, fmt, args);
+        fprintf(stderr, "\n");
     }
 }
 

--- a/src/core/src/logging.cpp
+++ b/src/core/src/logging.cpp
@@ -38,12 +38,47 @@
 # include <dsn/tool-api/command.h>
 # include <dsn/tool-api/logging_provider.h>
 # include <dsn/tool_api.h>
+# include <dsn/utility/logging.h>
 # include "service_engine.h"
 # include <dsn/cpp/auto_codes.h>
 # include <cstdio>
 # include <cinttypes>
 
 DSN_API dsn_log_level_t dsn_log_start_level = dsn_log_level_t::LOG_LEVEL_INFORMATION;
+
+// route diagnostics emitted by the foundational (utility) layer through the real
+// process logger. The utility layer sits below dsn.core and cannot call dsn_logv
+// directly, so it logs via a pluggable sink (dsn::utils::logf); here we install
+// a sink that forwards to dsn_logv, honoring the same start-level gate as the
+// dlog macros. Installed at static-init so it is active before main() runs; any
+// utility diagnostics emitted before this point fall back to stderr, which is
+// where dsn_logv would route them during early bootstrap anyway.
+static void forward_utils_log_to_dsn(
+    ::dsn::utils::log_level_t level, const char* file, const char* function, int line, const char* msg)
+{
+    // dsn::utils::log_level_t mirrors dsn_log_level_t one-to-one (INFORMATION=0 .. FATAL=4).
+    dsn_log_level_t dlevel = static_cast<dsn_log_level_t>(level);
+    if (dlevel < LOG_LEVEL_INFORMATION || dlevel > LOG_LEVEL_FATAL)
+    {
+        dlevel = LOG_LEVEL_WARNING;
+    }
+    if (dlevel >= dsn_log_start_level)
+    {
+        // pass msg as an argument (not as the format) so any '%' in it is safe.
+        dsn_logf(file, function, line, dlevel, file, "%s", msg);
+    }
+}
+
+namespace {
+struct utils_log_sink_installer
+{
+    utils_log_sink_installer()
+    {
+        ::dsn::utils::set_logging_sink(forward_utils_log_to_dsn);
+    }
+};
+static utils_log_sink_installer s_utils_log_sink_installer;
+}
 
 static void log_on_sys_exit(::dsn::sys_exit_type)
 {

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -562,6 +562,12 @@ bool run(
     
     // init tools
     dsn_all.tool = ::dsn::utils::factory_store< ::dsn::tools::tool_app>::create(spec.tool.c_str(), ::dsn::PROVIDER_TYPE_MAIN, spec.tool.c_str());
+    if (dsn_all.tool == nullptr)
+    {
+        fprintf(stderr, "cannot create tool '%s' specified by [core] tool, "
+                        "please check it is a valid and registered tool name\n", spec.tool.c_str());
+        return false;
+    }
     dsn_all.tool->install(spec);
 
     // init app specs

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -473,7 +473,7 @@ bool run(
 
     if (!dsn_all.config->load(config_file, config_arguments, config_overwrites))
     {
-        fprintf(stderr, "Fail to load config file %s\n", config_file);
+        derror("Fail to load config file %s", config_file);
         return false;
     }
     dwarn("load config file '%s' successfully", config_file);
@@ -483,10 +483,11 @@ bool run(
         "whether to pause at startup time for easier debugging"))
     {
 # if defined(_WIN32)
-        printf("\nPause for debugging (pid = %d)...\n", static_cast<int>(::GetCurrentProcessId()));
+        int debug_pid = static_cast<int>(::GetCurrentProcessId());
 # else
-        printf("\nPause for debugging (pid = %d)...\n", static_cast<int>(getpid()));
+        int debug_pid = static_cast<int>(getpid());
 # endif
+        dwarn("Pause for debugging (pid = %d)...", debug_pid);
         getchar();
     }
 
@@ -508,7 +509,7 @@ bool run(
     ::dsn::service_spec spec;
     if (!spec.init())
     {
-        fprintf(stderr, "error in config file %s, exit ...\n", config_file);
+        derror("error in config file %s, exit ...", config_file);
         return false;
     }
 
@@ -518,21 +519,21 @@ bool run(
     auto& data_dir = spec.data_dir;
     if (dsn::utils::filesystem::file_exists(data_dir.c_str()))
     {
-        fprintf(stderr, "%s should not be a file.\n", data_dir.c_str());
+        derror("%s should not be a file.", data_dir.c_str());
         return false;
     }
     if (!dsn::utils::filesystem::directory_exists(data_dir.c_str()))
     {
         if (!dsn::utils::filesystem::create_directory(data_dir.c_str()))
         {
-            fprintf(stderr, "Fail to create %s.\n", data_dir.c_str());
+            derror("Fail to create %s.", data_dir.c_str());
             return false;
         }
     }
     std::string cdir;
     if (!dsn::utils::filesystem::get_absolute_path(data_dir.c_str(), cdir))
     {
-        fprintf(stderr, "Fail to get absolute path from %s.\n", data_dir.c_str());
+        derror("Fail to get absolute path from %s.", data_dir.c_str());
         return false;
     }
     spec.data_dir = cdir.c_str();
@@ -542,12 +543,12 @@ bool run(
     if (!dsn::utils::filesystem::directory_exists(spec.dir_coredump.c_str()) &&
         !dsn::utils::filesystem::create_directory(spec.dir_coredump.c_str()))
     {
-        fprintf(stderr, "Fail to create %s.\n", spec.dir_coredump.c_str());
+        derror("Fail to create %s.", spec.dir_coredump.c_str());
         return false;
     }
     if (!::dsn::utils::coredump::init(spec.dir_coredump.c_str()))
     {
-        fprintf(stderr, "Fail to init coredump in %s.\n", spec.dir_coredump.c_str());
+        derror("Fail to init coredump in %s.", spec.dir_coredump.c_str());
         return false;
     }
 
@@ -556,7 +557,7 @@ bool run(
     if (!dsn::utils::filesystem::directory_exists(spec.dir_log.c_str()) &&
         !dsn::utils::filesystem::create_directory(spec.dir_log.c_str()))
     {
-        fprintf(stderr, "Fail to create %s.\n", spec.dir_log.c_str());
+        derror("Fail to create %s.", spec.dir_log.c_str());
         return false;
     }
     
@@ -564,8 +565,7 @@ bool run(
     dsn_all.tool = ::dsn::utils::factory_store< ::dsn::tools::tool_app>::create(spec.tool.c_str(), ::dsn::PROVIDER_TYPE_MAIN, spec.tool.c_str());
     if (dsn_all.tool == nullptr)
     {
-        fprintf(stderr, "cannot create tool '%s' specified by [core] tool, "
-                        "please check it is a valid and registered tool name\n", spec.tool.c_str());
+        derror("cannot create tool '%s' specified by [core] tool, please check it is a valid and registered tool name", spec.tool.c_str());
         return false;
     }
     dsn_all.tool->install(spec);
@@ -573,7 +573,7 @@ bool run(
     // init app specs
     if (!spec.init_app_specs())
     {
-        fprintf(stderr, "error in config file %s, exit ...\n", config_file);
+        derror("error in config file %s, exit ...", config_file);
         return false;
     }
 
@@ -649,9 +649,7 @@ bool run(
                         if (!::dsn::utils::lexical_cast_integer<int>(
                                 std::string(argskvs.back().c_str()), app_index))
                         {
-                            fprintf(stderr,
-                                "Invalid app index '%s' in app_list for %s, expected an integer.\n",
-                                argskvs.back().c_str(),
+                            derror("Invalid app index '%s' in app_list for %s, expected an integer.", argskvs.back().c_str(),
                                 sp.config_section.c_str());
                             return false;
                         }
@@ -666,7 +664,7 @@ bool run(
         {
             if (::dsn::service_engine::fast_instance().start_node(sp) == nullptr)
             {
-                fprintf(stderr, "Fail to start app %s.\n", sp.name.c_str());
+                derror("Fail to start app %s.", sp.name.c_str());
                 return false;
             }
         }
@@ -819,12 +817,12 @@ DSN_API void dsn_run(int argc, char** argv, bool sleep_after_init)
     }
     catch (const std::exception& err)
     {
-        fprintf(stderr, "run the system failed due to exception: %s\n", err.what());
+        derror("run the system failed due to exception: %s", err.what());
     }
 
     if (!run_succeeded)
     {
-        fprintf(stderr, "run the system failed\n");
+        derror("run the system failed");
         dsn_exit(-1);
         return;
     }
@@ -845,7 +843,7 @@ DSN_API bool dsn_run_config(const char* config, bool sleep_after_init)
     }
     catch (const std::exception& err)
     {
-        fprintf(stderr, "run the system failed due to exception: %s\n", err.what());
+        derror("run the system failed due to exception: %s", err.what());
     }
 
     return false;

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -1940,8 +1940,7 @@ err:
 
 NORETURN DSN_API void dsn_exit(int code)
 {
-    printf("dsn exit with code %d\n", code);
-    fflush(stdout);
+    dinfo("dsn exit with code %d", code);
     ::dsn::tools::sys_exit.execute(::dsn::SYS_EXIT_NORMAL);
 
 # if defined(_WIN32)

--- a/src/core/src/task_engine.test.cpp
+++ b/src/core/src/task_engine.test.cpp
@@ -91,7 +91,7 @@ TEST(core, task_engine)
     safe_vector<safe_string> args;
     safe_sstream oss;
     engine->get_runtime_info("  ", args, oss);
-    printf("%s\n", oss.str().c_str());
+    fprintf(stdout, "%s\n", oss.str().c_str());
 
     std::vector<task_worker_pool*>& pools = engine->pools();
     for (size_t i = 0; i < pools.size(); ++i)
@@ -160,7 +160,7 @@ TEST(core, task_engine)
     std::vector<std::string> args;
     std::stringstream oss;
     engine.get_runtime_info("  ", args, oss);
-    printf("%s\n", oss.str().c_str());
+    fprintf(stdout, "%s\n", oss.str().c_str());
 
     std::vector<task_worker_pool*>& pools = engine.pools();
     for (size_t i = 0; i < pools.size(); ++i)

--- a/src/core/src/tool_api.cpp
+++ b/src/core/src/tool_api.cpp
@@ -64,7 +64,15 @@ namespace dsn {
                 }
                 
                 err = _node->start_app();
-                dassert(err == ERR_OK, "start app failed, err = %s", err.to_string());
+                if (err != ERR_OK)
+                {
+                    // A node whose app cannot be started is non-functional, so
+                    // fail-stop the process. Exit gracefully with a clear
+                    // diagnostic instead of aborting with a coredump.
+                    derror("start app %s failed, err = %s; exiting the process",
+                           sp.name.c_str(), err.to_string());
+                    dsn_exit(1);
+                }
             }
             else
             {

--- a/src/dev/utility/configuration.cpp
+++ b/src/dev/utility/configuration.cpp
@@ -34,6 +34,7 @@
  */
 
 # include <dsn/utility/configuration.h>
+# include <dsn/utility/logging.h>
 # include <dsn/cpp/utils.h>
 # include <cassert>
 # include <errno.h>
@@ -98,11 +99,11 @@ bool configuration::load_include(const char* inc, const char* arguments)
     configuration conf;
     if (!conf.load(include_file.c_str(), arguments))
     {
-        fprintf(stderr, "load included configuration file %s failed\n", include_file.c_str());
+        dutil_error("load included configuration file %s failed", include_file.c_str());
         return false;
     }
 
-    fprintf(stderr, "load included configuration file %s ...\n", include_file.c_str());
+    dutil_info("load included configuration file %s ...", include_file.c_str());
     for (auto& sec : conf._configs)
     {
         for (auto& kv : sec.second)
@@ -126,25 +127,25 @@ bool configuration::load(const char* file_name, const char* arguments, const cha
     {
         std::string cdir;
         dsn::utils::filesystem::get_current_directory(cdir);
-        fprintf(stderr, "ERROR: cannot open file %s in %s, err = %s\n", file_name, cdir.c_str(), strerror(errno));
+        dutil_error("cannot open file %s in %s, err = %s", file_name, cdir.c_str(), strerror(errno));
         return false;
     }
     if (::fseek(fd, 0, SEEK_END) != 0)
     {
-        fprintf(stderr, "ERROR: cannot seek to end of %s, err = %s\n", file_name, strerror(errno));
+        dutil_error("cannot seek to end of %s, err = %s", file_name, strerror(errno));
         if (::fclose(fd) != 0)
         {
-            fprintf(stderr, "ERROR: cannot close file %s, err = %s\n", file_name, strerror(errno));
+            dutil_error("cannot close file %s, err = %s", file_name, strerror(errno));
         }
         return false;
     }
     long len = ftell(fd);
     if (len == -1 || len == 0)
     {
-        fprintf(stderr, "ERROR: cannot get length of %s, err = %s\n", file_name, strerror(errno));
+        dutil_error("cannot get length of %s, err = %s", file_name, strerror(errno));
         if (::fclose(fd) != 0)
         {
-            fprintf(stderr, "ERROR: cannot close file %s, err = %s\n", file_name, strerror(errno));
+            dutil_error("cannot close file %s, err = %s", file_name, strerror(errno));
         }
         return false;
     }
@@ -152,22 +153,22 @@ bool configuration::load(const char* file_name, const char* arguments, const cha
     _file_data.resize(len + 1);
     if (::fseek(fd, 0, SEEK_SET) != 0)
     {
-        fprintf(stderr, "ERROR: cannot seek to beginning of %s, err = %s\n", file_name, strerror(errno));
+        dutil_error("cannot seek to beginning of %s, err = %s", file_name, strerror(errno));
         if (::fclose(fd) != 0)
         {
-            fprintf(stderr, "ERROR: cannot close file %s, err = %s\n", file_name, strerror(errno));
+            dutil_error("cannot close file %s, err = %s", file_name, strerror(errno));
         }
         return false;
     }
     auto sz = ::fread((char*)_file_data.c_str(), static_cast<size_t>(len), 1, fd);
     if (::fclose(fd) != 0)
     {
-        fprintf(stderr, "ERROR: cannot close file %s, err = %s\n", file_name, strerror(errno));
+        dutil_error("cannot close file %s, err = %s", file_name, strerror(errno));
         return false;
     }
     if (sz != 1)
     {
-        fprintf(stderr, "ERROR: cannot read correct data of %s, err = %s\n", file_name, strerror(errno));
+        dutil_error("cannot read correct data of %s, err = %s", file_name, strerror(errno));
         return false;
     }
     _file_data[len] = '\n';
@@ -186,7 +187,7 @@ bool configuration::load(const char* file_name, const char* arguments, const cha
             utils::split_args(kv.c_str(), vs, '=');
             if (vs.size() != 2)
             {
-                fprintf(stderr, "ERROR: invalid configuration argument: '%s' in '%s'\n", kv.c_str(), arguments);
+                dutil_error("invalid configuration argument: '%s' in '%s'", kv.c_str(), arguments);
                 return false;
             }
 
@@ -195,7 +196,7 @@ bool configuration::load(const char* file_name, const char* arguments, const cha
 
             _file_data = utils::replace_string(_file_data, key, value);
 
-            fprintf(stderr, "config.replace: %s => %s\n", key.c_str(), value.c_str());
+            dutil_info("config.replace: %s => %s", key.c_str(), value.c_str());
         }
     }
     
@@ -275,7 +276,7 @@ bool configuration::load(const char* file_name, const char* arguments, const cha
         {
 ConfReg:
             if (pSection == nullptr) {
-                fprintf(stderr, "ERROR: configuration section not defined\n");
+                dutil_error("configuration section not defined");
                 goto err;
             }
             if (pEqual)    *pEqual = '\0';
@@ -288,14 +289,12 @@ ConfReg:
             {
                 auto it = pSection->find((const char*)pKey);
 
-                fprintf(stderr, "WARNING: overwrite option [%s] %s = (%s => %s) (line %u => %u)\n",
-                    pSectionName,
+                dutil_warn("overwrite option [%s] %s = (%s => %s) (line %u => %u)", pSectionName,
                     pKey,
                     it->second->value.c_str(),
                     pValue,
                     it->second->line,
-                    lineno
-                );
+                    lineno);
 
                 it->second->value = pValue ? pValue : "";
                 it->second->line = lineno;
@@ -388,11 +387,9 @@ Next:
                             value // 12345
                         );
 
-                        fprintf(stderr, "config.config.args: [%s] %s = %s\n",
-                            kv.second->section.c_str(),
+                        dutil_info("config.config.args: [%s] %s = %s", kv.second->section.c_str(),
                             kv.second->key.c_str(),
-                            kv.second->value.c_str()
-                        );
+                            kv.second->value.c_str());
                     }
                 }
             }
@@ -413,7 +410,7 @@ Next:
             utils::split_args(kv.c_str(), vs, '=');
             if (vs.size() != 2 && vs.size() != 1)
             {
-                fprintf(stderr, "ERROR: invalid configuration overwrites: '%s' in '%s'\n", kv.c_str(), arguments);
+                dutil_error("invalid configuration overwrites: '%s' in '%s'", kv.c_str(), arguments);
                 return false;
             }
 
@@ -423,10 +420,7 @@ Next:
             auto pos = section_and_key.find_last_of('.');
             if (pos == std::string::npos)
             {
-                fprintf(stderr, "ERROR: invalid configuration overwrites: "
-                    "'%s' does not represent section.key\n", 
-                    section_and_key.c_str()
-                );
+                dutil_error("invalid configuration overwrites: '%s' does not represent section.key", section_and_key.c_str());
                 return false;
             }
 
@@ -442,7 +436,7 @@ Next:
     return true;
     
 err:
-    fprintf(stderr, "ERROR: unexpected configuration in %s(line %d): %s\n", file_name, lineno, pLine);
+    dutil_error("unexpected configuration in %s(line %d): %s", file_name, lineno, pLine);
     return false;
 }
 
@@ -470,7 +464,7 @@ void configuration::get_all_keys(const char* section, std::vector<const char*>& 
     keys.clear();
     if (section == nullptr || section[0] == '\0')
     {
-        fprintf(stderr, "ERROR: configuration section cannot be null or empty\n");
+        dutil_error("configuration section cannot be null or empty");
         return;
     }
 
@@ -493,25 +487,25 @@ bool configuration::get_string_value_internal(const char* section, const char* k
 {
     if (ov == nullptr)
     {
-        fprintf(stderr, "ERROR: configuration output value cannot be null\n");
+        dutil_error("configuration output value cannot be null");
         return false;
     }
 
     if (section == nullptr || section[0] == '\0')
     {
-        fprintf(stderr, "ERROR: configuration section cannot be null or empty\n");
+        dutil_error("configuration section cannot be null or empty");
         return false;
     }
 
     if (key == nullptr || key[0] == '\0')
     {
-        fprintf(stderr, "ERROR: configuration key cannot be null or empty\n");
+        dutil_error("configuration key cannot be null or empty");
         return false;
     }
 
     if (default_value == nullptr)
     {
-        fprintf(stderr, "ERROR: configuration default value cannot be null\n");
+        dutil_error("configuration default value cannot be null");
         *ov = nullptr;
         return false;
     }
@@ -536,8 +530,7 @@ bool configuration::get_string_value_internal(const char* section, const char* k
             {
                 if (it2->second->value != default_value)
                 {
-                    fprintf(stderr, "ERROR: configuration default value is different for '[%s] %s': %s <--> %s\n",
-                        section, key, it2->second->value.c_str(), default_value);
+                    dutil_error("configuration default value is different for '[%s] %s': %s <--> %s", section, key, it2->second->value.c_str(), default_value);
                     ::abort();
                 }
             }
@@ -583,11 +576,9 @@ const char* configuration::get_string_value(const char* section, const char* key
     {
         if (_warning)
         {
-            fprintf(stderr, "WARNING: configuration '[%s] %s' is not defined, default value is '%s'\n",
-                section,
+            dutil_warn("configuration '[%s] %s' is not defined, default value is '%s'", section,
                 key,
-                default_value
-                );
+                default_value);
         }
     }
     return ov;
@@ -600,11 +591,9 @@ std::list<std::string> configuration::get_string_value_list(const char* section,
     {
         if (_warning)
         {
-            fprintf(stderr, "WARNING: configuration '[%s] %s' is not defined, default value is '%s'\n",
-                section,
+            dutil_warn("configuration '[%s] %s' is not defined, default value is '%s'", section,
                 key,
-                ""
-                );
+                "");
         }
     }
 
@@ -675,12 +664,10 @@ void configuration::set(const char* section, const char* key, const char* value,
     }
     else
     {        
-        fprintf(stderr, "WARNING: overwrite [%s] %s = (%s => %s)\n",
-            section,
+        dutil_warn("overwrite [%s] %s = (%s => %s)", section,
             key, 
             it2->second->value.c_str(),
-            value
-            );
+            value);
 
         it2->second->value = value;
     }
@@ -690,7 +677,7 @@ void configuration::set(const char* section, const char* key, const char* value,
 
 void configuration::register_config_change_notification(config_file_change_notifier notifier)
 {
-    fprintf(stderr, "ERROR: method register_config_change_notification() not implemented\n");
+    dutil_error("method register_config_change_notification() not implemented");
     ::abort();
 }
 
@@ -700,7 +687,7 @@ bool configuration::has_section(const char* section)
     bool r = (it != _configs.end());
     if (!r && _warning)
     {
-        fprintf(stderr, "WARNING: configuration section '[%s]' is not defined, using default settings\n", section);
+        dutil_warn("configuration section '[%s]' is not defined, using default settings", section);
     }
     return r;
 }

--- a/src/dev/utility/configuration.cpp
+++ b/src/dev/utility/configuration.cpp
@@ -54,16 +54,55 @@ configuration::~configuration()
 {
 }
 
+static bool cfg_is_absolute_path(const char* path)
+{
+    if (path == nullptr || path[0] == '\0')
+    {
+        return false;
+    }
+    if (path[0] == '/' || path[0] == '\\')
+    {
+        return true;
+    }
+#ifdef _WIN32
+    if (((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z'))
+        && path[1] == ':')
+    {
+        return true;
+    }
+#endif
+    return false;
+}
+
 bool configuration::load_include(const char* inc, const char* arguments)
 {
-    configuration conf;
-    if (!conf.load(inc, arguments))
+    // Resolve a relative @include path against the directory of the parent
+    // configuration file (like the C preprocessor / nginx), rather than the
+    // process working directory, so that a config and its includes stay
+    // relocatable. Fall back to the original (working-directory relative) path
+    // when the parent-relative file does not exist, for backward compatibility.
+    std::string include_file = inc;
+    if (!cfg_is_absolute_path(inc))
     {
-        fprintf(stderr, "load included configuration file %s failed\n", inc);
+        std::string parent_dir = dsn::utils::filesystem::remove_file_name(_file_name);
+        if (!parent_dir.empty())
+        {
+            std::string candidate = dsn::utils::filesystem::path_combine(parent_dir, inc);
+            if (!candidate.empty() && dsn::utils::filesystem::file_exists(candidate))
+            {
+                include_file = candidate;
+            }
+        }
+    }
+
+    configuration conf;
+    if (!conf.load(include_file.c_str(), arguments))
+    {
+        fprintf(stderr, "load included configuration file %s failed\n", include_file.c_str());
         return false;
     }
 
-    printf("load included configuration file %s ...\n", inc);
+    fprintf(stderr, "load included configuration file %s ...\n", include_file.c_str());
     for (auto& sec : conf._configs)
     {
         for (auto& kv : sec.second)
@@ -156,7 +195,7 @@ bool configuration::load(const char* file_name, const char* arguments, const cha
 
             _file_data = utils::replace_string(_file_data, key, value);
 
-            printf("config.replace: %s => %s\n", key.c_str(), value.c_str());
+            fprintf(stderr, "config.replace: %s => %s\n", key.c_str(), value.c_str());
         }
     }
     
@@ -349,7 +388,7 @@ Next:
                             value // 12345
                         );
 
-                        printf("config.config.args: [%s] %s = %s\n",
+                        fprintf(stderr, "config.config.args: [%s] %s = %s\n",
                             kv.second->section.c_str(),
                             kv.second->key.c_str(),
                             kv.second->value.c_str()

--- a/src/dev/utility/join_point.cpp
+++ b/src/dev/utility/join_point.cpp
@@ -34,6 +34,7 @@
  */
 
 # include <dsn/utility/join_point.h>
+# include <dsn/utility/logging.h>
 # include <cassert>
 # include <cstdio>
 # include <cstring>
@@ -79,7 +80,7 @@ bool join_point_base::put_before(const char* base, void* fn, const char* name, b
     auto e0 = get_by_name(base);
     if (e0 == nullptr)
     {
-        fprintf(stderr, "cannot find advice with name '%s' in '%s'", base, _name.c_str());
+        dutil_fatal("cannot find advice with name '%s' in '%s'", base, _name.c_str());
         abort();
         return false;
     }
@@ -100,7 +101,7 @@ bool join_point_base::put_after(const char* base, void* fn, const char* name, bo
     auto e0 = get_by_name(base);
     if (e0 == nullptr)
     {
-        fprintf(stderr, "cannot find advice with name '%s' in '%s'", base, _name.c_str());
+        dutil_fatal("cannot find advice with name '%s' in '%s'", base, _name.c_str());
         abort();
         return false;
     }
@@ -121,7 +122,7 @@ bool join_point_base::put_replace(const char* base, void* fn, const char* name)
     auto e0 = get_by_name(base);
     if (e0 == nullptr)
     {
-        fprintf(stderr, "cannot find advice with name '%s' in '%s'", base, _name.c_str());
+        dutil_fatal("cannot find advice with name '%s' in '%s'", base, _name.c_str());
         abort();
         return false;
     }
@@ -138,7 +139,7 @@ bool join_point_base::remove(const char* name)
     auto e0 = get_by_name(name);
     if (e0 == nullptr)
     {
-        fprintf(stderr, "cannot find advice with name '%s' in '%s'", name, _name.c_str());
+        dutil_fatal("cannot find advice with name '%s' in '%s'", name, _name.c_str());
         abort();
         return false;
     }

--- a/src/dev/utility/logging.cpp
+++ b/src/dev/utility/logging.cpp
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ * 
+ * -=- Robust Distributed System Nucleus (rDSN) -=- 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Description:
+ *     Implementation of the low-level (utility-layer) logging facade.
+ *
+ * Revision history:
+ *     2026-07-07, unify rDSN diagnostics onto the logger, first version
+ */
+
+# include <dsn/utility/logging.h>
+# include <cstdio>
+
+namespace dsn {
+namespace utils {
+
+// The installed sink, or nullptr when none has been installed yet. Set once
+// during core initialization (before worker threads start); reads are plain
+// loads of a pointer that is constant for the rest of the process lifetime.
+static logging_sink s_logging_sink = nullptr;
+
+void set_logging_sink(logging_sink sink)
+{
+    s_logging_sink = sink;
+}
+
+void logv(log_level_t level, const char* file, const char* function, int line, const char* fmt, va_list args)
+{
+    char buffer[2048];
+    int n = vsnprintf(buffer, sizeof(buffer), fmt, args);
+    if (n < 0)
+    {
+        buffer[0] = '\0';
+    }
+
+    logging_sink sink = s_logging_sink;
+    if (sink != nullptr)
+    {
+        sink(level, file, function, line, buffer);
+    }
+    else
+    {
+        // No sink installed yet (very early bootstrap before dsn.core wires one
+        // up, or the utility library used standalone). Diagnostics go to stderr
+        // so that stdout stays clean for machine-readable program output.
+        static const char s_level_char[] = "IDWEF";
+        char lc = (level >= LOG_LEVEL_UTIL_INFORMATION && level <= LOG_LEVEL_UTIL_FATAL)
+                    ? s_level_char[level] : '?';
+        fprintf(stderr, "%c %s:%d:%s(): %s\n", lc, file, line, function, buffer);
+    }
+}
+
+void logf(log_level_t level, const char* file, const char* function, int line, const char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    logv(level, file, function, line, fmt, args);
+    va_end(args);
+}
+
+}} // namespace dsn::utils

--- a/src/plugins/apps.skv/simple_kv.server.h
+++ b/src/plugins/apps.skv/simple_kv.server.h
@@ -59,21 +59,21 @@ protected:
     // RPC_SIMPLE_KV_SIMPLE_KV_READ 
     virtual void on_read(const std::string& key, ::dsn::rpc_replier<std::string>& reply)
     {
-        std::cout << "... exec RPC_SIMPLE_KV_SIMPLE_KV_READ ... (not implemented) " << std::endl;
+        dwarn("... exec RPC_SIMPLE_KV_SIMPLE_KV_READ ... (not implemented) ");
         std::string resp;
         reply(resp);
     }
     // RPC_SIMPLE_KV_SIMPLE_KV_WRITE 
     virtual void on_write(const kv_pair& pr, ::dsn::rpc_replier<int32_t>& reply)
     {
-        std::cout << "... exec RPC_SIMPLE_KV_SIMPLE_KV_WRITE ... (not implemented) " << std::endl;
+        dwarn("... exec RPC_SIMPLE_KV_SIMPLE_KV_WRITE ... (not implemented) ");
         int32_t resp = 0;
         reply(resp);
     }
     // RPC_SIMPLE_KV_SIMPLE_KV_APPEND 
     virtual void on_append(const kv_pair& pr, ::dsn::rpc_replier<int32_t>& reply)
     {
-        std::cout << "... exec RPC_SIMPLE_KV_SIMPLE_KV_APPEND ... (not implemented) " << std::endl;
+        dwarn("... exec RPC_SIMPLE_KV_SIMPLE_KV_APPEND ... (not implemented) ");
         int32_t resp = 0;
         reply(resp);
     }

--- a/src/plugins/tools.common/simple_logger.cpp
+++ b/src/plugins/tools.common/simple_logger.cpp
@@ -46,65 +46,6 @@
 namespace dsn {
     namespace tools {
 
-        static void print_header(FILE* fp, dsn_log_level_t log_level)
-        {
-            static char s_level_char[] = "IDWEF";
-
-            uint64_t ts = 0;
-            if (::dsn::tools::is_engine_ready())
-                ts = dsn_now_ns();
-
-            char str[24];
-            ::dsn::utils::time_ms_to_string(ts / 1000000, str, sizeof(str));
-
-            int tid = ::dsn::utils::get_current_tid(); 
-
-            fprintf(fp, "%c%s (%" PRIu64 " %04x) ", s_level_char[log_level],
-                    str, ts, tid);
-
-            auto t = task::get_current_task_id();
-            if (t)
-            {
-                if (nullptr != task::get_current_worker2())
-                {
-                    fprintf(fp, "%6s.%7s%d.%016" PRIx64 ": ",
-                        task::get_current_node_name(),
-                        task::get_current_worker2()->pool_spec().name.c_str(),
-                        task::get_current_worker2()->index(),
-                        t
-                        );
-                }
-                else
-                {
-                    fprintf(fp, "%6s.%7s.%05d.%016" PRIx64 ": ",
-                        task::get_current_node_name(),
-                        "io-thrd",
-                        tid,
-                        t
-                        );
-                }
-            }
-            else
-            {
-                if (nullptr != task::get_current_worker2())
-                {
-                    fprintf(fp, "%6s.%7s%u: ",
-                        task::get_current_node_name(),
-                        task::get_current_worker2()->pool_spec().name.c_str(),
-                        task::get_current_worker2()->index()
-                        );
-                }
-                else
-                {
-                    fprintf(fp, "%6s.%7s.%05d: ",
-                        task::get_current_node_name(),
-                        "io-thrd",
-                        tid
-                        );
-                }
-            }
-        }
-
         screen_logger::screen_logger(const char* log_dir, logging_provider* inner)
             : logging_provider(log_dir, inner)
         {
@@ -127,18 +68,20 @@ namespace dsn {
         {
             utils::auto_lock< ::dsn::utils::ex_lock_nr> l(_lock);
 
-            print_header(stdout, log_level);
+            // write logs to stderr (not stdout) so that stdout stays clean for
+            // machine-readable program output (metrics, cli results, etc.)
+            logging_provider::print_header(stderr, log_level);
             if (!_short_header)
             {
-                printf("%s:%d:%s(): ", title, line, function);
+                fprintf(stderr, "%s:%d:%s(): ", title, line, function);
             }
-            vprintf(fmt, args);
-            printf("\n");
+            vfprintf(stderr, fmt, args);
+            fprintf(stderr, "\n");
         }
 
         void screen_logger::flush()
         {
-            ::fflush(stdout);
+            ::fflush(stderr);
         }
 
         simple_logger::simple_logger(const char* log_dir, logging_provider* inner)
@@ -300,7 +243,7 @@ namespace dsn {
                 {
                     if (log_level >= _stderr_start_level)
                     {
-                        print_header(stderr, log_level);
+                        logging_provider::print_header(stderr, log_level);
                         if (!_short_header)
                         {
                             fprintf(stderr, "%s:%d:%s(): ", title, line, function);
@@ -316,7 +259,7 @@ namespace dsn {
                 }
             }
          
-            print_header(_log, log_level);
+            logging_provider::print_header(_log, log_level);
             if (!_short_header)
             {
                 fprintf(_log, "%s:%d:%s(): ", title, line, function);
@@ -333,7 +276,7 @@ namespace dsn {
 
             if (log_level >= _stderr_start_level)
             {
-                print_header(stderr, log_level);
+                logging_provider::print_header(stderr, log_level);
                 if (!_short_header)
                 {
                     fprintf(stderr, "%s:%d:%s(): ", title, line, function);

--- a/src/plugins/tools.nfs/nfs_server.h
+++ b/src/plugins/tools.nfs/nfs_server.h
@@ -49,14 +49,14 @@ protected:
     // RPC_NFS_NFS_COPY
     virtual void on_copy(const copy_request& request, ::dsn::rpc_replier<copy_response>& reply)
     {
-        std::cout << "... exec RPC_NFS_NFS_COPY ... (not implemented) " << std::endl;
+        dwarn("... exec RPC_NFS_NFS_COPY ... (not implemented) ");
         copy_response resp;
         reply(resp);
     }
     // RPC_NFS_NFS_GET_FILE_SIZE
     virtual void on_get_file_size(const get_file_size_request& request, ::dsn::rpc_replier<get_file_size_response>& reply)
     {
-        std::cout << "... exec RPC_NFS_NFS_GET_FILE_SIZE ... (not implemented) " << std::endl;
+        dwarn("... exec RPC_NFS_NFS_GET_FILE_SIZE ... (not implemented) ");
         get_file_size_response resp;
         reply(resp);
     }


### PR DESCRIPTION
## Overview

This branch makes rDSN's startup and diagnostic output more robust and
consistent. It fixes several startup crash / misconfiguration paths, and routes
scattered diagnostic output (`fprintf(stderr)`, `std::cout`, `std::cerr`,
`printf`, raw `derror`/`dwarn`) through **one replaceable logger** so that:

- **stdout stays clean** for machine-readable output (e.g. metrics json /
  prometheus, CLI results) — consumers no longer have to skip past banner/log
  noise;
- **diagnostics go to stderr** through the configurable logging provider, with
  a consistent header format.

## Part 1 — Startup hardening (4 colleague-reported issues)

1. **Graceful app-start failure.** A non-`ERR_OK` return from an app `start()`
   no longer triggers a fatal `dassert` coredump on the standard launch path;
   it logs via `derror` and `dsn_exit(1)` for a clean fail-stop. The
   `dsn_app_start` doc is corrected to describe the real behavior (and the
   mimic-path exception).
2. **`@include` resolution.** `configuration::load_include()` now resolves a
   relative `@include` against the *parent config file's* directory instead of
   the process CWD, with a CWD-relative fallback for backward compatibility;
   absolute paths are used as-is.
3. **Missing `[core] tool`.** Startup now null-checks the tool factory result:
   a missing/invalid `[core] tool` fails cleanly with a clear error instead of
   dereferencing `nullptr` and crashing with SIGSEGV.
4. **Clean stdout at startup.** Config-load messages and the `dsn cli begin ...`
   banner move to stderr; the interactive CLI prompt and command results stay
   on stdout.

## Part 2 — Diagnostic-output unification

- **Unified log header.** A single `logging_provider::print_header` produces the
  `LEVEL file:line:func()` prefix; the bootstrap null-logger fallback and
  `screen_logger` now write to **stderr** (previously stdout).
- **Utility-layer logging facade.** New `include/dsn/utility/logging.h` +
  `src/dev/utility/logging.cpp` expose a small `dutil_info/debug/warn/error/fatal`
  facade backed by a settable sink. Because `dsn.core` links `dsn.dev.utility`
  (utility sits *below* core), utility code can't call `dsn_logv` directly; core
  installs a forwarding sink at static-init that maps levels, applies the
  configured level gate, and routes through the real logger. This lets
  low-level components (`configuration`, `join_point`, `factory_store`) emit
  diagnostics without a hard dependency on the logger.
- **Logger-dependent components.** `global_config`, `service_api_c`
  (`dsn_exit`), `nfs_server`, `main.cpp`, the `CONFIG_FLD_*` config-reader
  macros in `config_helper.h`, and the `simple_kv` stubs now use
  `dinfo/dwarn/derror` instead of raw `fprintf`/`std::cout`.
- **`printf` normalization.** Remaining bare `printf(...)` calls become
  `fprintf(stdout, ...)` for an explicit, exception-free stream (behavior
  unchanged; `std::cout`/`std::cerr` sites left as-is).

## Submodule bumps

- `rDSN.dist.service`: `ca52e98 -> 2a681d6`.
- `rDSN.dist.deployment`: `a983196 -> e1af16d`.

Each bump introduces only its merged PR.

## What is intentionally left as-is

Genuine program output and paths where the logger is unavailable/unsafe are
kept on their direct streams: interactive CLI/admin tools (`tools/cli`,
`command_manager` REPL, `ddl_client`, `repli`), examples/demos, logger
implementation internals (`simple_logger`, `hpc_logger`), crash-time handlers
(`coredump.*`), the CRC code generator, the monitor display path, tests, and a
few deliberate bootstrap exceptions in `main.cpp` (logger-init failure, usage,
bad args).