### PR TITLE
Harden runtime concurrency, command handling, and performance counters

### DIFF
--- a/include/dsn/tool-api/task.h
+++ b/include/dsn/tool-api/task.h
@@ -183,7 +183,7 @@ private:
     std::atomic<void*>     _wait_event;
     int                    _hash;
     int                    _delay_milliseconds;
-    bool                   _wait_for_cancel;
+    std::atomic<bool>      _wait_for_cancel;
     task_spec              *_spec;
     service_node           *_node;
     trackable_task         _context_tracker; // when tracker is gone, the task is cancelled automatically

--- a/include/dsn/tool_api.h
+++ b/include/dsn/tool_api.h
@@ -71,6 +71,8 @@
 
 namespace dsn { namespace tools {
 
+class service_control_completion;
+
 /*!
 @addtogroup tool-api-providers
 @{  
@@ -132,6 +134,9 @@ public:
     DSN_API virtual void stop_all_apps(bool cleanup);
     
     DSN_API static const service_spec& get_service_spec();
+
+private:
+    std::vector<std::shared_ptr<service_control_completion>> _app_start_completions;
 };
 
 namespace internal_use_only
@@ -190,4 +195,3 @@ template <typename T> bool register_message_header_parser(network_header_format 
 }
 
 }} // end namespace dsn::tools
-

--- a/src/core/src/aio.perf.test.cpp
+++ b/src/core/src/aio.perf.test.cpp
@@ -96,14 +96,14 @@ void aio_testcase(uint64_t block_size, size_t concurrency, bool is_write, bool s
     
     std::atomic<uint64_t> io_count(0);
     std::atomic<uint64_t> cb_flying_count(0);
-    volatile bool exit = false;
+    std::atomic<bool> exit(false);
     std::function<void(int)> cb;
     std::vector<uint64_t> offsets;
     offsets.resize(concurrency);
     
     cb = [&](int index)
     {
-        if (!exit)
+        if (!exit.load(std::memory_order_relaxed))
         {
             auto ioc = io_count++;
             uint64_t offset;
@@ -165,7 +165,7 @@ void aio_testcase(uint64_t block_size, size_t concurrency, bool is_write, bool s
         << std::endl;
 
     // safe exit
-    exit = true;
+    exit.store(true, std::memory_order_relaxed);
 
     while (cb_flying_count.load() > 0)
     {

--- a/src/core/src/aio.test.cpp
+++ b/src/core/src/aio.test.cpp
@@ -216,11 +216,11 @@ TEST(core, operation_failed)
     auto fp = dsn_file_open(tmp_file.c_str(), O_WRONLY, 0600);
     EXPECT_TRUE(fp == nullptr);
 
-    ::dsn::error_code* err = new ::dsn::error_code;
-    size_t* count = new size_t;
-    auto io_callback = [err, count](::dsn::error_code e, size_t n) {
-        *err = e;
-        *count = n;
+    ::dsn::error_code err;
+    size_t count = 0;
+    auto io_callback = [&err, &count](::dsn::error_code e, size_t n) {
+        err = e;
+        count = n;
     };
 
     fp = dsn_file_open(tmp_file.c_str(), O_WRONLY|O_CREAT|O_BINARY, 0666);
@@ -229,26 +229,26 @@ TEST(core, operation_failed)
     const char* str = "hello file";
     auto t = ::dsn::file::write(fp, str, strlen(str), 0, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
-    EXPECT_TRUE(*err == ERR_OK && *count==strlen(str));
+    EXPECT_TRUE(err == ERR_OK && count==strlen(str));
 
     t = ::dsn::file::read(fp, buffer, 512, 0, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
-    EXPECT_TRUE(*err == ERR_FILE_OPERATION_FAILED);
+    EXPECT_TRUE(err == ERR_FILE_OPERATION_FAILED);
 
     auto fp2 = dsn_file_open(tmp_file.c_str(), O_RDONLY|O_BINARY, 0);
     EXPECT_TRUE(fp2 != nullptr);
 
     t = ::dsn::file::read(fp2, buffer, 512, 0, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
-    EXPECT_TRUE(*err == ERR_OK && *count==strlen(str));
+    EXPECT_TRUE(err == ERR_OK && count==strlen(str));
 
     t = ::dsn::file::read(fp2, buffer, 5, 0, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
-    EXPECT_TRUE(*err == ERR_OK && *count==5);
+    EXPECT_TRUE(err == ERR_OK && count==5);
 
     t = ::dsn::file::read(fp2, buffer, 512, 100, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
-    ddebug("error code: %s", err->to_string());
+    ddebug("error code: %s", err.to_string());
     dsn_file_close(fp);
     dsn_file_close(fp2);
 

--- a/src/core/src/command_manager.cpp
+++ b/src/core/src/command_manager.cpp
@@ -34,6 +34,7 @@
  */
 
 # include "command_manager.h"
+# include <algorithm>
 # include <climits>
 # include <cstdlib>
 # include <iostream>
@@ -42,6 +43,7 @@
 # include <cstring>
 # include <chrono>
 # include <exception>
+# include <stdexcept>
 # include <dsn/cpp/utils.h>
 # include <dsn/cpp/rpc_stream.h>
 # include "service_engine.h"
@@ -122,9 +124,35 @@ DSN_API dsn_handle_t dsn_cli_register(
             {
                 c_args.push_back(s.c_str());
             }
-            dsn_cli_reply reply;
+            dsn_cli_reply reply{};
             cmd_handler(context, (int)c_args.size(), c_args.empty() ? nullptr : (const char**)&c_args[0], &reply);
-            auto cpp_output = dsn::safe_string(reply.message, reply.message + reply.size);
+
+            dsn::safe_string cpp_output;
+            try
+            {
+                if (reply.message == nullptr && reply.size != 0)
+                {
+                    throw std::invalid_argument(
+                        "cli command handler returned a null message with a non-zero size");
+                }
+
+                if (reply.size >
+                    static_cast<uint64_t>((std::numeric_limits<size_t>::max)()))
+                {
+                    throw std::length_error("cli command handler returned an oversized message");
+                }
+
+                if (reply.size != 0)
+                {
+                    cpp_output.assign(reply.message, static_cast<size_t>(reply.size));
+                }
+            }
+            catch (...)
+            {
+                output_freer(reply);
+                throw;
+            }
+
             output_freer(reply);
             return cpp_output;
         }
@@ -266,53 +294,118 @@ namespace dsn {
 
     dsn_handle_t command_manager::register_command(const safe_vector<const char*>& commands, const char* help_one_line, const char* help_long, command_handler handler)
     {
-        utils::auto_write_lock l(_lock);
-
-        for (auto cmd : commands)
+        std::shared_ptr<command> c;
+        try
         {
-            if (cmd != nullptr)
+            c = std::make_shared<command>();
+            c->address.set_invalid();
+            c->commands.reserve(commands.size());
+            for (const char* cmd : commands)
             {
-                auto it = _handlers.find(cmd);
-                dassert(it == _handlers.end(), "command '%s' already regisered", cmd);
+                if (cmd == nullptr || cmd[0] == '\0')
+                {
+                    derror("cannot register a null or empty command");
+                    return nullptr;
+                }
+                c->commands.emplace_back(cmd);
+            }
+            c->help_long = help_long;
+            c->help_short = help_one_line;
+            c->handler = std::move(handler);
+        }
+        catch (const std::exception& ex)
+        {
+            derror("failed to allocate command registration: %s", ex.what());
+            return nullptr;
+        }
+        catch (...)
+        {
+            derror("failed to allocate command registration");
+            return nullptr;
+        }
+
+        utils::auto_write_lock l(_lock);
+        for (const auto& cmd : c->commands)
+        {
+            auto it = _handlers.find(cmd);
+            if (it != _handlers.end())
+            {
+                derror("command '%s' is already registered", cmd.c_str());
+                return nullptr;
             }
         }
 
-        command* c = new command;
-        c->address.set_invalid();
-        c->commands = commands;
-        c->help_long = help_long;
-        c->help_short = help_one_line;
-        c->handler = handler;
-        _commands.push_back(c);
-        
-        for (auto cmd : commands)
+        auto rollback = [&]()
         {
-            if (cmd != nullptr)
-            {
-                _handlers[cmd] = c;
-            }
-        }
-        return c;
-    }
-    
-    void command_manager::deregister_command(dsn_handle_t handle)
-    {
-        auto c = reinterpret_cast<command*>(handle);
-        dassert(c != nullptr, "cannot deregister a null handle");
-        utils::auto_write_lock l(_lock);
-        for (auto cmd : c->commands)
-        {
-            if (cmd != nullptr)
+            for (const auto& cmd : c->commands)
             {
                 auto it = _handlers.find(cmd);
-                if (it != _handlers.end())
+                if (it != _handlers.end() && it->second == c)
                 {
                     _handlers.erase(it);
                 }
             }
-        }
-        delete c;
 
+            auto command_it = std::find(_commands.begin(), _commands.end(), c);
+            if (command_it != _commands.end())
+            {
+                _commands.erase(command_it);
+            }
+        };
+
+        try
+        {
+            _commands.push_back(c);
+            for (const auto& cmd : c->commands)
+            {
+                if (!_handlers.emplace(cmd, c).second)
+                {
+                    rollback();
+                    derror("command '%s' is already registered", cmd.c_str());
+                    return nullptr;
+                }
+            }
+        }
+        catch (const std::exception& ex)
+        {
+            rollback();
+            derror("failed to publish command registration: %s", ex.what());
+            return nullptr;
+        }
+        catch (...)
+        {
+            rollback();
+            derror("failed to publish command registration");
+            return nullptr;
+        }
+
+        return c.get();
+    }
+    
+    void command_manager::deregister_command(dsn_handle_t handle)
+    {
+        utils::auto_write_lock l(_lock);
+        auto command_it = std::find_if(
+            _commands.begin(),
+            _commands.end(),
+            [handle](const std::shared_ptr<command>& c) { return c.get() == handle; });
+        if (command_it == _commands.end())
+        {
+            derror("cannot deregister an unknown command handle");
+            return;
+        }
+
+        auto c = *command_it;
+        for (const auto& cmd : c->commands)
+        {
+            auto it = _handlers.find(cmd);
+            if (it != _handlers.end() && it->second == c)
+            {
+                _handlers.erase(it);
+            }
+        }
+
+        _commands.erase(command_it);
     }
 
     bool command_manager::run_command(const safe_string& cmdline, /*out*/ safe_string& output)
@@ -348,12 +441,16 @@ namespace dsn {
 
     bool command_manager::run_command(const safe_string& cmd, const safe_vector<safe_string>& args, /*out*/ safe_string& output)
     {
-        command* h = nullptr;
+        std::shared_ptr<command> h;
+        dsn::rpc_address address;
         {
             utils::auto_read_lock l(_lock);
             auto it = _handlers.find(cmd);
             if (it != _handlers.end())
+            {
                 h = it->second;
+                address = h->address;
+            }
         }
 
         if (h == nullptr)
@@ -363,7 +460,8 @@ namespace dsn {
         }
         else
         {
-            if (h->address.is_invalid() || h->address == dsn::task::get_current_rpc()->primary_address())
+            if (address.is_invalid() ||
+                address == dsn::task::get_current_rpc()->primary_address())
             {
                 // Command handlers run here with fully caller-controlled args. Via the remote CLI
                 // (RPC_CLI_CLI_CALL, unauthenticated and enabled by default because [core] cli_remote
@@ -397,8 +495,6 @@ namespace dsn {
             }
             else
             {
-                ::dsn::rpc_read_stream response;
-                
                 dsn_message_t msg = dsn_msg_create_request(RPC_CLI_CLI_CALL);
                 ::dsn::command rcmd;
                 rcmd.cmd = cmd.c_str();
@@ -408,13 +504,30 @@ namespace dsn {
                 }
 
                 ::dsn::marshall(msg, rcmd);
-                auto resp = dsn_rpc_call_wait(h->address.c_addr(), msg);
+                auto resp = dsn_rpc_call_wait(address.c_addr(), msg);
                 if (resp != nullptr)
                 {
-                    std::string o2 = output.c_str();
+                    ::dsn::safe_handle<dsn_msg_release_ref> response_guard(resp, true);
+                    std::string o2;
                     if (::dsn::try_unmarshall(resp, o2) != ERR_OK)
                     {
                         dwarn("cli run for %s failed: invalid response", cmd.c_str());
+                        return false;
+                    }
+                    try
+                    {
+                        output.assign(o2.data(), o2.size());
+                    }
+                    catch (const std::exception& ex)
+                    {
+                        derror("cli run for %s failed to copy the response: %s",
+                               cmd.c_str(),
+                               ex.what());
+                        return false;
+                    }
+                    catch (...)
+                    {
+                        derror("cli run for %s failed to copy the response", cmd.c_str());
                         return false;
                     }
                     return true;
@@ -454,7 +567,7 @@ namespace dsn {
 
     void command_manager::start_local_cli()
     {
-        new std::thread(std::bind(&command_manager::run_console, this));
+        std::thread(std::bind(&command_manager::run_console, this)).detach();
     }
 
     void remote_cli_handler(dsn_message_t req, void*)
@@ -507,7 +620,18 @@ namespace dsn {
 
     void command_manager::set_cli_target_address(dsn_handle_t handle, dsn::rpc_address address)
     {
-        reinterpret_cast<command*>(handle)->address = address;
+        utils::auto_write_lock l(_lock);
+        auto command_it = std::find_if(
+            _commands.begin(),
+            _commands.end(),
+            [handle](const std::shared_ptr<command>& c) { return c.get() == handle; });
+        if (command_it == _commands.end())
+        {
+            derror("cannot set target address for an unknown command handle");
+            return;
+        }
+
+        (*command_it)->address = address;
     }
 
     command_manager::command_manager()

--- a/src/core/src/command_manager.h
+++ b/src/core/src/command_manager.h
@@ -40,6 +40,7 @@
 # include <dsn/utility/singleton.h>
 # include <dsn/tool-api/rpc_message.h>
 # include <map>
+# include <memory>
 
 namespace dsn {
 
@@ -64,15 +65,15 @@ namespace dsn {
         struct command
         {
             dsn::rpc_address address;
-            safe_vector<const char*> commands;
+            safe_vector<safe_string> commands;
             std::string     help_short;
             std::string     help_long;
             command_handler handler;
         };
 
         ::dsn::utils::rw_lock_nr        _lock;
-        std::map<safe_string, command*> _handlers;
-        std::vector<command*>           _commands;
+        std::map<safe_string, std::shared_ptr<command>> _handlers;
+        std::vector<std::shared_ptr<command>>           _commands;
     };
 
 }

--- a/src/core/src/main.cpp
+++ b/src/core/src/main.cpp
@@ -62,6 +62,7 @@
 # include <fstream>
 # include <cstring>
 # include <chrono>
+# include <atomic>
 
 # if defined(_WIN32)
 # include <tlhelp32.h>
@@ -82,7 +83,7 @@
 static struct _all_info_
 {
     unsigned int                                              magic;
-    bool                                                      engine_ready;
+    std::atomic<bool>                                         engine_ready{false};
     bool                                                      config_completed;
     ::dsn::tools::tool_app                                    *tool;
     ::dsn::configuration_ptr                                  config;
@@ -95,7 +96,7 @@ static struct _all_info_
     }
 
     bool is_engine_ready() const {
-        return magic == 0xdeadbeef && engine_ready;
+        return magic == 0xdeadbeef && engine_ready.load(std::memory_order_acquire);
     }
 
 } dsn_all;
@@ -463,7 +464,7 @@ bool run(
 
     ::dsn::task::set_tls_dsn_context(nullptr, nullptr, nullptr);
 
-    dsn_all.engine_ready = false;
+    dsn_all.engine_ready.store(false, std::memory_order_relaxed);
     dsn_all.config_completed = false;
     dsn_all.tool = nullptr;
     dsn_all.engine = &::dsn::service_engine::instance();
@@ -613,7 +614,7 @@ bool run(
     // init runtime
     ::dsn::service_engine::fast_instance().init_after_toollets();
 
-    dsn_all.engine_ready = true;
+    dsn_all.engine_ready.store(true, std::memory_order_release);
 
     // split app_name and app_index
     std::list<std::string> applistkvs;

--- a/src/core/src/rpc.perf.test.cpp
+++ b/src/core/src/rpc.perf.test.cpp
@@ -41,7 +41,7 @@ void rpc_testcase(uint64_t block_size, size_t concurrency)
 {
     std::atomic<uint64_t> io_count(0);
     std::atomic<uint64_t> cb_flying_count(0);
-    volatile bool exit = false;
+    std::atomic<bool> exit(false);
     std::function<void(int)> cb;    
     std::string req;
     req.resize(block_size, 'x');
@@ -58,7 +58,7 @@ void rpc_testcase(uint64_t block_size, size_t concurrency)
 
     cb = [&](int index)
     {
-        if (!exit)
+        if (!exit.load(std::memory_order_relaxed))
         {
             io_count++;            
             cb_flying_count++;
@@ -100,7 +100,7 @@ void rpc_testcase(uint64_t block_size, size_t concurrency)
         << std::endl;
 
     // safe exit
-    exit = true;
+    exit.store(true, std::memory_order_relaxed);
 
     while (cb_flying_count.load() > 0)
     {
@@ -120,12 +120,12 @@ void lpc_testcase(size_t concurrency)
 {
     std::atomic<uint64_t> io_count(0);
     std::atomic<uint64_t> cb_flying_count(0);
-    volatile bool exit = false;
+    std::atomic<bool> exit(false);
     std::function<void(int)> cb;
 
     cb = [&](int index)
     {
-        if (!exit)
+        if (!exit.load(std::memory_order_relaxed))
         {
             io_count++;
             cb_flying_count++;
@@ -161,7 +161,7 @@ void lpc_testcase(size_t concurrency)
         << std::endl;
 
     // safe exit
-    exit = true;
+    exit.store(true, std::memory_order_relaxed);
 
     while (cb_flying_count.load() > 0)
     {

--- a/src/core/src/task.cpp
+++ b/src/core/src/task.cpp
@@ -142,14 +142,13 @@ __thread uint16_t tls_dsn_lower32_task_id_mask = 0;
 }
 
 task::task(dsn_task_code_t code, void* context, dsn_task_cancelled_handler_t on_cancel, int hash, service_node* node)
-    : _state(TASK_STATE_READY), _wait_event(nullptr)
+    : _state(TASK_STATE_READY), _wait_event(nullptr), _wait_for_cancel(false)
 {
     _spec = task_spec::get(code);
     _context = context;
     _on_cancel = on_cancel;
     _hash = hash;
     _delay_milliseconds = 0;
-    _wait_for_cancel = false;
     _is_null = false;
     next = nullptr;
     
@@ -188,7 +187,9 @@ task::~task()
 bool task::set_retry(bool enqueue_immediately /*= true*/)
 {
     task_state RUNNING_STATE = TASK_STATE_RUNNING;
-    if (_state.compare_exchange_strong(RUNNING_STATE, TASK_STATE_READY, std::memory_order_relaxed))
+    if (_state.compare_exchange_strong(RUNNING_STATE,
+                                       TASK_STATE_READY,
+                                       std::memory_order_seq_cst))
     {
         _error = enqueue_immediately ? ERR_OK : ERR_IO_PENDING;
         return true;
@@ -219,7 +220,10 @@ void task::exec_internal()
         }
         else
         {
-            if (!_wait_for_cancel)
+            // This load and set_retry()'s state transition form one side of the
+            // handshake with cancel(true): cancellation must either win the
+            // state transition or be observed here before the task is retried.
+            if (!_wait_for_cancel.load(std::memory_order_seq_cst))
             {
                 // for retried tasks such as timer or rpc_response_task
                 notify_if_necessary = false;
@@ -343,20 +347,30 @@ bool task::cancel(bool wait_until_finished, /*out*/ bool* finished /*= nullptr*/
     task *current_tsk = get_current_task();
     bool finish = false;
     bool succ = false;
+
+    if (wait_until_finished)
+    {
+        _wait_for_cancel.store(true, std::memory_order_seq_cst);
+    }
     
     if (current_tsk == this)
     {
-        // make sure timers are cancelled
-        _wait_for_cancel = true;
+        // A recurring timer cancels itself with cancel(false). Publish the
+        // intent so exec_internal() suppresses the retry after this callback.
+        _wait_for_cancel.store(true, std::memory_order_seq_cst);
 
         if (finished)
+        {
             *finished = false;
+        }
 
         return false;
     }
     
     task_state old_state = READY_STATE;
-    if (_state.compare_exchange_strong(old_state, TASK_STATE_CANCELLED, std::memory_order_relaxed))
+    if (_state.compare_exchange_strong(old_state,
+                                       TASK_STATE_CANCELLED,
+                                       std::memory_order_seq_cst))
     {
         succ = true;
         finish = true;
@@ -375,7 +389,6 @@ bool task::cancel(bool wait_until_finished, /*out*/ bool* finished /*= nullptr*/
         }
         else if (wait_until_finished)
         {
-            _wait_for_cancel = true;
             bool r  = wait(TIME_MS_MAX, true);
             dassert(r, "wait failed, it is only possible when task runs for more than 0x0fffffff ms");
 

--- a/src/core/src/tool_api.cpp
+++ b/src/core/src/tool_api.cpp
@@ -38,16 +38,53 @@
 # include <dsn/utility/singleton_store.h>
 # include "service_engine.h"
 # include "message_parser_manager.h"
+# include <condition_variable>
+# include <memory>
+# include <mutex>
+# include <vector>
 
 namespace dsn { 
 
     DEFINE_TASK_CODE(LPC_CONTROL_SERVICE_APP, TASK_PRIORITY_HIGH, THREAD_POOL_DEFAULT)
 
+    namespace tools {
+
+    class service_control_completion
+    {
+    public:
+        void signal()
+        {
+            {
+                std::lock_guard<std::mutex> guard(_lock);
+                _finished = true;
+            }
+            _cv.notify_one();
+        }
+
+        void wait()
+        {
+            std::unique_lock<std::mutex> guard(_lock);
+            _cv.wait(guard, [this] { return _finished; });
+        }
+
+    private:
+        std::mutex _lock;
+        std::condition_variable _cv;
+        bool _finished = false;
+    };
+
     class service_control_task : public task
     {
     public:
-        service_control_task(service_node* node, bool start, bool cleanup = false)
-            : task(LPC_CONTROL_SERVICE_APP, nullptr, nullptr, 0, node), _node(node), _start(start), _cleanup(cleanup)
+        service_control_task(service_node* node,
+                             bool start,
+                             const std::shared_ptr<service_control_completion>& completion,
+                             bool cleanup = false)
+            : task(LPC_CONTROL_SERVICE_APP, nullptr, nullptr, 0, node),
+              _node(node),
+              _start(start),
+              _cleanup(cleanup),
+              _completion(completion)
         {
         }
 
@@ -78,16 +115,17 @@ namespace dsn {
             {
                 sp.role->layer1.destroy(_node->get_app_context_ptr(), _cleanup);
             }
+
+            _completion->signal();
         }
 
     private:
         service_node* _node;
         bool          _start; // false for stop
         bool          _cleanup; // for stop
+        std::shared_ptr<service_control_completion> _completion;
     };
 
-
-    namespace tools {
 
         tool_base::tool_base(const char* name)
         {
@@ -107,9 +145,12 @@ namespace dsn {
         void tool_app::start_all_apps()
         {
             auto apps = service_engine::fast_instance().get_all_nodes();
+            _app_start_completions.reserve(apps.size());
             for (auto& kv : apps)
             {
-                task* t = new service_control_task(kv.second, true);
+                auto completion = std::make_shared<service_control_completion>();
+                _app_start_completions.push_back(completion);
+                task* t = new service_control_task(kv.second, true, completion);
                 t->set_delay(1000 * kv.second->spec().delay_seconds);
                 t->enqueue();
             }
@@ -118,11 +159,26 @@ namespace dsn {
 
         void tool_app::stop_all_apps(bool cleanup)
         {
+            for (const auto& completion : _app_start_completions)
+            {
+                completion->wait();
+            }
+            _app_start_completions.clear();
+
             auto apps = service_engine::fast_instance().get_all_nodes();
+            std::vector<std::shared_ptr<service_control_completion>> completions;
+            completions.reserve(apps.size());
             for (auto& kv : apps)
             {
-                task* t = new service_control_task(kv.second, false, cleanup);
+                auto completion = std::make_shared<service_control_completion>();
+                completions.push_back(completion);
+                task* t = new service_control_task(kv.second, false, completion, cleanup);
                 t->enqueue();
+            }
+
+            for (const auto& completion : completions)
+            {
+                completion->wait();
             }
         }
 

--- a/src/plugins/tools.common/simple_perf_counter.cpp
+++ b/src/plugins/tools.common/simple_perf_counter.cpp
@@ -49,6 +49,7 @@
 # include <functional>
 # include <utility>
 # include <atomic>
+# include <mutex>
 
 namespace dsn {
     namespace tools {
@@ -80,9 +81,17 @@ namespace dsn {
         {
         public:
             perf_counter_rate(const char* app, const char *section, const char *name, dsn_perf_counter_type_t type, const char *dsptr)
-                : perf_counter(app, section, name, type, dsptr), _val(0)
+                : perf_counter(app, section, name, type, dsptr),
+                  _val(0),
+                  _rate(0),
+                  _last_time(0),
+                  _clock_initialized(false)
             {
-                qts = 0;
+                if (::dsn::tools::is_engine_ready())
+                {
+                    _last_time = dsn_now_ns();
+                    _clock_initialized = true;
+                }
             }
             ~perf_counter_rate(void) {}
 
@@ -92,23 +101,37 @@ namespace dsn {
             virtual void   set(uint64_t val) override { dassert(false, "invalid execution flow"); }
             virtual double get_value() override
             {
+                std::lock_guard<std::mutex> guard(_sample_lock);
                 uint64_t now = dsn_now_ns();
-                uint64_t interval = now - qts;
-                if (interval == 0)
+                if (!_clock_initialized)
                 {
-                    return 0.0;
+                    _last_time = now;
+                    _clock_initialized = true;
+                    _val.exchange(0, std::memory_order_relaxed);
+                    return _rate;
                 }
-                double val = static_cast<double>(_val.load(std::memory_order_relaxed));
-                qts = now;
-                _val = 0;
-                return val / interval * 1000 * 1000 * 1000;
+
+                if (now <= _last_time)
+                {
+                    return _rate;
+                }
+
+                uint64_t interval = now - _last_time;
+                double val =
+                    static_cast<double>(_val.exchange(0, std::memory_order_relaxed));
+                _last_time = now;
+                _rate = val / interval * 1000 * 1000 * 1000;
+                return _rate;
             }
             virtual uint64_t get_integer_value() override { return (uint64_t)get_value(); }
             virtual double get_percentile(dsn_perf_counter_percentile_type_t type) override { dassert(false, "invalid execution flow"); return 0.0; }
 
         private:
             std::atomic<uint64_t> _val;
-            std::atomic<uint64_t> qts;
+            double _rate;
+            uint64_t _last_time;
+            bool _clock_initialized;
+            std::mutex _sample_lock;
         };
 
         // -----------   NUMBER_PERCENTILE perf counter ---------------------------------
@@ -135,13 +158,14 @@ namespace dsn {
                     _counter_computation_interval_seconds = 1;
                 }
 
+                memset(_samples, 0, sizeof(_samples));
+                memset(_results, 0, sizeof(_results));
+
                 _timer.reset(new boost::asio::deadline_timer(shared_io_service::instance().ios));
                 _timer->expires_from_now(boost::posix_time::seconds(rand() % _counter_computation_interval_seconds + 1));
 
                 this->add_ref();
                 _timer->async_wait(std::bind(&perf_counter_number_percentile::on_timer, this, _timer, std::placeholders::_1));
-
-                memset(_samples, 0, sizeof(_samples));
             }
             
             ~perf_counter_number_percentile(void) 
@@ -153,6 +177,7 @@ namespace dsn {
             virtual void   add(uint64_t val) override { dassert(false, "invalid execution flow"); }
             virtual void   set(uint64_t val) override
             {
+                std::lock_guard<std::mutex> guard(_samples_lock);
                 auto idx = _tail.fetch_add(1, std::memory_order_relaxed);
                 _samples[idx % MAX_QUEUE_LENGTH] = val;
             }
@@ -162,43 +187,60 @@ namespace dsn {
 
             virtual double get_percentile(dsn_perf_counter_percentile_type_t type) override
             {
-                if (_tail == 0)
-                    return -1.0;
                 if ((type < 0) || (type >= COUNTER_PERCENTILE_COUNT))
                 {
                     dassert(false, "send a wrong counter percentile type");
                     return -1;
                 }
+
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                if (_tail.load(std::memory_order_relaxed) == 0)
+                    return -1.0;
                 return (double)_results[type];
             }
 
             virtual int get_latest_samples(int required_sample_count, /*out*/ samples_t& samples) const override
-            { 
+            {
                 dassert(required_sample_count <= MAX_QUEUE_LENGTH, "");
 
-                int count = _tail.load();
-                int return_count = count >= required_sample_count ? required_sample_count : count;
-
                 samples.clear();
-                int end_index = (count + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH;
-                int start_index = (end_index + MAX_QUEUE_LENGTH - return_count) % MAX_QUEUE_LENGTH;
+                if (required_sample_count <= 0)
+                {
+                    return 0;
+                }
 
-                if (end_index >= start_index)
+                static thread_local uint64_t snapshot[MAX_QUEUE_LENGTH];
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                uint64_t count = _tail.load(std::memory_order_relaxed);
+                int return_count =
+                    count >= static_cast<uint64_t>(required_sample_count)
+                        ? required_sample_count
+                        : static_cast<int>(count);
+
+                if (return_count <= 0)
                 {
-                    samples.push_back(std::make_pair((uint64_t*)_samples + start_index, return_count));
+                    return 0;
                 }
-                else
+
+                int end_index =
+                    static_cast<int>((count + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH);
+                int start_index =
+                    (end_index + MAX_QUEUE_LENGTH - return_count + 1) % MAX_QUEUE_LENGTH;
+                for (int i = 0; i < return_count; ++i)
                 {
-                    samples.push_back(std::make_pair((uint64_t*)_samples + start_index, MAX_QUEUE_LENGTH - start_index));
-                    samples.push_back(std::make_pair((uint64_t*)_samples, return_count - (MAX_QUEUE_LENGTH - start_index)));
+                    snapshot[i] = _samples[(start_index + i) % MAX_QUEUE_LENGTH];
                 }
+                samples.push_back(std::make_pair(snapshot, return_count));
 
                 return return_count;
             }
 
             virtual uint64_t get_latest_sample() const override
             {
-                int idx = (_tail + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH;
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                int idx = static_cast<int>(
+                    (_tail.load(std::memory_order_relaxed) + MAX_QUEUE_LENGTH - 1) %
+                    MAX_QUEUE_LENGTH);
                 return _samples[idx];
             }
 
@@ -209,6 +251,7 @@ namespace dsn {
                 uint64_t tmp[MAX_QUEUE_LENGTH];
                 uint64_t mid_tmp[MAX_QUEUE_LENGTH];
                 int      calc_queue[MAX_QUEUE_LENGTH][4];
+                uint64_t results[COUNTER_PERCENTILE_COUNT];
             };
 
         private:
@@ -257,7 +300,7 @@ namespace dsn {
                 {
                     for (i = qleft; i <= qright; i++)
                     if (ctx->ask[i] == 1)
-                        _results[i] = ctx->tmp[left];
+                        ctx->results[i] = ctx->tmp[left];
                     else
                         dassert(false, "select percentail wrong!!!");
                     return;
@@ -294,12 +337,18 @@ namespace dsn {
 
             void   calc(std::shared_ptr<compute_context>& ctx)
             {
-                if (_tail == 0)
-                    return;
+                int tmp_num;
+                {
+                    std::lock_guard<std::mutex> guard(_samples_lock);
+                    uint64_t count = _tail.load(std::memory_order_relaxed);
+                    if (count == 0)
+                        return;
 
-                int tmp_num = _tail > MAX_QUEUE_LENGTH ? MAX_QUEUE_LENGTH : _tail.load();
-                for (int i = 0; i < tmp_num; i++)
-                    ctx->tmp[i] = _samples[i];
+                    tmp_num = count > MAX_QUEUE_LENGTH ? MAX_QUEUE_LENGTH
+                                                       : static_cast<int>(count);
+                    for (int i = 0; i < tmp_num; i++)
+                        ctx->tmp[i] = _samples[i];
+                }
 
                 ctx->ask[COUNTER_PERCENTILE_50] = (int)(tmp_num * 0.5) + 1;
                 ctx->ask[COUNTER_PERCENTILE_90] = (int)(tmp_num * 0.90) + 1;
@@ -315,7 +364,9 @@ namespace dsn {
                 for (l = 1; l <= r; l++)
                     select(ctx, ctx->calc_queue[l][_LEFT], ctx->calc_queue[l][_RIGHT], ctx->calc_queue[l][_QLEFT], ctx->calc_queue[l][_QRIGHT], r);
 
-                return;
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                for (int i = 0; i < COUNTER_PERCENTILE_COUNT; ++i)
+                    _results[i] = ctx->results[i];
             }
 
             void on_timer(std::shared_ptr<boost::asio::deadline_timer> timer, const boost::system::error_code& ec)
@@ -348,10 +399,11 @@ namespace dsn {
             }
 
             std::shared_ptr<boost::asio::deadline_timer> _timer;
-            std::atomic<int> _tail;
+            std::atomic<uint64_t> _tail;
             uint64_t _samples[MAX_QUEUE_LENGTH];
             uint64_t _results[COUNTER_PERCENTILE_COUNT];
             int      _counter_computation_interval_seconds;
+            mutable std::mutex _samples_lock;
         };
 
         // ---------------------- perf counter dispatcher ---------------------

--- a/src/plugins/tools.common/simple_perf_counter_v2_atomic.cpp
+++ b/src/plugins/tools.common/simple_perf_counter_v2_atomic.cpp
@@ -45,6 +45,7 @@
 # include <functional>
 # include <utility>
 # include <atomic>
+# include <mutex>
 
 namespace dsn {
     namespace tools {
@@ -87,7 +88,7 @@ namespace dsn {
             virtual void   set(uint64_t val) override
             {
                 uint64_t task_id = static_cast<int>(::dsn::utils::get_current_tid());
-                _val[task_id % DIVIDE_CONTAINER] = val;
+                _val[task_id % DIVIDE_CONTAINER].store(val, std::memory_order_relaxed);
             }
             virtual double get_value() override
             {
@@ -119,9 +120,10 @@ namespace dsn {
         {
         public:
             perf_counter_rate_v2_atomic(const char* app, const char *section, const char *name, dsn_perf_counter_type_t type, const char *dsptr)
-                : perf_counter(app, section, name, type, dsptr), _rate(0)
+                : perf_counter(app, section, name, type, dsptr),
+                  _rate(0),
+                  _last_time(::dsn::utils::get_current_physical_time_ns())
             {
-                _last_time = ::dsn::utils::get_current_rdtsc();
                 for (int i = 0; i < DIVIDE_CONTAINER; i++)
                 {
                     _val[i].store(0, std::memory_order_relaxed);
@@ -147,25 +149,27 @@ namespace dsn {
             virtual void   set(uint64_t val) override { dassert(false, "invalid execution flow"); }
             virtual double get_value() override
             {
+                std::lock_guard<std::mutex> guard(_sample_lock);
+                uint64_t now = ::dsn::utils::get_current_physical_time_ns();
+                if (now <= _last_time)
+                {
+                    return _rate;
+                }
+
+                double interval = (now - _last_time) / 1e9;
+                if (interval <= 0.1)
+                {
+                    return _rate;
+                }
+
                 double val = 0;
                 for (int i = 0; i < DIVIDE_CONTAINER; i++)
                 {
-                    val += static_cast<double>(_val[i].load(std::memory_order_relaxed));
+                    val += static_cast<double>(
+                        _val[i].exchange(0, std::memory_order_relaxed));
                 }
-
-                uint64_t now = ::dsn::utils::get_current_rdtsc();
-                double interval = (now - _last_time) / 1e9;
-                if (interval <= 0.0)
-                    return _rate;
-                if (interval <= 0.1)
-                    return _rate;
 
                 _last_time = now;
-                for (int i = 0; i < DIVIDE_CONTAINER; i++)
-                {
-                    _val[i].store(0, std::memory_order_relaxed);
-                }
-
                 _rate = val / interval;
                 return _rate;
             }
@@ -173,9 +177,10 @@ namespace dsn {
             virtual double get_percentile(dsn_perf_counter_percentile_type_t type) override { dassert(false, "invalid execution flow"); return 0.0; }
 
         private:
-            std::atomic<double> _rate;
-            std::atomic<uint64_t> _last_time;
+            double _rate;
+            uint64_t _last_time;
             std::atomic<uint64_t> _val[DIVIDE_CONTAINER];
+            std::mutex _sample_lock;
         };
 
         // -----------   NUMBER_PERCENTILE perf counter ---------------------------------
@@ -198,6 +203,10 @@ namespace dsn {
                 _results[COUNTER_PERCENTILE_99] = 0;
                 _results[COUNTER_PERCENTILE_999] = 0;
                 _tail = 0;
+                for (uint64_t& sample : _samples)
+                {
+                    sample = 0;
+                }
 
                 _counter_computation_interval_seconds = (int)dsn_config_get_value_uint64(
                     "components.simple_perf_counter_v2_atomic",
@@ -220,6 +229,7 @@ namespace dsn {
             virtual void   add(uint64_t val) override { dassert(false, "invalid execution flow"); }
             virtual void   set(uint64_t val) override
             {
+                std::lock_guard<std::mutex> guard(_samples_lock);
                 auto idx = _tail++;
                 _samples[idx % MAX_QUEUE_LENGTH] = val;
             }
@@ -233,6 +243,7 @@ namespace dsn {
                     dassert(false, "send a wrong counter percentile type");
                     return 0.0;
                 }
+                std::lock_guard<std::mutex> guard(_samples_lock);
                 return (double)_results[type];
             }
 
@@ -240,29 +251,43 @@ namespace dsn {
             {
                 dassert(required_sample_count <= MAX_QUEUE_LENGTH, "");
 
-                int count = _tail;
-                int return_count = count >= required_sample_count ? required_sample_count : count;
-
                 samples.clear();
-                int end_index = (count + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH;
-                int start_index = (end_index + MAX_QUEUE_LENGTH - return_count) % MAX_QUEUE_LENGTH;
+                if (required_sample_count <= 0)
+                {
+                    return 0;
+                }
 
-                if (end_index >= start_index)
+                static thread_local uint64_t snapshot[MAX_QUEUE_LENGTH];
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                uint64_t count = _tail;
+                int return_count =
+                    count >= static_cast<uint64_t>(required_sample_count)
+                        ? required_sample_count
+                        : static_cast<int>(count);
+
+                if (return_count <= 0)
                 {
-                    samples.push_back(std::make_pair((uint64_t*)_samples + start_index, return_count));
+                    return 0;
                 }
-                else
+
+                int end_index =
+                    static_cast<int>((count + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH);
+                int start_index =
+                    (end_index + MAX_QUEUE_LENGTH - return_count + 1) % MAX_QUEUE_LENGTH;
+                for (int i = 0; i < return_count; ++i)
                 {
-                    samples.push_back(std::make_pair((uint64_t*)_samples + start_index, MAX_QUEUE_LENGTH - start_index));
-                    samples.push_back(std::make_pair((uint64_t*)_samples, return_count - (MAX_QUEUE_LENGTH - start_index)));
+                    snapshot[i] = _samples[(start_index + i) % MAX_QUEUE_LENGTH];
                 }
+                samples.push_back(std::make_pair(snapshot, return_count));
 
                 return return_count;
             }
 
             virtual uint64_t get_latest_sample() const override
             {
-                int idx = (_tail + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH;
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                int idx =
+                    static_cast<int>((_tail + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH);
                 return _samples[idx];
             }
 
@@ -273,6 +298,7 @@ namespace dsn {
                 uint64_t tmp[MAX_QUEUE_LENGTH];
                 uint64_t mid_tmp[MAX_QUEUE_LENGTH];
                 int      calc_queue[MAX_QUEUE_LENGTH][4];
+                uint64_t results[COUNTER_PERCENTILE_COUNT];
             };
 
             inline void insert_calc_queue(std::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
@@ -319,7 +345,7 @@ namespace dsn {
                 {
                     for (i = qleft; i <= qright; i++)
                     if (ctx->ask[i] == 1)
-                        _results[i] = ctx->tmp[left];
+                        ctx->results[i] = ctx->tmp[left];
                     else
                         dassert(false, "select percentail wrong!!!");
                     return;
@@ -356,12 +382,17 @@ namespace dsn {
 
             void   calc(std::shared_ptr<compute_context>& ctx)
             {
-                int _num = _tail > MAX_QUEUE_LENGTH ? MAX_QUEUE_LENGTH : _tail;
+                int _num;
+                {
+                    std::lock_guard<std::mutex> guard(_samples_lock);
+                    _num = _tail > MAX_QUEUE_LENGTH ? MAX_QUEUE_LENGTH
+                                                    : static_cast<int>(_tail);
 
-                if (_num == 0)
-                    return;
-                for (int i = 0; i < _num; i++)
-                    ctx->tmp[i] = _samples[i];
+                    if (_num == 0)
+                        return;
+                    for (int i = 0; i < _num; i++)
+                        ctx->tmp[i] = _samples[i];
+                }
 
                 ctx->ask[COUNTER_PERCENTILE_50] = (int)(_num * 0.5) + 1;
                 ctx->ask[COUNTER_PERCENTILE_90] = (int)(_num * 0.90) + 1;
@@ -377,7 +408,9 @@ namespace dsn {
                 for (l = 1; l <= r; l++)
                     select(ctx, ctx->calc_queue[l][_LEFT], ctx->calc_queue[l][_RIGHT], ctx->calc_queue[l][_QLEFT], ctx->calc_queue[l][_QRIGHT], r);
 
-                return;
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                for (int i = 0; i < COUNTER_PERCENTILE_COUNT; ++i)
+                    _results[i] = ctx->results[i];
             }
 
             void on_timer(std::shared_ptr<boost::asio::deadline_timer> timer, const boost::system::error_code& ec)
@@ -405,10 +438,11 @@ namespace dsn {
             }
 
             std::shared_ptr<boost::asio::deadline_timer> _timer;
-            int _tail;
+            uint64_t _tail;
             uint64_t _samples[MAX_QUEUE_LENGTH];
             uint64_t _results[COUNTER_PERCENTILE_COUNT];
             int      _counter_computation_interval_seconds;
+            mutable std::mutex _samples_lock;
         };
 
         // ---------------------- perf counter dispatcher ---------------------

--- a/src/plugins/tools.common/simple_perf_counter_v2_fast.cpp
+++ b/src/plugins/tools.common/simple_perf_counter_v2_fast.cpp
@@ -45,6 +45,7 @@
 # include <functional>
 # include <utility>
 # include <atomic>
+# include <mutex>
 
 namespace dsn {
     namespace tools {
@@ -63,7 +64,7 @@ namespace dsn {
             {
                 for (int i = 0; i < DIVIDE_CONTAINER; i++)
                 {
-                    _val[i] = 0;
+                    _val[i].store(0, std::memory_order_relaxed);
                 }
             }
             ~perf_counter_number_v2_fast(void) {}
@@ -71,29 +72,29 @@ namespace dsn {
             virtual void   increment() override
             {
                 uint64_t task_id = static_cast<uint64_t>(::dsn::utils::get_current_tid());
-                _val[task_id % DIVIDE_CONTAINER]++;
+                _val[task_id % DIVIDE_CONTAINER].fetch_add(1, std::memory_order_relaxed);
             }
             virtual void   decrement() override
             {
                 uint64_t task_id = static_cast<uint64_t>(::dsn::utils::get_current_tid());
-                _val[task_id % DIVIDE_CONTAINER]--;
+                _val[task_id % DIVIDE_CONTAINER].fetch_sub(1, std::memory_order_relaxed);
             }
             virtual void   add(uint64_t val) override
             {
                 uint64_t task_id = static_cast<uint64_t>(::dsn::utils::get_current_tid());
-                _val[task_id % DIVIDE_CONTAINER] += val;
+                _val[task_id % DIVIDE_CONTAINER].fetch_add(val, std::memory_order_relaxed);
             }
             virtual void   set(uint64_t val) override
             {
                 uint64_t task_id = static_cast<uint64_t>(::dsn::utils::get_current_tid());
-                _val[task_id % DIVIDE_CONTAINER] = val;
+                _val[task_id % DIVIDE_CONTAINER].store(val, std::memory_order_relaxed);
             }
             virtual double get_value() override
             {
                 double val = 0;
                 for (int i = 0; i < DIVIDE_CONTAINER; i++)
                 {
-                    val += (double)_val[i];
+                    val += static_cast<double>(_val[i].load(std::memory_order_relaxed));
                 }
                 return val;
             }
@@ -102,14 +103,14 @@ namespace dsn {
                 uint64_t val = 0;
                 for (int i = 0; i < DIVIDE_CONTAINER; i++)
                 {
-                    val += _val[i];
+                    val += _val[i].load(std::memory_order_relaxed);
                 }
                 return val;
             }
             virtual double get_percentile(dsn_perf_counter_percentile_type_t type) override { dassert(false, "invalid execution flow"); return 0.0; }
 
         private:
-            uint64_t              _val[DIVIDE_CONTAINER];
+            std::atomic<uint64_t> _val[DIVIDE_CONTAINER];
         };
 
         // -----------   RATE perf counter ---------------------------------
@@ -123,48 +124,50 @@ namespace dsn {
                 _last_time = ::dsn::utils::get_current_physical_time_ns();
                 for (int i = 0; i < DIVIDE_CONTAINER; i++)
                 {
-                    _val[i] = 0;
+                    _val[i].store(0, std::memory_order_relaxed);
                 }
             }
             ~perf_counter_rate_v2_fast(void) {}
 
             virtual void   increment() override
             {
-                uint64_t task_id = static_cast<int>(::dsn::utils::get_current_tid());
-                _val[task_id % DIVIDE_CONTAINER]++;
+                uint64_t task_id = static_cast<uint64_t>(::dsn::utils::get_current_tid());
+                _val[task_id % DIVIDE_CONTAINER].fetch_add(1, std::memory_order_relaxed);
             }
             virtual void   decrement() override
             {
-                uint64_t task_id = static_cast<int>(::dsn::utils::get_current_tid());
-                _val[task_id % DIVIDE_CONTAINER]--;
+                uint64_t task_id = static_cast<uint64_t>(::dsn::utils::get_current_tid());
+                _val[task_id % DIVIDE_CONTAINER].fetch_sub(1, std::memory_order_relaxed);
             }
             virtual void   add(uint64_t val) override
             {
-                uint64_t task_id = static_cast<int>(::dsn::utils::get_current_tid());
-                _val[task_id % DIVIDE_CONTAINER] += val;
+                uint64_t task_id = static_cast<uint64_t>(::dsn::utils::get_current_tid());
+                _val[task_id % DIVIDE_CONTAINER].fetch_add(val, std::memory_order_relaxed);
             }
             virtual void   set(uint64_t val) override { dassert(false, "invalid execution flow"); }
             virtual double get_value() override
             {
+                std::lock_guard<std::mutex> guard(_sample_lock);
+                uint64_t now = ::dsn::utils::get_current_physical_time_ns();
+                if (now <= _last_time)
+                {
+                    return _rate;
+                }
+
+                double interval = (now - _last_time) / 1e9;
+                if (interval <= 0.1)
+                {
+                    return _rate;
+                }
+
                 double val = 0;
                 for (int i = 0; i < DIVIDE_CONTAINER; i++)
                 {
-                    val += _val[i];
+                    val += static_cast<double>(
+                        _val[i].exchange(0, std::memory_order_relaxed));
                 }
-
-                uint64_t now = ::dsn::utils::get_current_physical_time_ns();
-                double interval = (now - _last_time) / 1e9;
-                if (interval <= 0.0)
-                    return _rate;
-                if (interval <= 0.1)
-                    return _rate;
 
                 _last_time = now;
-                for (int i = 0; i < DIVIDE_CONTAINER; i++)
-                {
-                    _val[i] = 0;
-                }
-
                 _rate = val / interval;
                 return _rate;
             }
@@ -172,9 +175,10 @@ namespace dsn {
             virtual double get_percentile(dsn_perf_counter_percentile_type_t type) override { dassert(false, "invalid execution flow"); return 0.0; }
 
         private:
-            std::atomic<double> _rate;
-            std::atomic<uint64_t> _last_time;
-            uint64_t              _val[DIVIDE_CONTAINER];
+            double _rate;
+            uint64_t _last_time;
+            std::atomic<uint64_t> _val[DIVIDE_CONTAINER];
+            std::mutex _sample_lock;
         };
 
         // -----------   NUMBER_PERCENTILE perf counter ---------------------------------
@@ -197,6 +201,10 @@ namespace dsn {
                 _results[COUNTER_PERCENTILE_99] = 0;
                 _results[COUNTER_PERCENTILE_999] = 0;
                 _tail = 0;
+                for (uint64_t& sample : _samples)
+                {
+                    sample = 0;
+                }
 
                 _counter_computation_interval_seconds = (int)dsn_config_get_value_uint64(
                     "components.simple_perf_counter_v2_fast",
@@ -219,6 +227,7 @@ namespace dsn {
             virtual void   add(uint64_t val) override { dassert(false, "invalid execution flow"); }
             virtual void   set(uint64_t val) override
             {
+                std::lock_guard<std::mutex> guard(_samples_lock);
                 auto idx = _tail++;
                 _samples[idx % MAX_QUEUE_LENGTH] = val;
             }
@@ -233,6 +242,7 @@ namespace dsn {
                     dassert(false, "send a wrong counter percentile type");
                     return 0.0;
                 }
+                std::lock_guard<std::mutex> guard(_samples_lock);
                 return (double)_results[type];
             }
 
@@ -240,29 +250,43 @@ namespace dsn {
             {
                 dassert(required_sample_count <= MAX_QUEUE_LENGTH, "");
 
-                int count = _tail;
-                int return_count = count >= required_sample_count ? required_sample_count : count;
-
                 samples.clear();
-                int end_index = (count + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH;
-                int start_index = (end_index + MAX_QUEUE_LENGTH - return_count) % MAX_QUEUE_LENGTH;
+                if (required_sample_count <= 0)
+                {
+                    return 0;
+                }
 
-                if (end_index >= start_index)
+                static thread_local uint64_t snapshot[MAX_QUEUE_LENGTH];
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                uint64_t count = _tail;
+                int return_count =
+                    count >= static_cast<uint64_t>(required_sample_count)
+                        ? required_sample_count
+                        : static_cast<int>(count);
+
+                if (return_count <= 0)
                 {
-                    samples.push_back(std::make_pair((uint64_t*)_samples + start_index, return_count));
+                    return 0;
                 }
-                else
+
+                int end_index =
+                    static_cast<int>((count + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH);
+                int start_index =
+                    (end_index + MAX_QUEUE_LENGTH - return_count + 1) % MAX_QUEUE_LENGTH;
+                for (int i = 0; i < return_count; ++i)
                 {
-                    samples.push_back(std::make_pair((uint64_t*)_samples + start_index, MAX_QUEUE_LENGTH - start_index));
-                    samples.push_back(std::make_pair((uint64_t*)_samples, return_count - (MAX_QUEUE_LENGTH - start_index)));
+                    snapshot[i] = _samples[(start_index + i) % MAX_QUEUE_LENGTH];
                 }
+                samples.push_back(std::make_pair(snapshot, return_count));
 
                 return return_count;
             }
 
             virtual uint64_t get_latest_sample() const override
             {
-                int idx = (_tail + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH;
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                int idx =
+                    static_cast<int>((_tail + MAX_QUEUE_LENGTH - 1) % MAX_QUEUE_LENGTH);
                 return _samples[idx];
             }
 
@@ -273,6 +297,7 @@ namespace dsn {
                 uint64_t tmp[MAX_QUEUE_LENGTH];
                 uint64_t mid_tmp[MAX_QUEUE_LENGTH];
                 int      calc_queue[MAX_QUEUE_LENGTH][4];
+                uint64_t results[COUNTER_PERCENTILE_COUNT];
             };
 
             inline void insert_calc_queue(std::shared_ptr<compute_context>& ctx, int left, int right, int qleft, int qright, int &calc_tail)
@@ -319,7 +344,7 @@ namespace dsn {
                 {
                     for (i = qleft; i <= qright; i++)
                     if (ctx->ask[i] == 1)
-                        _results[i] = ctx->tmp[left];
+                        ctx->results[i] = ctx->tmp[left];
                     else
                         dassert(false, "select percentail wrong!!!");
                     return;
@@ -356,12 +381,17 @@ namespace dsn {
 
             void   calc(std::shared_ptr<compute_context>& ctx)
             {
-                int _num = _tail > MAX_QUEUE_LENGTH ? MAX_QUEUE_LENGTH : _tail;
+                int _num;
+                {
+                    std::lock_guard<std::mutex> guard(_samples_lock);
+                    _num = _tail > MAX_QUEUE_LENGTH ? MAX_QUEUE_LENGTH
+                                                    : static_cast<int>(_tail);
 
-                if (_num == 0)
-                    return;
-                for (int i = 0; i < _num; i++)
-                    ctx->tmp[i] = _samples[i];
+                    if (_num == 0)
+                        return;
+                    for (int i = 0; i < _num; i++)
+                        ctx->tmp[i] = _samples[i];
+                }
 
                 ctx->ask[COUNTER_PERCENTILE_50] = (int)(_num * 0.5) + 1;
                 ctx->ask[COUNTER_PERCENTILE_90] = (int)(_num * 0.90) + 1;
@@ -377,7 +407,9 @@ namespace dsn {
                 for (l = 1; l <= r; l++)
                     select(ctx, ctx->calc_queue[l][_LEFT], ctx->calc_queue[l][_RIGHT], ctx->calc_queue[l][_QLEFT], ctx->calc_queue[l][_QRIGHT], r);
 
-                return;
+                std::lock_guard<std::mutex> guard(_samples_lock);
+                for (int i = 0; i < COUNTER_PERCENTILE_COUNT; ++i)
+                    _results[i] = ctx->results[i];
             }
 
             void on_timer(std::shared_ptr<boost::asio::deadline_timer> timer, const boost::system::error_code& ec)
@@ -404,10 +436,11 @@ namespace dsn {
             }
 
             std::shared_ptr<boost::asio::deadline_timer> _timer;
-            int _tail;
+            uint64_t _tail;
             uint64_t _samples[MAX_QUEUE_LENGTH];
             uint64_t _results[COUNTER_PERCENTILE_COUNT];
             int      _counter_computation_interval_seconds;
+            mutable std::mutex _samples_lock;
         };
 
         // ---------------------- perf counter dispatcher ---------------------

--- a/src/plugins/tools.emulator/emulator.cpp
+++ b/src/plugins/tools.emulator/emulator.cpp
@@ -148,8 +148,9 @@ void emulator::add_checker(const char* name, dsn_checker_create create, dsn_chec
 
 void emulator::run()
 {
-    scheduler::instance().start();
+    scheduler::instance().initialize();
     tool_app::run();
+    scheduler::instance().start();
 }
 
 }} // end namespace dsn::tools

--- a/src/plugins/tools.emulator/scheduler.cpp
+++ b/src/plugins/tools.emulator/scheduler.cpp
@@ -115,7 +115,6 @@ __thread bool scheduler::_is_scheduling = false;
 scheduler::scheduler(void)
 {
     _time_ns = 0;
-    _running = false;
     _running_thread = nullptr;
     task_worker::on_create.put_back(on_task_worker_create, "emulation.on_task_worker_create");
     task_worker::on_start.put_back(on_task_worker_start, "emulation.on_task_worker_start");
@@ -137,7 +136,7 @@ scheduler::~scheduler(void)
 
 /*static*/ void scheduler::on_task_worker_start(task_worker* worker)
 {
-    while (!scheduler::instance()._running)
+    while (!scheduler::instance()._running.load(std::memory_order_acquire))
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
@@ -148,7 +147,6 @@ scheduler::~scheduler(void)
     auto s = task_worker_ext::get_inited(worker);    
     s->worker = worker;
     s->first_time_schedule = true;
-    s->in_continuation = false;
     s->index = static_cast<int>(scheduler::instance()._threads.size());    
     scheduler::instance()._threads.push_back(s);
 }
@@ -179,7 +177,7 @@ scheduler::~scheduler(void)
     {
         for (auto& w : ts->wait_threads)
         {
-            w->is_continuation_ready = true;
+            w->is_continuation_ready.store(true, std::memory_order_release);
         }
     }
 }
@@ -199,7 +197,7 @@ void scheduler::add_system_event(uint64_t ts_ns, std::function<void()> t)
     _wheel.add_system_event(ts_ns, t);
 }
 
-void scheduler::start()
+void scheduler::initialize()
 {
     // init all checkers
     dsn_app_info apps[DSN_MAX_APP_COUNT_IN_SAME_PROCESS]; // maximum apps
@@ -208,9 +206,11 @@ void scheduler::start()
     {
         c->checker_ptr = c->create(c->name.c_str(), apps, count);
     }
+}
 
-    // set flag
-    _running = true;
+void scheduler::start()
+{
+    _running.store(true, std::memory_order_release);
 }
 
 void scheduler::add_checker(const char* name, dsn_checker_create create, dsn_checker_apply apply)
@@ -236,8 +236,8 @@ void scheduler::check()
 void scheduler::wait_schedule(bool in_continue, bool is_continue_ready /*= false*/)
 {
     auto s = task_worker_ext::get(task::get_current_worker());
-    s->in_continuation = in_continue;
-    s->is_continuation_ready = is_continue_ready;
+    s->in_continuation.store(in_continue, std::memory_order_release);
+    s->is_continuation_ready.store(is_continue_ready, std::memory_order_release);
 
     if (s->first_time_schedule)
     {
@@ -264,9 +264,10 @@ void scheduler::schedule()
         std::vector<int> ready_workers;
         for (auto& s : _threads)
         {
-            if ((s->in_continuation && s->is_continuation_ready)
-                || (!s->in_continuation && s->worker->queue()->count() > 0)
-                )
+            const bool in_continuation = s->in_continuation.load(std::memory_order_acquire);
+            if ((in_continuation &&
+                 s->is_continuation_ready.load(std::memory_order_acquire)) ||
+                (!in_continuation && s->worker->queue()->count() > 0))
             {
                 ready_workers.push_back(s->index);
             }

--- a/src/plugins/tools.emulator/scheduler.h
+++ b/src/plugins/tools.emulator/scheduler.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <dsn/tool_api.h>
 #include <dsn/utility/synchronize.h>
 
@@ -69,8 +70,8 @@ struct sim_worker_state
     int               index;
     task_worker       *worker;
     bool              first_time_schedule;
-    bool              in_continuation;
-    bool              is_continuation_ready;
+    std::atomic<bool>  in_continuation{false};
+    std::atomic<bool>  is_continuation_ready{false};
 
     static void deletor(void* p)
     {
@@ -85,6 +86,7 @@ public:
     scheduler(void);
     ~scheduler(void);
 
+    void initialize();
     void start();
     uint64_t now_ns() const { utils::auto_lock< ::dsn::utils::ex_lock> l(_lock); return _time_ns; }
 
@@ -120,7 +122,7 @@ private:
     event_wheel                    _wheel;
     mutable ::dsn::utils::ex_lock  _lock;
     uint64_t                       _time_ns;
-    bool                           _running;
+    std::atomic<bool>              _running{false};
     std::vector<sim_worker_state*> _threads;
     sim_worker_state*              _running_thread;
     static __thread bool           _is_scheduling;

--- a/src/plugins/tools.emulator/task_engine.sim.cpp
+++ b/src/plugins/tools.emulator/task_engine.sim.cpp
@@ -103,7 +103,7 @@ void sim_semaphore_provider::signal(int count)
 
         sim_worker_state* thread = _wait_threads.front();
         _wait_threads.pop_front();
-        thread->is_continuation_ready = true;
+        thread->is_continuation_ready.store(true, std::memory_order_release);
     }
 }
 

--- a/src/plugins/tools.emulator/task_engine.sim.cpp
+++ b/src/plugins/tools.emulator/task_engine.sim.cpp
@@ -53,18 +53,17 @@ sim_task_queue::sim_task_queue(task_worker_pool* pool, int index, task_queue* in
 void sim_task_queue::enqueue(task* t)
 {
     dassert(0 == t->delay_milliseconds(), "delay time must be zero");
-    if (_tasks.size() > 0)
     {
-        do {
+        std::lock_guard<std::mutex> guard(_tasks_lock);
+        do
+        {
             int random_pos = dsn_random32(0, 1000000);
             auto pr = _tasks.insert(std::map<uint32_t, task*>::value_type(random_pos, t));
-            if (pr.second) break;
+            if (pr.second)
+            {
+                break;
+            }
         } while (true);
-    }
-    else
-    {
-        int random_pos = dsn_random32(0, 1000000);
-        _tasks.insert(std::map<uint32_t, task*>::value_type(random_pos, t));
     }
 
     // for scheduling
@@ -79,7 +78,8 @@ task* sim_task_queue::dequeue(/*inout*/int& batch_size)
 {
     scheduler::instance().wait_schedule(false);
 
-    if (_tasks.size() > 0)
+    std::lock_guard<std::mutex> guard(_tasks_lock);
+    if (!_tasks.empty())
     {
         auto t = _tasks.begin()->second;
         _tasks.erase(_tasks.begin());

--- a/src/plugins/tools.emulator/task_engine.sim.h
+++ b/src/plugins/tools.emulator/task_engine.sim.h
@@ -37,6 +37,7 @@
 
 #include <dsn/tool_api.h>
 #include <dsn/utility/priority_queue.h>
+#include <mutex>
 
 namespace dsn { namespace tools {
 
@@ -63,6 +64,7 @@ public:
     virtual task*    dequeue(/*inout*/int& batch_size) override;
 
 private:
+    std::mutex _tasks_lock;
     std::map<uint32_t, task*> _tasks;
 };
 


### PR DESCRIPTION
## Summary

- harden task, startup, and emulator lifecycle synchronization
- make command registration, execution, forwarding, and deregistration lifetime-safe
- remove races and correctness defects from all performance-counter providers
- sync `rDSN.dist.service` to the merged meta-service shutdown hardening

## Key changes

### Runtime and emulator lifecycle

- synchronize simulator queue publication and worker startup
- avoid retaining task objects while joining application shutdown
- publish runtime readiness only after startup completes
- tighten cancellation and callback ownership around task completion

### Command management

- prevent command execution/deregistration use-after-free
- validate handles and reject duplicate registrations without aborting
- make registration publication atomic under allocation failure
- synchronize target-address publication
- preserve forwarded output while balancing response references
- clean up local CLI threads and C API reply buffers on failure

### Performance counters

- serialize percentile sampling and result publication
- preserve concurrent rate increments in all three providers
- initialize first-sample baselines consistently
- fix window bounds, signed rollover, and invalid sample counts
- use nanosecond timestamps instead of CPU-cycle values in the atomic provider

### Distributed service

- update the submodule to `rDSN.dist.service` master commit `7300df5`
- include the meta-service shutdown hardening merged through PR #38

## Validation

- GCC 8 ThreadSanitizer build completed successfully
- focused Simple-KV shutdown and counter runs completed without target warnings
- command-lifetime and concurrent-counter stress coverage passed
- final affected `dsn.core` and `dsn.tools.common` targets built successfully