### PR TITLE
Fix numeric limits calls on Windows

### DIFF
--- a/src/plugins/tools.common/http_message_parser.cpp
+++ b/src/plugins/tools.common/http_message_parser.cpp
@@ -404,7 +404,7 @@ http_message_parser::http_message_parser()
         // on the fast path) or under-allocated the destination and heap-overflowed in memcpy (slow
         // path). Reject it by closing the connection, the same graceful failure the parser already
         // uses for other malformed input.
-        if (length > static_cast<size_t>(std::numeric_limits<unsigned int>::max()) - old_len)
+        if (length > static_cast<size_t>((std::numeric_limits<unsigned int>::max)()) - old_len)
         {
             derror("http message body too large (already %u bytes, +%zu more), closing connection",
                    old_len, static_cast<size_t>(length));

--- a/src/plugins/tools.common/thrift_message_parser.cpp
+++ b/src/plugins/tools.common/thrift_message_parser.cpp
@@ -338,8 +338,9 @@ namespace dsn
                 // attacker-controlled size (up to ~2GB) up front, before the short read is detected
                 // -- a memory-amplification DoS (a 56-byte message can force a multi-GB allocation).
                 int32_t read_limit =
-                    body_data.length() > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())
-                        ? std::numeric_limits<int32_t>::max()
+                    body_data.length() >
+                            static_cast<uint32_t>((std::numeric_limits<int32_t>::max)())
+                        ? (std::numeric_limits<int32_t>::max)()
                         : static_cast<int32_t>(body_data.length());
                 iprot.setStringSizeLimit(read_limit);
                 iprot.setContainerSizeLimit(read_limit);


### PR DESCRIPTION
## Summary

- Use macro-safe `numeric_limits<T>::max` syntax in the HTTP and Thrift message parsers.
- Prevent collision with the Windows SDK’s `max` macro.

## Validation

- Built `dsn.tools.common` with VS2022.