### PR TITLE
Harden rDSN against fault-injection crashes, deadlocks, and alignment UB

### DIFF
--- a/include/dsn/cpp/optional.h
+++ b/include/dsn/cpp/optional.h
@@ -46,7 +46,7 @@ template<typename T>
 class optional
 {
     bool _is_some;
-    char _data_placeholder[sizeof(T)];
+    alignas(T) char _data_placeholder[sizeof(T)];
    
 public:
     optional() : _is_some(false) {}

--- a/include/dsn/tool-api/rpc_message.h
+++ b/include/dsn/tool-api/rpc_message.h
@@ -173,6 +173,13 @@ namespace dsn
         bool                   _rw_committed; // mark if it is in middle state of reading/writing
         bool                   _is_read;      // is for read(recv) or write(send)
 
+        // Lifetime holder for a received message's header. On the receive path the
+        // wire header is copied into max_align_t-aligned storage (see
+        // create_receive_message) so reads of message_header fields are aligned; this
+        // blob keeps that storage alive as long as the message does. It is empty for
+        // send messages, whose header lives inside buffers[0].
+        blob                   _received_header;
+
     public:
         static uint32_t s_local_hash;  // used by fast_rpc_name
     };

--- a/include/dsn/utility/logging.h
+++ b/include/dsn/utility/logging.h
@@ -28,37 +28,33 @@
  * Description:
  *     A very small logging facade for the foundational (utility) layer.
  *
- *     The utility layer sits *below* dsn.core in the library dependency graph
- *     (dsn.core links dsn.dev.utility, not the other way around), so utility
- *     code cannot call the real logger (dsn_logv / dinfo/dwarn/derror) directly
- *     without creating a reverse library dependency. Historically it therefore
- *     hard-wired diagnostics to fprintf(stderr), which both bypasses the
- *     configured logger and scatters an un-replaceable sink across the code.
+ *     Goal: give low-level modules a single, uniform, dlog-like logging API
+ *     (dutil_info / dutil_debug / dutil_warn / dutil_error / dutil_fatal) so
+ *     they stop scattering ad-hoc fprintf() calls. This is about a consistent
+ *     interface, not about the destination -- the utility layer sits *below*
+ *     dsn.core in the library dependency graph (dsn.core links dsn.dev.utility,
+ *     not the other way around), so utility code cannot route into the real
+ *     process logger (dsn_logv / dinfo/dwarn/derror) without creating a reverse
+ *     library dependency. The facade therefore writes to stderr. stderr (not
+ *     stdout) keeps stdout clean for machine-readable program output.
  *
- *     This facade fixes that: low-level components log through dutil_info /
- *     dutil_warn / dutil_error, which forward to a pluggable sink. dsn.core
- *     installs a sink (set_logging_sink) that routes everything to dsn_logv, so
- *     utility diagnostics flow through the same configurable, replaceable logger
- *     as the rest of rDSN. Until a sink is installed (very early bootstrap, or
- *     when the utility library is used standalone) the default is stderr, so
- *     stdout stays clean for machine-readable program output.
+ *     These helpers are internal plumbing for rDSN's foundational layer, not
+ *     part of the public API; they are intentionally not exported from any
+ *     shared library.
  *
  * Revision history:
  *     2026-07-07, unify rDSN diagnostics onto the logger, first version
+ *     2026-07-09, drop the pluggable sink; utility logs directly to stderr
  */
 
 # pragma once
-
-# include <dsn/utility/dlib.h>
-# include <cstdarg>
 
 namespace dsn {
 namespace utils {
 
 // Low-level logging severities. These deliberately mirror the core
-// dsn_log_level_t values one-to-one (INFORMATION=0 .. FATAL=4) so the core sink
-// can map them with a plain cast, while keeping the utility layer free of any
-// dependency on the C logging API header.
+// dsn_log_level_t values one-to-one (INFORMATION=0 .. FATAL=4), keeping the
+// utility layer free of any dependency on the C logging API header.
 enum log_level_t
 {
     LOG_LEVEL_UTIL_INFORMATION = 0,
@@ -68,21 +64,11 @@ enum log_level_t
     LOG_LEVEL_UTIL_FATAL
 };
 
-// A sink that dsn.core installs so utility-layer diagnostics are routed through
-// the real, replaceable process logger. The message is already formatted.
-typedef void (*logging_sink)(
-    log_level_t level, const char* file, const char* function, int line, const char* msg);
-
-// Install (or clear, with nullptr) the sink. Intended to be called once during
-// core initialization, before worker threads start; not synchronized against
-// concurrent logging.
-extern DSN_API void set_logging_sink(logging_sink sink);
-
-// Format and emit a single diagnostic. Routed to the installed sink, or to
-// stderr when none is installed.
-extern DSN_API void logv(
-    log_level_t level, const char* file, const char* function, int line, const char* fmt, va_list args);
-extern DSN_API void logf(
+// Format and emit a single diagnostic to stderr. This is the only entry point
+// the dutil_* macros use. It is internal to the foundational layer and
+// deliberately not exported from any shared library (utility code must not
+// depend on dsn.core, so it cannot route through the configured logger).
+extern void logf(
     log_level_t level, const char* file, const char* function, int line, const char* fmt, ...);
 
 }} // namespace dsn::utils

--- a/src/core/src/configuration.test.cpp
+++ b/src/core/src/configuration.test.cpp
@@ -311,7 +311,7 @@ TEST(core, configuration_concurrent_include)
     std::vector<std::thread> threads;
     for (int t = 0; t < thread_count; ++t)
     {
-        threads.emplace_back([&diamond_ok, &cycle_rejected, iterations]() {
+        threads.emplace_back([&diamond_ok, &cycle_rejected]() {
             for (int i = 0; i < iterations; ++i)
             {
                 {

--- a/src/core/src/configuration.test.cpp
+++ b/src/core/src/configuration.test.cpp
@@ -303,7 +303,12 @@ TEST(core, configuration_concurrent_include)
     // false positive. No matter how the loads interleave, every valid (diamond)
     // load must succeed and every circular load must be rejected.
     const int thread_count = 8;
-    const int iterations = 50;
+    // Static storage so the thread lambda below can read it *without* capturing
+    // it: capturing this const int is flagged by clang (-Wunused-lambda-capture,
+    // it's a constant expression) while NOT capturing an automatic one is
+    // rejected by MSVC (C3493). A static local is never captured, which satisfies
+    // clang, gcc and MSVC alike.
+    static const int iterations = 50;
 
     std::atomic<int> diamond_ok(0);
     std::atomic<int> cycle_rejected(0);

--- a/src/core/src/configuration.test.cpp
+++ b/src/core/src/configuration.test.cpp
@@ -39,6 +39,10 @@
 # include <algorithm>
 # include <fstream>
 # include <cstring>
+# include <atomic>
+# include <string>
+# include <thread>
+# include <vector>
 
 using namespace ::dsn;
 
@@ -239,4 +243,102 @@ TEST(core, configuration_invalid_numeric_values)
     ASSERT_EQ(14, c.get_value<long>(section, "invalid_hex", 14, ""));
     ASSERT_EQ(15, c.get_value<long long>(section, "invalid_uppercase_hex", 15, ""));
     ASSERT_EQ(18, c.get_value<long long>(section, "overflow_hex", 18, ""));
+}
+
+TEST(core, configuration_circular_include)
+{
+    // A circular @include chain must be rejected gracefully (load returns false)
+    // instead of recursing through load()/load_include() until the stack
+    // overflows and the process crashes.
+
+    // a.ini -> b.ini -> a.ini
+    {
+        configuration c;
+        ASSERT_FALSE(c.load("config-include-cycle-a.ini"));
+    }
+
+    // self-include: a.ini -> a.ini
+    {
+        configuration c;
+        ASSERT_FALSE(c.load("config-include-self.ini"));
+    }
+
+    // 3-node cycle: a.ini -> b.ini -> c.ini -> a.ini
+    {
+        configuration c;
+        ASSERT_FALSE(c.load("config-include-cycle3-a.ini"));
+    }
+
+    // A diamond include (the same file reached via two different, non-cyclic
+    // paths) is NOT a cycle and must still load successfully.
+    {
+        configuration c;
+        ASSERT_TRUE(c.load("config-include-diamond-a.ini"));
+        ASSERT_STREQ("dv", c.get_string_value("diamond_test", "dk", "unknown", ""));
+    }
+
+    // A deep (non-cyclic) include chain must load successfully.
+    {
+        configuration c;
+        ASSERT_TRUE(c.load("config-include-deep-a.ini"));
+        ASSERT_STREQ("dv", c.get_string_value("deep_test", "dk", "unknown", ""));
+    }
+
+    // After a rejected circular load, the per-thread include-tracking state must
+    // be clean again, so a subsequent valid load on the same thread succeeds.
+    {
+        configuration c1;
+        ASSERT_FALSE(c1.load("config-include-cycle-a.ini"));
+        configuration c2;
+        ASSERT_TRUE(c2.load("config-include-diamond-a.ini"));
+        ASSERT_STREQ("dv", c2.get_string_value("diamond_test", "dk", "unknown", ""));
+    }
+}
+
+TEST(core, configuration_concurrent_include)
+{
+    // The include-tracking set is thread_local, so loading configurations
+    // concurrently on multiple threads is race-free: each thread tracks only its
+    // own @include ancestry, with no shared mutable state and no cross-thread
+    // false positive. No matter how the loads interleave, every valid (diamond)
+    // load must succeed and every circular load must be rejected.
+    const int thread_count = 8;
+    const int iterations = 50;
+
+    std::atomic<int> diamond_ok(0);
+    std::atomic<int> cycle_rejected(0);
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < thread_count; ++t)
+    {
+        threads.emplace_back([&diamond_ok, &cycle_rejected, iterations]() {
+            for (int i = 0; i < iterations; ++i)
+            {
+                {
+                    configuration c;
+                    if (c.load("config-include-diamond-a.ini")
+                        && std::string("dv")
+                               == c.get_string_value("diamond_test", "dk", "unknown", ""))
+                    {
+                        diamond_ok.fetch_add(1);
+                    }
+                }
+                {
+                    configuration c;
+                    if (!c.load("config-include-cycle-a.ini"))
+                    {
+                        cycle_rejected.fetch_add(1);
+                    }
+                }
+            }
+        });
+    }
+
+    for (auto& th : threads)
+    {
+        th.join();
+    }
+
+    ASSERT_EQ(thread_count * iterations, diamond_ok.load());
+    ASSERT_EQ(thread_count * iterations, cycle_rejected.load());
 }

--- a/src/core/src/logging.cpp
+++ b/src/core/src/logging.cpp
@@ -38,47 +38,12 @@
 # include <dsn/tool-api/command.h>
 # include <dsn/tool-api/logging_provider.h>
 # include <dsn/tool_api.h>
-# include <dsn/utility/logging.h>
 # include "service_engine.h"
 # include <dsn/cpp/auto_codes.h>
 # include <cstdio>
 # include <cinttypes>
 
 DSN_API dsn_log_level_t dsn_log_start_level = dsn_log_level_t::LOG_LEVEL_INFORMATION;
-
-// route diagnostics emitted by the foundational (utility) layer through the real
-// process logger. The utility layer sits below dsn.core and cannot call dsn_logv
-// directly, so it logs via a pluggable sink (dsn::utils::logf); here we install
-// a sink that forwards to dsn_logv, honoring the same start-level gate as the
-// dlog macros. Installed at static-init so it is active before main() runs; any
-// utility diagnostics emitted before this point fall back to stderr, which is
-// where dsn_logv would route them during early bootstrap anyway.
-static void forward_utils_log_to_dsn(
-    ::dsn::utils::log_level_t level, const char* file, const char* function, int line, const char* msg)
-{
-    // dsn::utils::log_level_t mirrors dsn_log_level_t one-to-one (INFORMATION=0 .. FATAL=4).
-    dsn_log_level_t dlevel = static_cast<dsn_log_level_t>(level);
-    if (dlevel < LOG_LEVEL_INFORMATION || dlevel > LOG_LEVEL_FATAL)
-    {
-        dlevel = LOG_LEVEL_WARNING;
-    }
-    if (dlevel >= dsn_log_start_level)
-    {
-        // pass msg as an argument (not as the format) so any '%' in it is safe.
-        dsn_logf(file, function, line, dlevel, file, "%s", msg);
-    }
-}
-
-namespace {
-struct utils_log_sink_installer
-{
-    utils_log_sink_installer()
-    {
-        ::dsn::utils::set_logging_sink(forward_utils_log_to_dsn);
-    }
-};
-static utils_log_sink_installer s_utils_log_sink_installer;
-}
 
 static void log_on_sys_exit(::dsn::sys_exit_type)
 {

--- a/src/core/src/rpc_message.cpp
+++ b/src/core/src/rpc_message.cpp
@@ -561,7 +561,27 @@ task_code message_ex::rpc_code()
 message_ex* message_ex::create_receive_message(const blob& data)
 {
     message_ex* msg = new message_ex();
-    msg->header = (message_header*)data.data();
+
+    // Copy the wire header into max_align_t-aligned storage and keep the body
+    // zero-copy. On the receive path the header sits at an arbitrary offset inside
+    // the shared socket buffer, so data.data() is generally unaligned; reading
+    // message_header fields (id, trace_id, the embedded rpc_address, ...) directly
+    // from there is misaligned-access undefined behavior -- benign on x86 but a real
+    // hazard on stricter ISAs such as arm64. dsn_transient_malloc returns
+    // max_align_t-aligned memory, so the copied header is safe to read in place.
+    char* header_ptr = static_cast<char*>(dsn_transient_malloc(sizeof(message_header)));
+    if (header_ptr == nullptr)
+    {
+        derror("message_ex::create_receive_message failed to allocate aligned header");
+        delete msg;
+        return nullptr;
+    }
+
+    std::shared_ptr<char> header_holder(header_ptr, [](char* c) { dsn_transient_free(c); });
+    memcpy(header_ptr, data.data(), sizeof(message_header));
+    msg->_received_header = blob(std::move(header_holder), sizeof(message_header));
+    msg->header = reinterpret_cast<message_header*>(header_ptr);
+
     msg->_is_read = true;
     // the message_header is hidden ahead of the buffer
     auto data2 = data.range((int)sizeof(message_header));
@@ -647,18 +667,20 @@ message_ex* message_ex::copy(bool clone_content, bool copy_for_receive)
     {
         msg->header = header; // header is within the buffer
         msg->buffers = buffers;
+        msg->_received_header = _received_header; // keep the aligned received header alive
     }
     else
     {
-        int total_length = body_size() + sizeof(dsn::message_header);
+        size_t total_length = body_size() + sizeof(dsn::message_header);
         std::shared_ptr<char> recv_buffer(dsn::make_shared_array<char>(total_length));
         char* ptr = recv_buffer.get();
-        int i=0;
+        size_t i = 0;
 
         if ((const char*)header != buffers[0].data())
         {
             memcpy(ptr, (const void*)header, sizeof(message_header));
             ptr += sizeof(message_header);
+            i += sizeof(message_header); // header copied separately; count it
         }
 
         for (dsn::blob& bb: buffers)
@@ -669,7 +691,7 @@ message_ex* message_ex::copy(bool clone_content, bool copy_for_receive)
         }
         dassert(i==total_length, "");
 
-        auto data = dsn::blob(recv_buffer, total_length);
+        auto data = dsn::blob(recv_buffer, (unsigned int)total_length);
         
         msg->header = (message_header*)data.data();
         if (msg->_is_read)
@@ -682,13 +704,19 @@ message_ex* message_ex::copy(bool clone_content, bool copy_for_receive)
 
 message_ex* message_ex::copy_and_prepare_send(bool clone_content)
 {
-    auto copy = this->copy(clone_content, false);
+    // A received message keeps its header in separate, max_align_t-aligned storage
+    // (see create_receive_message), so the header is no longer contiguous with the
+    // body buffer. Clone in that case: copy() rebuilds a single contiguous
+    // [header][body] buffer (it already handles a non-contiguous header), which we
+    // then expose as the send buffer below. Send messages keep the original path.
+    auto copy = this->copy(_is_read ? true : clone_content, false);
 
     if (_is_read)
     {
         // the message_header is hidden ahead of the buffer, expose it to buffer
-        dassert(buffers.size() == 1, "there must be only one buffer for read msg");
-        dassert((char*)header + sizeof(message_header) == (char*)buffers[0].data(), "header and content must be contigous");
+        dassert(copy->buffers.size() == 1, "there must be only one buffer for read msg");
+        dassert((char*)copy->header + sizeof(message_header) == (char*)copy->buffers[0].data(),
+            "header and content must be contigous");
 
         copy->buffers[0] = copy->buffers[0].range(-(int)sizeof(message_header));
 

--- a/src/core/src/task_spec.cpp
+++ b/src/core/src/task_spec.cpp
@@ -212,7 +212,13 @@ bool task_spec::init()
 
         std::string section_name = std::string("task.") + std::string(dsn_task_code_to_string(code));
         task_spec* spec = task_spec::get(code);
-        dassert (spec != nullptr, "task_spec cannot be null");
+        if (spec == nullptr)
+        {
+            derror("task_spec for code %d (%s) is missing, likely because its "
+                   "registration failed under resource pressure; abort startup",
+                   code, dsn_task_code_to_string(code));
+            return false;
+        }
 
         if (!read_config(section_name.c_str(), *spec, &default_spec))
             return false;

--- a/src/core/src/test/config-include-common.ini
+++ b/src/core/src/test/config-include-common.ini
@@ -1,0 +1,2 @@
+[diamond_test]
+dk = dv

--- a/src/core/src/test/config-include-cycle-a.ini
+++ b/src/core/src/test/config-include-cycle-a.ini
@@ -1,0 +1,3 @@
+[apps.server]
+run = true
+@include config-include-cycle-b.ini

--- a/src/core/src/test/config-include-cycle-b.ini
+++ b/src/core/src/test/config-include-cycle-b.ini
@@ -1,0 +1,3 @@
+[apps.server]
+count = 1
+@include config-include-cycle-a.ini

--- a/src/core/src/test/config-include-cycle3-a.ini
+++ b/src/core/src/test/config-include-cycle3-a.ini
@@ -1,0 +1,3 @@
+[apps.server]
+run = true
+@include config-include-cycle3-b.ini

--- a/src/core/src/test/config-include-cycle3-b.ini
+++ b/src/core/src/test/config-include-cycle3-b.ini
@@ -1,0 +1,3 @@
+[apps.server]
+count = 1
+@include config-include-cycle3-c.ini

--- a/src/core/src/test/config-include-cycle3-c.ini
+++ b/src/core/src/test/config-include-cycle3-c.ini
@@ -1,0 +1,3 @@
+[apps.server]
+type = test
+@include config-include-cycle3-a.ini

--- a/src/core/src/test/config-include-deep-a.ini
+++ b/src/core/src/test/config-include-deep-a.ini
@@ -1,0 +1,3 @@
+[apps.server]
+run = true
+@include config-include-deep-b.ini

--- a/src/core/src/test/config-include-deep-b.ini
+++ b/src/core/src/test/config-include-deep-b.ini
@@ -1,0 +1,3 @@
+[apps.server]
+count = 1
+@include config-include-deep-c.ini

--- a/src/core/src/test/config-include-deep-c.ini
+++ b/src/core/src/test/config-include-deep-c.ini
@@ -1,0 +1,2 @@
+[deep_test]
+dk = dv

--- a/src/core/src/test/config-include-diamond-a.ini
+++ b/src/core/src/test/config-include-diamond-a.ini
@@ -1,0 +1,4 @@
+[apps.server]
+run = true
+@include config-include-common.ini
+@include config-include-diamond-b.ini

--- a/src/core/src/test/config-include-diamond-b.ini
+++ b/src/core/src/test/config-include-diamond-b.ini
@@ -1,0 +1,3 @@
+[apps.server]
+count = 1
+@include config-include-common.ini

--- a/src/core/src/test/config-include-self.ini
+++ b/src/core/src/test/config-include-self.ini
@@ -1,0 +1,3 @@
+[apps.server]
+run = true
+@include config-include-self.ini

--- a/src/core/src/transient_memory.cpp
+++ b/src/core/src/transient_memory.cpp
@@ -52,6 +52,31 @@ namespace dsn
 
     static size_t tls_trans_mem_default_block_bytes = 1024 * 1024; // 1 MB
 
+    // The single alignment invariant for transient memory: every pointer handed out by
+    // tls_trans_mem_next is aligned to alignof(std::max_align_t) -- the strictest
+    // alignment any scalar type needs. Enforcing it in this one low-level place makes
+    // every structure later overlaid on transient memory naturally aligned, with no
+    // alignment logic at the call sites:
+    //   * message_header on the send path (message_ex::prepare_buffer_header / write_next),
+    //   * the std::shared_ptr bookkeeping tls_trans_malloc stores below its user pointer,
+    //   * and the pointer returned by the public dsn_transient_malloc, whose malloc-style
+    //     contract requires max_align_t alignment.
+    // Fresh blocks come from make_shared_array<char> (operator new[]), which is already
+    // max_align_t-aligned, so tls_trans_mem_next only has to re-align the bump pointer
+    // after each exact-size commit.
+    static const size_t tls_trans_alignment = alignof(std::max_align_t);
+
+    // tls_trans_malloc stores [ std::shared_ptr<char> ][ pad ][ uint32_t magic ] in the
+    // tls_trans_malloc_header_size bytes immediately below the pointer it returns.
+    // header_size is rounded up to tls_trans_alignment so that, given an aligned base from
+    // tls_trans_mem_next, both the shared_ptr (placed at the base) and the returned user
+    // pointer (base + header_size) are aligned. tls_trans_malloc and tls_trans_free share
+    // these constants so the write and free layouts can never drift apart.
+    static const size_t tls_trans_malloc_magic_size = sizeof(uint32_t);
+    static const size_t tls_trans_malloc_header_size =
+        ((sizeof(std::shared_ptr<char>) + tls_trans_malloc_magic_size + tls_trans_alignment - 1)
+            / tls_trans_alignment) * tls_trans_alignment;
+
     void tls_trans_mem_init(size_t default_per_block_bytes)
     {
         tls_trans_mem_default_block_bytes = default_per_block_bytes;
@@ -85,6 +110,24 @@ namespace dsn
         {
             dassert(tls_trans_memory.committed == true,
                 "tls_trans_mem_next and tls_trans_mem_commit must be called in pair");
+
+            // Round the bump pointer up to tls_trans_alignment before handing it out.
+            // Commits advance next by exact use sizes, so without this every allocation
+            // after the first would start at an arbitrary offset and misalign the
+            // structures overlaid on it (e.g. message_header in prepare_buffer_header).
+            const uintptr_t cur = reinterpret_cast<uintptr_t>(tls_trans_memory.next);
+            const size_t pad =
+                (tls_trans_alignment - (cur & (tls_trans_alignment - 1))) & (tls_trans_alignment - 1);
+            if (pad <= tls_trans_memory.remain_bytes)
+            {
+                tls_trans_memory.next += pad;
+                tls_trans_memory.remain_bytes -= pad;
+            }
+            else
+            {
+                // not enough room left even to align; force a fresh (aligned) block below
+                tls_trans_memory.remain_bytes = 0;
+            }
 
             if (min_size > tls_trans_memory.remain_bytes)
                 tls_trans_mem_alloc(min_size);
@@ -126,46 +169,49 @@ namespace dsn
     void* tls_trans_malloc(size_t sz)
     {
         const size_t user_size = sz;
-        const size_t header_size = sizeof(std::shared_ptr<char>) + sizeof(uint32_t);
-        const size_t alignment = alignof(std::max_align_t);
-        // Guard against size_t overflow when padding the request for the header and alignment.
-        // Without this, a ~4GB request on a 32-bit build would wrap alloc_size to a tiny value,
-        // and the subsequent writes would run past the end of the allocation (heap overflow).
-        if (user_size > (std::numeric_limits<std::size_t>::max)() - (header_size + alignment - 1))
+        const size_t header_size = tls_trans_malloc_header_size;
+        // Guard against size_t overflow when padding the request for the header. Without
+        // this, a ~4GB request on a 32-bit build would wrap alloc_size to a tiny value and
+        // the subsequent writes would run past the end of the allocation (heap overflow).
+        if (user_size > (std::numeric_limits<std::size_t>::max)() - header_size)
         {
             derror("tls_trans_malloc: requested size %zu is too large", user_size);
             return nullptr;
         }
-        const size_t alloc_size = user_size + header_size + alignment - 1;
+        const size_t alloc_size = user_size + header_size;
         void* ptr;
         size_t sz2;
         tls_trans_mem_next(&ptr, &sz2, alloc_size);
 
+        // tls_trans_mem_next hands back a max_align_t-aligned base and header_size is a
+        // multiple of that alignment, so the shared_ptr placed at the base and the returned
+        // user pointer are both aligned without any per-allocation rounding here.
         char* const raw_ptr = static_cast<char*>(ptr);
-        const uintptr_t unaligned_user_ptr = reinterpret_cast<uintptr_t>(raw_ptr) + header_size;
-        const uintptr_t aligned_user_ptr =
-            ((unaligned_user_ptr + alignment - 1) / alignment) * alignment;
-        char* const user_ptr = reinterpret_cast<char*>(aligned_user_ptr);
-        char* const header_ptr = user_ptr - header_size;
+        char* const user_ptr = raw_ptr + header_size;
 
         // add ref
-        new (header_ptr) std::shared_ptr<char>(*::dsn::tls_trans_memory.block);
+        new (raw_ptr) std::shared_ptr<char>(*::dsn::tls_trans_memory.block);
 
         // add magic
-        *(uint32_t*)(user_ptr - sizeof(uint32_t)) = 0xdeadbeef;
+        *(uint32_t*)(user_ptr - tls_trans_malloc_magic_size) = 0xdeadbeef;
 
-        tls_trans_mem_commit(static_cast<size_t>(user_ptr + user_size - raw_ptr));
+        tls_trans_mem_commit(alloc_size);
 
         return user_ptr;
     }
 
     void tls_trans_free(void* ptr)
     {
-        ptr = (void*)((char*)ptr - sizeof(uint32_t));
-        dassert(*(uint32_t*)(ptr) == 0xdeadbeef, "invalid transient memory block");
+        // Mirror the layout written by tls_trans_malloc: the magic sits just below the user
+        // pointer, and the shared_ptr sits header_size below it (header_size is padded so the
+        // shared_ptr was stored on an aligned address).
+        char* const user_ptr = static_cast<char*>(ptr);
+        dassert(*(uint32_t*)(user_ptr - tls_trans_malloc_magic_size) == 0xdeadbeef,
+            "invalid transient memory block");
 
-        ptr = (void*)((char*)ptr - sizeof(std::shared_ptr<char>));
-        ((std::shared_ptr<char>*)(ptr))->~shared_ptr<char>();
+        std::shared_ptr<char>* const holder =
+            reinterpret_cast<std::shared_ptr<char>*>(user_ptr - tls_trans_malloc_header_size);
+        holder->~shared_ptr<char>();
     }
 }
 

--- a/src/core/src/transient_memory.test.cpp
+++ b/src/core/src/transient_memory.test.cpp
@@ -35,8 +35,24 @@
 
 # include "transient_memory.h"
 # include <gtest/gtest.h>
+# include <cstddef>
+# include <cstdint>
 
 using namespace ::dsn;
+
+namespace
+{
+    // tls_trans_mem_next hands out every pointer aligned to alignof(std::max_align_t)
+    // (see tls_trans_alignment in transient_memory.cpp): after a commit of an unaligned
+    // size, the next acquire rounds the bump pointer up before returning it. Rounding an
+    // offset the same way lets the assertions below track the bump pointer across the
+    // unaligned commits this test performs.
+    inline size_t align_up(size_t v)
+    {
+        const size_t a = alignof(std::max_align_t);
+        return (v + a - 1) / a * a;
+    }
+}
 
 TEST(core, transient_memory)
 {
@@ -79,15 +95,17 @@ TEST(core, transient_memory)
     // acquire 200
     tls_trans_mem_next(&ptr, &sz, 200);
     ASSERT_EQ((void*)tls_trans_memory.next, (void*)ptr);
-    ASSERT_EQ(924u, sz);
-    ASSERT_EQ((void*)tls_trans_memory.next, (void*)(tls_trans_memory.block->get() + 100));
-    ASSERT_EQ(924u, tls_trans_memory.remain_bytes);
+    // the previous commit left next at offset 100; acquiring rounds it up to align_up(100),
+    // consuming the padding from the remaining bytes.
+    ASSERT_EQ(1024u - align_up(100), sz);
+    ASSERT_EQ((void*)tls_trans_memory.next, (void*)(tls_trans_memory.block->get() + align_up(100)));
+    ASSERT_EQ(1024u - align_up(100), tls_trans_memory.remain_bytes);
     ASSERT_FALSE(tls_trans_memory.committed);
 
     // commit 300
     tls_trans_mem_commit(300);
-    ASSERT_EQ((void*)tls_trans_memory.next, (void*)(tls_trans_memory.block->get() + 400));
-    ASSERT_EQ(624u, tls_trans_memory.remain_bytes);
+    ASSERT_EQ((void*)tls_trans_memory.next, (void*)(tls_trans_memory.block->get() + align_up(100) + 300));
+    ASSERT_EQ(1024u - align_up(100) - 300, tls_trans_memory.remain_bytes);
     ASSERT_TRUE(tls_trans_memory.committed);
 
     // acquire 10240
@@ -103,6 +121,39 @@ TEST(core, transient_memory)
     ASSERT_EQ((void*)tls_trans_memory.next, (void*)(tls_trans_memory.block->get()));
     ASSERT_EQ(10240u, tls_trans_memory.remain_bytes);
     ASSERT_TRUE(tls_trans_memory.committed);
+
+    tls_trans_mem_init(1024 * 1024); // restore
+}
+
+TEST(core, transient_memory_alignment)
+{
+    const size_t align = alignof(std::max_align_t);
+
+    // Every pointer tls_trans_mem_next returns must be max_align_t-aligned, even right
+    // after a commit of an unaligned size. This is the invariant that keeps a message_header
+    // (or any other structure) overlaid on the next allocation naturally aligned.
+    void* ptr;
+    size_t sz;
+    const size_t unaligned_commits[] = { 1, 7, 13, 100, 4095 };
+    for (size_t i = 0; i < sizeof(unaligned_commits) / sizeof(unaligned_commits[0]); ++i)
+    {
+        tls_trans_mem_next(&ptr, &sz, 8);
+        ASSERT_EQ(0u, reinterpret_cast<uintptr_t>(ptr) % align);
+        tls_trans_mem_commit(unaligned_commits[i]);
+    }
+
+    // dsn_transient_malloc must honor its malloc-style contract of returning
+    // max_align_t-aligned memory regardless of the requested size, and the shared_ptr
+    // bookkeeping it stores below the returned pointer must itself be aligned (otherwise
+    // its destructor in dsn_transient_free would be an unaligned access).
+    const uint32_t malloc_sizes[] = { 1, 3, 17, 64, 1000 };
+    for (size_t i = 0; i < sizeof(malloc_sizes) / sizeof(malloc_sizes[0]); ++i)
+    {
+        void* p = dsn_transient_malloc(malloc_sizes[i]);
+        ASSERT_NE(nullptr, p);
+        ASSERT_EQ(0u, reinterpret_cast<uintptr_t>(p) % align);
+        dsn_transient_free(p);
+    }
 
     tls_trans_mem_init(1024 * 1024); // restore
 }

--- a/src/dev/utility/configuration.cpp
+++ b/src/dev/utility/configuration.cpp
@@ -579,7 +579,7 @@ bool configuration::get_string_value_internal(const char* section, const char* k
     }
 
     *ov = default_value;
-    _lock.lock();
+    std::lock_guard<std::mutex> guard(_lock);
 
     std::map<std::string, conf*> *ps = nullptr;
     auto it = _configs.find(section);
@@ -604,7 +604,6 @@ bool configuration::get_string_value_internal(const char* section, const char* k
             *ov = it2->second->value.c_str();
             bool ret = it2->second->present ? true : false;
 
-            _lock.unlock();
             return ret;
         }
     }
@@ -628,7 +627,6 @@ bool configuration::get_string_value_internal(const char* section, const char* k
 
     *ov = cf->value.c_str();
 
-    _lock.unlock();
     return false;
 }
 
@@ -672,7 +670,7 @@ std::list<std::string> configuration::get_string_value_list(const char* section,
 
 void configuration::dump(std::ostream& os)
 {
-    _lock.lock();
+    std::lock_guard<std::mutex> guard(_lock);
 
     for (auto& s : _configs)
     {
@@ -692,16 +690,14 @@ void configuration::dump(std::ostream& os)
 
         os << std::endl;
     }
-
-    _lock.unlock();
 }
 
 void configuration::set(const char* section, const char* key, const char* value, const char* dsptr)
 {
     std::map<std::string, conf*>* psection;
 
-    _lock.lock();
-    
+    std::lock_guard<std::mutex> guard(_lock);
+
     auto it = _configs.find(section);
     if (it != _configs.end())
     {
@@ -734,8 +730,6 @@ void configuration::set(const char* section, const char* key, const char* value,
 
         it2->second->value = value;
     }
-
-    _lock.unlock();
 }
 
 void configuration::register_config_change_notification(config_file_change_notifier notifier)

--- a/src/dev/utility/configuration.cpp
+++ b/src/dev/utility/configuration.cpp
@@ -42,8 +42,23 @@
 # include <algorithm>
 # include <cstring>
 # include <utility>
+# include <set>
 
 namespace dsn {
+
+namespace {
+// Per-thread set of configuration files currently being loaded on this thread
+// (the active @include ancestry). The entire @include recursion runs
+// synchronously on one thread, so a thread-local set lets nested load() /
+// load_include() calls detect a circular @include chain -- which would
+// otherwise recurse until the stack overflows and the process crashes --
+// without exposing any state in configuration.h.
+std::set<std::string>& active_include_stack()
+{
+    static thread_local std::set<std::string> stack;
+    return stack;
+}
+}
 
 
 configuration::configuration()
@@ -121,6 +136,54 @@ bool configuration::load_include(const char* inc, const char* arguments)
 bool configuration::load(const char* file_name, const char* arguments, const char* overwrites)
 {
     _file_name = std::string(file_name);
+
+    // Detect circular @include chains (e.g. a.ini -> b.ini -> a.ini), which
+    // would otherwise recurse through load()/load_include() until the stack
+    // overflows and the process crashes. Track the files currently being loaded
+    // on this thread (the active include ancestry): if a file tries to include
+    // one of its own ancestors, reject it with a clear error. The canonical
+    // (realpath) form is used so different spellings of the same file (relative
+    // paths, symlinks, ..) are recognized as the same file.
+    std::string canonical_name;
+    if (!dsn::utils::filesystem::get_absolute_path(_file_name, canonical_name)
+        || canonical_name.empty())
+    {
+        canonical_name = _file_name;
+    }
+
+    std::set<std::string>& active_includes = active_include_stack();
+
+    // The outermost (root) load owns the per-thread set. Detecting the root
+    // here lets it clear the whole set when it finishes, guaranteeing the set
+    // is empty again after every top-level load -- whether it succeeded, failed,
+    // or unwound through an exception -- so no stale state can leak into a later
+    // load on the same thread. The root always inserts into an empty set, so it
+    // never triggers the cycle rejection below.
+    const bool is_root_load = active_includes.empty();
+
+    if (!active_includes.insert(canonical_name).second)
+    {
+        dutil_error("circular @include detected for configuration file '%s'", canonical_name.c_str());
+        return false;
+    }
+
+    // Remove this file from the active ancestry on every exit path, so the same
+    // file can still be included via a different, non-cyclic path (a diamond);
+    // the root load additionally clears the whole set as a safety net.
+    struct include_guard
+    {
+        std::set<std::string>& active;
+        const std::string& key;
+        bool is_root;
+        ~include_guard()
+        {
+            active.erase(key);
+            if (is_root)
+            {
+                active.clear();
+            }
+        }
+    } guard{active_includes, canonical_name, is_root_load};
 
     FILE* fd = ::fopen(file_name, "rb");
     if (fd == nullptr)

--- a/src/dev/utility/logging.cpp
+++ b/src/dev/utility/logging.cpp
@@ -27,28 +27,24 @@
 /*
  * Description:
  *     Implementation of the low-level (utility-layer) logging facade.
+ *     Diagnostics are written to stderr; see logging.h for the rationale
+ *     (the utility layer sits below dsn.core and must not depend on it).
  *
  * Revision history:
  *     2026-07-07, unify rDSN diagnostics onto the logger, first version
+ *     2026-07-09, drop the pluggable sink; utility logs directly to stderr
  */
 
 # include <dsn/utility/logging.h>
 # include <cstdio>
+# include <cstdarg>
 
 namespace dsn {
 namespace utils {
 
-// The installed sink, or nullptr when none has been installed yet. Set once
-// during core initialization (before worker threads start); reads are plain
-// loads of a pointer that is constant for the rest of the process lifetime.
-static logging_sink s_logging_sink = nullptr;
-
-void set_logging_sink(logging_sink sink)
-{
-    s_logging_sink = sink;
-}
-
-void logv(log_level_t level, const char* file, const char* function, int line, const char* fmt, va_list args)
+// Internal formatter shared by logf; not declared in the header because nothing
+// outside this file calls it directly.
+static void logv(log_level_t level, const char* file, const char* function, int line, const char* fmt, va_list args)
 {
     char buffer[2048];
     int n = vsnprintf(buffer, sizeof(buffer), fmt, args);
@@ -57,21 +53,14 @@ void logv(log_level_t level, const char* file, const char* function, int line, c
         buffer[0] = '\0';
     }
 
-    logging_sink sink = s_logging_sink;
-    if (sink != nullptr)
-    {
-        sink(level, file, function, line, buffer);
-    }
-    else
-    {
-        // No sink installed yet (very early bootstrap before dsn.core wires one
-        // up, or the utility library used standalone). Diagnostics go to stderr
-        // so that stdout stays clean for machine-readable program output.
-        static const char s_level_char[] = "IDWEF";
-        char lc = (level >= LOG_LEVEL_UTIL_INFORMATION && level <= LOG_LEVEL_UTIL_FATAL)
-                    ? s_level_char[level] : '?';
-        fprintf(stderr, "%c %s:%d:%s(): %s\n", lc, file, line, function, buffer);
-    }
+    // The utility layer sits below dsn.core and cannot route into the configured
+    // process logger without a reverse library dependency, so its diagnostics go
+    // to stderr. stderr (not stdout) keeps stdout clean for machine-readable
+    // program output.
+    static const char s_level_char[] = "IDWEF";
+    char lc = (level >= LOG_LEVEL_UTIL_INFORMATION && level <= LOG_LEVEL_UTIL_FATAL)
+                ? s_level_char[level] : '?';
+    fprintf(stderr, "%c %s:%d:%s(): %s\n", lc, file, line, function, buffer);
 }
 
 void logf(log_level_t level, const char* file, const char* function, int line, const char* fmt, ...)

--- a/src/plugins/tools.common/dsn_message_parser.cpp
+++ b/src/plugins/tools.common/dsn_message_parser.cpp
@@ -60,9 +60,17 @@ namespace dsn
 
         if (buf_len >= sizeof(message_header))
         {
+            // The header sits at an arbitrary offset inside the shared receive buffer,
+            // so buf_ptr is generally unaligned. Read its fields through a naturally
+            // aligned stack copy to avoid misaligned-access undefined behavior (benign
+            // on x86 but a real hazard on stricter ISAs such as arm64).
+            // create_receive_message likewise stores the header in aligned storage.
+            message_header hdr_copy;
+            memcpy(&hdr_copy, buf_ptr, sizeof(message_header));
+
             if (!_header_checked)
             {
-                if (!is_right_header(buf_ptr))
+                if (!is_right_header(reinterpret_cast<char*>(&hdr_copy)))
                 {
                     derror("dsn message header check failed");
                     read_next = -1;
@@ -74,7 +82,7 @@ namespace dsn
                 }
             }
 
-            unsigned int body_length = message_ex::get_body_length(buf_ptr);
+            unsigned int body_length = hdr_copy.body_length;
 
             // body_length comes from the wire; compute the total size in 64-bit and reject a
             // value that would overflow the 32-bit msg_sz and wrap to a small size (which would
@@ -93,11 +101,17 @@ namespace dsn
             {
                 dsn::blob msg_bb = buf.range(0, msg_sz);
                 message_ex* msg = message_ex::create_receive_message(msg_bb);
+                if (msg == nullptr)
+                {
+                    derror("dsn message creation failed, id = %" PRIu64 ", trace_id = %016" PRIx64 ", rpc_name = %s, from_addr = %s",
+                           hdr_copy.id, hdr_copy.trace_id, hdr_copy.rpc_name, hdr_copy.from_address.to_string());
+                    read_next = -1;
+                    return nullptr;
+                }
                 if (!is_right_body(msg))
                 {
-                    message_header* header = (message_header*)buf_ptr;
                     derror("dsn message body check failed, id = %" PRIu64 ", trace_id = %016" PRIx64 ", rpc_name = %s, from_addr = %s",
-                           header->id, header->trace_id, header->rpc_name, header->from_address.to_string());
+                           hdr_copy.id, hdr_copy.trace_id, hdr_copy.rpc_name, hdr_copy.from_address.to_string());
                     read_next = -1;
                     return nullptr;
                 }

--- a/src/plugins/tools.common/dsn_message_parser.cpp
+++ b/src/plugins/tools.common/dsn_message_parser.cpp
@@ -66,7 +66,7 @@ namespace dsn
             // on x86 but a real hazard on stricter ISAs such as arm64).
             // create_receive_message likewise stores the header in aligned storage.
             message_header hdr_copy;
-            memcpy(&hdr_copy, buf_ptr, sizeof(message_header));
+            memcpy(static_cast<void*>(&hdr_copy), buf_ptr, sizeof(message_header));
 
             if (!_header_checked)
             {

--- a/src/plugins/tools.emulator/network.sim.cpp
+++ b/src/plugins/tools.emulator/network.sim.cpp
@@ -81,6 +81,10 @@ namespace dsn { namespace tools {
 
         blob bb(buffer, 0, msg->header->body_length + sizeof(message_header));
         message_ex* recv_msg = message_ex::create_receive_message(bb);
+        if (recv_msg == nullptr)
+        {
+            return nullptr;
+        }
         recv_msg->to_address = msg->to_address;
 
         msg->copy_to(*recv_msg); // extensible object state move
@@ -113,6 +117,10 @@ namespace dsn { namespace tools {
                 }
 
                 message_ex* recv_msg = virtual_send_message(msg);
+                if (recv_msg == nullptr)
+                {
+                    continue;
+                }
 
                 {
                     node_scoper ns(rnet->node());
@@ -145,6 +153,10 @@ namespace dsn { namespace tools {
         for (auto& msg : _sending_msgs)
         {
             message_ex* recv_msg = virtual_send_message(msg);
+            if (recv_msg == nullptr)
+            {
+                continue;
+            }
 
             {
                 node_scoper ns(_client->net().node());


### PR DESCRIPTION
## Summary

A robustness pass over rDSN's core driven by **libfiu** fault injection (low-probability `malloc`/I/O faults) and by **ASan + UBSan** builds. The changes fall into four areas: configuration-loader hardening, allocation-fault tolerance at startup/teardown, elimination of misaligned-access undefined behavior, and a small logging-facade cleanup. No wire-format or happy-path behavior changes.

## Motivation

Under injected allocation and I/O faults, several code paths turned already-tolerated soft failures into hard aborts, hangs, or silent data loss. Separately, UBSan flagged hundreds of misaligned-access errors that are benign on x86 but are real hazards on stricter ISAs (arm64 — Apple Silicon, Linux arm64). This PR makes the affected paths fail fast and cleanly, and makes the memory accesses well-defined on all platforms.

## Changes

### 1. Configuration loader robustness
- **Circular `@include` stack-overflow crash** — a cyclic or self-referential `@include` chain recursed until the thread stack was exhausted, crashing with SIGSEGV instead of reporting a config error. Now tracks the active include ancestry in a translation-unit-local `thread_local` set (RAII per-frame guard, canonical `realpath` keys) and rejects cycles with a clear error. Diamond/deep non-cyclic includes still load. Adds gtest coverage including an 8-thread concurrency test.
- **Config mutex lock leak → self-deadlock** — `get_string_value_internal`/`dump`/`set` guarded allocating critical sections with raw `lock()`/`unlock()`. A `std::bad_alloc` during the section unwound past `unlock()`, leaving the non-recursive mutex permanently locked and hanging the node on the next config access. Replaced with RAII `std::lock_guard`. Reproduced and confirmed fixed with libfiu malloc injection.

### 2. Allocation-fault tolerance
- **Startup / `mutation_log` teardown under allocation faults** — `task_spec::init()` aborted via `dassert` when a task code was left partially registered by an earlier gracefully-handled allocation failure; now logs and returns `false` (matching the function's existing failure idiom) so startup fails fast with a diagnostic. Also advances the submodule to the `mutation_log` destructor fix (eliminates a "pure virtual method called" abort on destroy-while-open).

### 3. Alignment / UBSan undefined behavior
- **`dsn::optional<T>` misaligned storage** — storage was `char[sizeof(T)]` (align 1); placement-new of an over-aligned `T` (e.g. `std::function` callbacks in `task_helper`) was misaligned-access UB. Added `alignas(T)`. Cleared the dominant UBSan cluster (231 → 84 errors).
- **Transient memory alignment** — `tls_trans_mem_next` now rounds every hand-out up to `alignof(std::max_align_t)`, so structures overlaid on bump-allocated memory (send-path `message_header`, `shared_ptr` bookkeeping) are aligned. Wire format unchanged (`sizeof(message_header)` is a multiple of 16; padding never transmitted).
- **Misaligned `message_header` reads on the RPC receive path** — the received header pointed at an arbitrary offset in the zero-copy socket buffer, making every `header->*` read misaligned UB (62 UBSan errors across 7 files, a real arm64 hazard). The header now gets its own `max_align_t`-aligned copy while the body stays zero-copy; the parser reads into a naturally-aligned stack copy first. Combined with the transient-memory fix, the receive-path cluster goes 62 → 0.

### 4. Logging facade cleanup
- **Drop the pluggable `logging_sink`** — the utility-layer facade forwarded through a sink that `dsn.core` installed. Since the utility layer sits below `dsn.core` and there's no realistic use for swapping the sink, the indirection is removed: `dutil_*` → `logf` → stderr directly. `logf` is no longer exported (removes `DSN_API`), which also resolves the Windows **C4273** inconsistent-dll-linkage warnings; `logv` becomes file-static.

### Submodule (`rDSN.dist.service`)
Pointer advanced to merged `master` (PR #34), which carries the `mutation_log` destructor drain fix, the **WAL-replay durability fix** (no longer discards a committed WAL segment on a *transient* read error — previously silent data loss), and the Windows LNK1104 build fix.

## Platform impact

The alignment fixes are correctness fixes for strict-alignment architectures (**arm64 / Apple Silicon, Linux arm64**), where the flagged misaligned accesses can fault or be silently fixed up at a performance cost; on x86 they were benign but still UB.

## Files changed

| Area | Files |
|------|-------|
| Configuration | `src/dev/utility/configuration.cpp`, `src/core/src/configuration.test.cpp`, `src/core/src/test/config-include-*.ini` (9) |
| Startup hardening | `src/core/src/task_spec.cpp` |
| Alignment / UBSan | `include/dsn/cpp/optional.h`, `src/core/src/transient_memory.cpp`, `src/core/src/transient_memory.test.cpp`, `include/dsn/tool-api/rpc_message.h`, `src/core/src/rpc_message.cpp`, `src/plugins/tools.common/dsn_message_parser.cpp`, `src/plugins/tools.emulator/network.sim.cpp` |
| Logging | `include/dsn/utility/logging.h`, `src/dev/utility/logging.cpp`, `src/core/src/logging.cpp` |
| Submodule | `src/plugins_ext/rDSN.dist.service` |