### PR TITLE
Harden runtime and plugin robustness with regression coverage

### DIFF
--- a/include/dsn/c/api_layer1.h
+++ b/include/dsn/c/api_layer1.h
@@ -1106,7 +1106,8 @@ extern DSN_API dsn_error_t  dsn_file_write_vector(
  \param remote     address of the remote nfs server
  \param source_dir source dir on remote server
  \param dest_dir   destination dir on local server
- \param overwrite  true to overwrite, false to preserve.
+ \param overwrite  true to replace existing destination files; false to fail
+                   the copy if any destination file exists, preserving it unchanged.
  \param cb         callback aio task to be executed on completion
  \return ERR_OK if the copy request is submitted, otherwise the submission error code.
  */
@@ -1126,7 +1127,8 @@ extern DSN_API dsn_error_t  dsn_file_copy_remote_directory(
  \param source_files zero-ended file string array within the source dir on remote server,
     when it contains no files, all files within source_dir are copied
  \param dest_dir     destination dir on local server
- \param overwrite    true to overwrite, false to preserve.
+ \param overwrite    true to replace existing destination files; false to fail
+                     the copy if any destination file exists, preserving it unchanged.
  \param cb           callback aio task to be executed on completion
  \return ERR_OK if the copy request is submitted, otherwise the submission error code.
  */

--- a/include/dsn/utility/customizable_id.h
+++ b/include/dsn/utility/customizable_id.h
@@ -39,8 +39,9 @@
 # include <dsn/utility/singleton.h>
 # include <dsn/utility/ports.h>
 # include <string>
+# include <deque>
+# include <mutex>
 # include <unordered_map>
-# include <vector>
 
 namespace dsn { namespace utils {
 
@@ -57,11 +58,12 @@ public:
     int get_id(const char* name) const;    
     const char* get_name(int id) const;
     int register_id(const char* name);
-    int max_value() const { return static_cast<int>(_names2.size()) - 1; }
+    int max_value() const;
 
 private:
+    mutable std::mutex _lock;
     std::unordered_map<std::string, int> _names;
-    std::vector<std::string>   _names2;
+    std::deque<std::string> _names2;
 };
 
 template<typename T>
@@ -174,6 +176,7 @@ int customized_id_mgr<T>::get_id(const char* name) const
         return -1;
     }
 
+    std::lock_guard<std::mutex> l(_lock);
     auto it = _names.find(std::string(name));
     if (it == _names.end())
     {
@@ -188,6 +191,7 @@ int customized_id_mgr<T>::get_id(const char* name) const
 template<typename T>
 const char* customized_id_mgr<T>::get_name(int id) const
 {
+    std::lock_guard<std::mutex> l(_lock);
     if (id >= 0 && id < static_cast<int>(_names2.size()))
     {
         return _names2[id].c_str();
@@ -196,6 +200,13 @@ const char* customized_id_mgr<T>::get_name(int id) const
     {
         return "unknown";
     }
+}
+
+template<typename T>
+int customized_id_mgr<T>::max_value() const
+{
+    std::lock_guard<std::mutex> l(_lock);
+    return static_cast<int>(_names2.size()) - 1;
 }
 
 template<typename T>
@@ -208,15 +219,29 @@ int customized_id_mgr<T>::register_id(const char* name)
 
     try
     {
-        int id = get_id(name);
-        if (-1 != id)
+        std::lock_guard<std::mutex> l(_lock);
+        auto found = _names.find(std::string(name));
+        if (found != _names.end())
         {
-            return id;
+            return found->second;
         }
 
-        int code = static_cast<int>(_names.size());
-        _names[std::string(name)] = code;
-        _names2.push_back(std::string(name));
+        int code = static_cast<int>(_names2.size());
+        auto inserted = _names.emplace(std::string(name), code);
+        if (!inserted.second)
+        {
+            return inserted.first->second;
+        }
+
+        try
+        {
+            _names2.push_back(inserted.first->first);
+        }
+        catch (...)
+        {
+            _names.erase(inserted.first);
+            throw;
+        }
         return code;
     }
     catch (...)

--- a/include/dsn/utility/exp_delay.h
+++ b/include/dsn/utility/exp_delay.h
@@ -87,14 +87,6 @@ namespace dsn
                 if (f < s_default_delay_points[DELAY_COUNT - 1])
                 {
                     int idx = static_cast<int>((f - 1.0) / 0.2);
-                    if (idx < 0)
-                    {
-                        idx = 0;
-                    }
-                    else if (idx >= DELAY_COUNT)
-                    {
-                        idx = DELAY_COUNT - 1;
-                    }
                     delay_milliseconds = _delay[idx];
                 }
                 else
@@ -149,14 +141,6 @@ namespace dsn
                 if (f < s_default_delay_points[DELAY_COUNT - 1])
                 {
                     int idx = static_cast<int>((f - 1.0) / 0.2);
-                    if (idx < 0)
-                    {
-                        idx = 0;
-                    }
-                    else if (idx >= DELAY_COUNT)
-                    {
-                        idx = DELAY_COUNT - 1;
-                    }
                     delay_milliseconds = _delay[idx];
                 }
                 else

--- a/include/dsn/utility/exp_delay.h
+++ b/include/dsn/utility/exp_delay.h
@@ -74,6 +74,11 @@ namespace dsn
 
         inline int delay(int value)
         {
+            if (_threshold <= 0)
+            {
+                return 0;
+            }
+
             if (value >= _threshold)
             {
                 double f = (double)value / (double)_threshold;
@@ -82,6 +87,14 @@ namespace dsn
                 if (f < s_default_delay_points[DELAY_COUNT - 1])
                 {
                     int idx = static_cast<int>((f - 1.0) / 0.2);
+                    if (idx < 0)
+                    {
+                        idx = 0;
+                    }
+                    else if (idx >= DELAY_COUNT)
+                    {
+                        idx = DELAY_COUNT - 1;
+                    }
                     delay_milliseconds = _delay[idx];
                 }
                 else
@@ -123,6 +136,11 @@ namespace dsn
 
         inline int delay(int value, int threshold)
         {
+            if (threshold <= 0)
+            {
+                return 0;
+            }
+
             if (value >= threshold)
             {
                 double f = (double)value / (double)threshold;
@@ -131,6 +149,14 @@ namespace dsn
                 if (f < s_default_delay_points[DELAY_COUNT - 1])
                 {
                     int idx = static_cast<int>((f - 1.0) / 0.2);
+                    if (idx < 0)
+                    {
+                        idx = 0;
+                    }
+                    else if (idx >= DELAY_COUNT)
+                    {
+                        idx = DELAY_COUNT - 1;
+                    }
                     delay_milliseconds = _delay[idx];
                 }
                 else

--- a/include/dsn/utility/singleton_vector_store.h
+++ b/include/dsn/utility/singleton_vector_store.h
@@ -36,6 +36,7 @@
 # pragma once
 
 # include <dsn/utility/singleton.h>
+# include <mutex>
 # include <vector>
 
 namespace dsn { namespace utils {
@@ -49,6 +50,7 @@ public:
 
     bool contains(int index) const
     {
+        std::lock_guard<std::mutex> l(_lock);
         if (index < 0 || index >= static_cast<int>(_contains.size()))
             return false;
         else
@@ -57,6 +59,7 @@ public:
 
     T get(int index) const
     {
+        std::lock_guard<std::mutex> l(_lock);
         if (index < 0 || index >= static_cast<int>(_contains.size()))
             return default_value;
         else
@@ -65,6 +68,7 @@ public:
 
     bool put(int index, T value)
     {
+        std::lock_guard<std::mutex> l(_lock);
         if (index < 0)
             return false;
 
@@ -91,6 +95,7 @@ public:
     }
 
 private:
+    mutable std::mutex _lock;
     std::vector<bool> _contains;
     std::vector<T>    _values;
 };

--- a/src/core/src/aio.test.cpp
+++ b/src/core/src/aio.test.cpp
@@ -38,9 +38,39 @@
 # include <dsn/cpp/utils.h>
 # include <gtest/gtest.h>
 # include <dsn/cpp/test_utils.h>
+# include <atomic>
 # include <cstring>
 
+# include "disk_engine.h"
+
 using namespace ::dsn;
+
+namespace
+{
+
+std::atomic<aio_task *> s_aio_type_target(nullptr);
+std::atomic<int> s_observed_aio_type(AIO_Invalid);
+
+void observe_aio_type(task *, aio_task *aio)
+{
+    if (aio == s_aio_type_target.load(std::memory_order_relaxed))
+    {
+        s_observed_aio_type.store(aio->aio()->type, std::memory_order_relaxed);
+    }
+}
+
+class aio_hook_guard
+{
+public:
+    explicit aio_hook_guard(task_spec *spec) : _spec(spec) {}
+
+    ~aio_hook_guard() { _spec->on_aio_call.remove("observe_aio_type"); }
+
+private:
+    task_spec *_spec;
+};
+
+} // anonymous namespace
 
 TEST(core, aio)
 {
@@ -295,5 +325,59 @@ TEST(core, aio_zero_length)
     EXPECT_EQ(0u, rcount);
     dsn_file_close(fp2);
 
+    EXPECT_TRUE(utils::filesystem::remove_path(tmp_file));
+}
+
+TEST(core, aio_type_is_published_before_hooks)
+{
+    auto *disk = task::get_current_disk();
+    if (disk == nullptr)
+    {
+        return;
+    }
+
+    ASSERT_TRUE(::dsn::utils::test::prepare_test_tmp_dir("dsn.core.aio_hook_type"));
+    const std::string tmp_file =
+        ::dsn::utils::test::test_tmp_path("dsn.core.aio_hook_type", "tmp");
+    auto hfile = dsn_file_open(tmp_file.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_BINARY, 0666);
+    ASSERT_NE(nullptr, hfile);
+
+    auto *spec = task_spec::get(LPC_AIO_TEST);
+    ASSERT_NE(nullptr, spec);
+    ASSERT_TRUE(spec->on_aio_call.put_front(&observe_aio_type, "observe_aio_type"));
+    aio_hook_guard hook_guard(spec);
+
+    auto read_task = file::create_aio_task(LPC_AIO_TEST, nullptr, empty_callback, 0);
+    ASSERT_NE(nullptr, read_task);
+    auto *read_aio = static_cast<aio_task *>(read_task->native_handle());
+    char read_buffer = 0;
+    read_aio->aio()->file = hfile;
+    read_aio->aio()->buffer = &read_buffer;
+    read_aio->aio()->buffer_size = 1;
+    read_aio->aio()->file_offset = 0;
+    read_aio->aio()->type = AIO_Invalid;
+    s_aio_type_target.store(read_aio, std::memory_order_relaxed);
+    s_observed_aio_type.store(AIO_Invalid, std::memory_order_relaxed);
+    disk->read(read_aio);
+    EXPECT_EQ(AIO_Read, s_observed_aio_type.load(std::memory_order_relaxed));
+    read_task->wait();
+
+    auto write_task = file::create_aio_task(LPC_AIO_TEST, nullptr, empty_callback, 0);
+    ASSERT_NE(nullptr, write_task);
+    auto *write_aio = static_cast<aio_task *>(write_task->native_handle());
+    char write_buffer = 'x';
+    write_aio->aio()->file = hfile;
+    write_aio->aio()->buffer = &write_buffer;
+    write_aio->aio()->buffer_size = 1;
+    write_aio->aio()->file_offset = 0;
+    write_aio->aio()->type = AIO_Invalid;
+    s_aio_type_target.store(write_aio, std::memory_order_relaxed);
+    s_observed_aio_type.store(AIO_Invalid, std::memory_order_relaxed);
+    disk->write(write_aio);
+    EXPECT_EQ(AIO_Write, s_observed_aio_type.load(std::memory_order_relaxed));
+    write_task->wait();
+
+    s_aio_type_target.store(nullptr, std::memory_order_relaxed);
+    EXPECT_EQ(ERR_OK, dsn_file_close(hfile));
     EXPECT_TRUE(utils::filesystem::remove_path(tmp_file));
 }

--- a/src/core/src/customizable_id.test.cpp
+++ b/src/core/src/customizable_id.test.cpp
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+# include <dsn/utility/customizable_id.h>
+# include <gtest/gtest.h>
+# include <atomic>
+# include <string>
+# include <thread>
+# include <vector>
+
+namespace dsn {
+namespace {
+
+struct customized_id_test_tag
+{
+};
+
+TEST(core, customized_id_registration_is_concurrent_and_pointer_stable)
+{
+    utils::customized_id_mgr<customized_id_test_tag> manager;
+    const int anchor_id = manager.register_id("customized_id.anchor");
+    ASSERT_GE(anchor_id, 0);
+
+    const char *const anchor_name = manager.get_name(anchor_id);
+    ASSERT_NE(nullptr, anchor_name);
+
+    for (int i = 0; i < 2048; ++i)
+    {
+        ASSERT_GE(manager.register_id(("customized_id.sequential." + std::to_string(i)).c_str()),
+                  0);
+    }
+
+    EXPECT_EQ(anchor_name, manager.get_name(anchor_id));
+    EXPECT_STREQ("customized_id.anchor", anchor_name);
+
+    constexpr int thread_count = 8;
+    constexpr int registrations_per_thread = 128;
+    std::atomic<bool> start(false);
+    std::atomic<bool> failed(false);
+    std::vector<int> shared_ids(thread_count, -1);
+    std::vector<std::thread> threads;
+
+    for (int thread_index = 0; thread_index < thread_count; ++thread_index)
+    {
+        threads.emplace_back([&, thread_index]() {
+            while (!start.load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+
+            shared_ids[thread_index] = manager.register_id("customized_id.concurrent.shared");
+            for (int i = 0; i < registrations_per_thread; ++i)
+            {
+                const std::string name = "customized_id.concurrent." +
+                                         std::to_string(thread_index) + "." + std::to_string(i);
+                const int id = manager.register_id(name.c_str());
+                const char *registered_name = manager.get_name(id);
+                if (id < 0 || registered_name == nullptr || name != registered_name)
+                {
+                    failed.store(true, std::memory_order_relaxed);
+                    return;
+                }
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto &thread : threads)
+    {
+        thread.join();
+    }
+
+    EXPECT_FALSE(failed.load(std::memory_order_relaxed));
+    for (int i = 1; i < thread_count; ++i)
+    {
+        EXPECT_EQ(shared_ids[0], shared_ids[i]);
+    }
+    EXPECT_STREQ("customized_id.anchor", anchor_name);
+}
+
+} // anonymous namespace
+} // namespace dsn

--- a/src/core/src/disk_engine.cpp
+++ b/src/core/src/disk_engine.cpp
@@ -269,18 +269,18 @@ void disk_engine::read(aio_task* aio)
         return;
     }
 
+    auto dio = aio->aio();
+    dio->type = AIO_Read;
     if (!aio->spec().on_aio_call.execute(task::get_current_task(), aio, true))
     {
         aio->enqueue(ERR_FILE_OPERATION_FAILED, 0);
         return;
     }
 
-    auto dio = aio->aio();
     auto df = (disk_file*)dio->file;
     dio->file = df->native_handle();
     dio->file_object = df;
     dio->engine = this;
-    dio->type = AIO_Read;
 
     auto wk = df->read(aio);
     if (wk)
@@ -323,18 +323,18 @@ void disk_engine::write(aio_task* aio)
         return;
     }
 
+    auto dio = aio->aio();
+    dio->type = AIO_Write;
     if (!aio->spec().on_aio_call.execute(task::get_current_task(), aio, true))
     {
         aio->enqueue(ERR_FILE_OPERATION_FAILED, 0);
         return;
     }
 
-    auto dio = aio->aio();
     auto df = (disk_file*)dio->file;
     dio->file = df->native_handle();
     dio->file_object = df;
     dio->engine = this;
-    dio->type = AIO_Write;    
 
     uint32_t sz;
     auto wk = df->write(aio, &sz);

--- a/src/core/src/exp_delay.test.cpp
+++ b/src/core/src/exp_delay.test.cpp
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+# include <dsn/utility/exp_delay.h>
+# include <gtest/gtest.h>
+
+namespace dsn {
+
+TEST(core, exp_delay_rejects_non_positive_threshold)
+{
+    exp_delay delay;
+    delay.initialize(0);
+    EXPECT_EQ(0, delay.delay(100));
+
+    shared_exp_delay shared_delay;
+    EXPECT_EQ(0, shared_delay.delay(0, 0));
+    EXPECT_EQ(0, shared_delay.delay(100, -1));
+}
+
+} // namespace dsn

--- a/src/core/src/join_point.test.cpp
+++ b/src/core/src/join_point.test.cpp
@@ -157,3 +157,18 @@ TEST(core, join_point)
     ASSERT_EQ(check_vec, jp_vec);
     }
 }
+
+TEST(core, join_point_replace_native_with_non_native)
+{
+    join_point_for_test jp;
+    std::vector<entry> entries;
+
+    ASSERT_TRUE(jp.put_front((void *)1, "native", true));
+    ASSERT_TRUE(jp.put_replace("native", (void *)2, "replacement"));
+
+    jp.get_all(entries);
+    ASSERT_EQ(1u, entries.size());
+    EXPECT_EQ("replacement", entries[0].name);
+    EXPECT_EQ((void *)2, entries[0].func);
+    EXPECT_FALSE(entries[0].is_native);
+}

--- a/src/core/src/service_api_c.cpp
+++ b/src/core/src/service_api_c.cpp
@@ -60,6 +60,7 @@
 # include "c_api_guard.h"
 # include <fstream>
 # include <cstring>
+# include <limits>
 
 # if defined(_WIN32)
 # include <tlhelp32.h>
@@ -1655,6 +1656,7 @@ DSN_API dsn_error_t dsn_file_write_vector(dsn_handle_t file, const dsn_file_buff
         return ::dsn::ERR_INVALID_STATE.get();
     }
 
+    uint64_t total_buffer_size = 0;
     for (int i = 0; i < buffer_count; i++)
     {
         if (buffers[i].size < 0)
@@ -1670,19 +1672,24 @@ DSN_API dsn_error_t dsn_file_write_vector(dsn_handle_t file, const dsn_file_buff
             derror("dsn_file_write_vector got null buffer at index = %d", i);
             return ::dsn::ERR_INVALID_PARAMETERS.get();
         }
+
+        total_buffer_size += static_cast<uint32_t>(buffers[i].size);
+        if (total_buffer_size > (std::numeric_limits<uint32_t>::max)())
+        {
+            derror("dsn_file_write_vector total buffer size exceeds %u bytes",
+                   static_cast<unsigned int>((std::numeric_limits<uint32_t>::max)()));
+            return ::dsn::ERR_INVALID_PARAMETERS.get();
+        }
     }
 
+    std::vector<dsn_file_buffer_t> write_buffers(buffers, buffers + buffer_count);
     callback->aio()->buffer = nullptr;
-    callback->aio()->buffer_size = 0;
+    callback->aio()->buffer_size = static_cast<uint32_t>(total_buffer_size);
     callback->aio()->engine = nullptr;
     callback->aio()->file = file;
     callback->aio()->file_offset = offset;
     callback->aio()->type = ::dsn::AIO_Write;
-    for (int i = 0; i < buffer_count; i++)
-    {
-        callback->_unmerged_write_buffers.push_back(buffers[i]);
-        callback->aio()->buffer_size += buffers[i].size;
-    }
+    callback->_unmerged_write_buffers = std::move(write_buffers);
 
     disk->write(callback);
     return ::dsn::ERR_OK.get();

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -769,6 +769,11 @@ TEST(core, dsn_file_dispatch_invalid_parameters)
 
 TEST(core, dsn_file_write_vector_rejection_is_transactional)
 {
+    if (task::get_current_disk() == nullptr)
+    {
+        return;
+    }
+
     auto aio_task =
         dsn_file_create_aio_task(TASK_CODE_AIO_FOR_TEST, noop_aio_handler, nullptr, 0);
     ASSERT_NE(nullptr, aio_task);

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -38,6 +38,7 @@
 # include <dsn/tool_api.h>
 # include <dsn/utility/configuration.h>
 # include <gtest/gtest.h>
+# include <climits>
 # include <string>
 # include <thread>
 # include <cstring>
@@ -762,6 +763,43 @@ TEST(core, dsn_file_dispatch_invalid_parameters)
     dsn_task_add_ref(compute_task);
     ASSERT_EQ(ERR_INVALID_PARAMETERS, dsn_file_task_enqueue(compute_task, ERR_OK, 0));
     dsn_task_release_ref(compute_task);
+
+    dsn_task_release_ref(aio_task);
+}
+
+TEST(core, dsn_file_write_vector_rejection_is_transactional)
+{
+    auto aio_task =
+        dsn_file_create_aio_task(TASK_CODE_AIO_FOR_TEST, noop_aio_handler, nullptr, 0);
+    ASSERT_NE(nullptr, aio_task);
+    dsn_task_add_ref(aio_task);
+
+    auto *callback_task = static_cast<::dsn::aio_task *>(aio_task);
+    char sentinel = 0;
+    const auto original_file = reinterpret_cast<dsn_handle_t>(1);
+    callback_task->aio()->file = original_file;
+    callback_task->aio()->engine = task::get_current_disk();
+    callback_task->aio()->buffer = &sentinel;
+    callback_task->aio()->buffer_size = 17;
+    callback_task->aio()->file_offset = 99;
+    callback_task->aio()->type = AIO_Read;
+    callback_task->_unmerged_write_buffers.push_back({&sentinel, 1});
+
+    dsn_file_buffer_t buffers[] = {
+        {&sentinel, INT_MAX}, {&sentinel, INT_MAX}, {&sentinel, INT_MAX}};
+    EXPECT_EQ(ERR_INVALID_PARAMETERS,
+              dsn_file_write_vector(
+                  reinterpret_cast<dsn_handle_t>(2), buffers, 3, 123, aio_task));
+
+    EXPECT_EQ(original_file, callback_task->aio()->file);
+    EXPECT_EQ(task::get_current_disk(), callback_task->aio()->engine);
+    EXPECT_EQ(&sentinel, callback_task->aio()->buffer);
+    EXPECT_EQ(17u, callback_task->aio()->buffer_size);
+    EXPECT_EQ(99u, callback_task->aio()->file_offset);
+    EXPECT_EQ(AIO_Read, callback_task->aio()->type);
+    ASSERT_EQ(1u, callback_task->_unmerged_write_buffers.size());
+    EXPECT_EQ(&sentinel, callback_task->_unmerged_write_buffers[0].buffer);
+    EXPECT_EQ(1u, callback_task->_unmerged_write_buffers[0].size);
 
     dsn_task_release_ref(aio_task);
 }

--- a/src/core/src/service_api_c.test.cpp
+++ b/src/core/src/service_api_c.test.cpp
@@ -779,7 +779,7 @@ TEST(core, dsn_file_write_vector_rejection_is_transactional)
     ASSERT_NE(nullptr, aio_task);
     dsn_task_add_ref(aio_task);
 
-    auto *callback_task = static_cast<::dsn::aio_task *>(aio_task);
+    auto *callback_task = static_cast< ::dsn::aio_task *>(aio_task);
     char sentinel = 0;
     const auto original_file = reinterpret_cast<dsn_handle_t>(1);
     callback_task->aio()->file = original_file;

--- a/src/core/src/singleton_vector_store.test.cpp
+++ b/src/core/src/singleton_vector_store.test.cpp
@@ -1,0 +1,82 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Microsoft Corporation
+ *
+ * -=- Robust Distributed System Nucleus (rDSN) -=-
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+# include <dsn/utility/singleton_vector_store.h>
+# include <gtest/gtest.h>
+# include <atomic>
+# include <thread>
+# include <vector>
+
+namespace dsn {
+namespace {
+
+TEST(core, singleton_vector_store_supports_concurrent_growth)
+{
+    utils::singleton_vector_store<long, -1> store;
+    constexpr int thread_count = 8;
+    constexpr int values_per_thread = 256;
+    std::atomic<bool> start(false);
+    std::atomic<bool> failed(false);
+    std::vector<std::thread> threads;
+
+    for (int thread_index = 0; thread_index < thread_count; ++thread_index)
+    {
+        threads.emplace_back([&, thread_index]() {
+            while (!start.load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+
+            for (int i = 0; i < values_per_thread; ++i)
+            {
+                const int index = thread_index * values_per_thread + i;
+                const long value = static_cast<long>(index) + 1000;
+                if (!store.put(index, value) || !store.contains(index) ||
+                    store.get(index) != value)
+                {
+                    failed.store(true, std::memory_order_relaxed);
+                    return;
+                }
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    for (auto &thread : threads)
+    {
+        thread.join();
+    }
+
+    EXPECT_FALSE(failed.load(std::memory_order_relaxed));
+    for (int i = 0; i < thread_count * values_per_thread; ++i)
+    {
+        EXPECT_TRUE(store.contains(i));
+        EXPECT_EQ(static_cast<long>(i) + 1000, store.get(i));
+    }
+}
+
+} // anonymous namespace
+} // namespace dsn

--- a/src/dev/utility/join_point.cpp
+++ b/src/dev/utility/join_point.cpp
@@ -130,6 +130,7 @@ bool join_point_base::put_replace(const char* base, void* fn, const char* name)
     {
         e0->func = fn;
         e0->name = name;
+        e0->is_native = false;
         return true;
     }
 }

--- a/src/plugins/dist.uri.resolver/CMakeLists.txt
+++ b/src/plugins/dist.uri.resolver/CMakeLists.txt
@@ -20,9 +20,9 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_INC_PATH "")
+set(MY_PROJ_INC_PATH ${GTEST_INCLUDE_DIR})
 
-set(MY_PROJ_LIBS "")
+set(MY_PROJ_LIBS gtest)
 
 set(MY_PROJ_LIB_PATH "")
 
@@ -31,4 +31,4 @@ set(MY_BINPLACES "")
 
 dsn_add_shared_library()
 
-# file(COPY test/ DESTINATION "${CMAKE_BINARY_DIR}/test/${MY_PROJ_NAME}")
+file(COPY test/ DESTINATION "${CMAKE_BINARY_DIR}/test/${MY_PROJ_NAME}")

--- a/src/plugins/dist.uri.resolver/partition_resolver_simple.cpp
+++ b/src/plugins/dist.uri.resolver/partition_resolver_simple.cpp
@@ -66,19 +66,33 @@ namespace dsn
             )
         {
             int idx = -1;
-            if (_app_partition_count != -1)
+            int app_id = -1;
+            rpc_address target;
             {
-                idx = get_partition_index(_app_partition_count, partition_hash);
-                rpc_address target;
-                if (ERR_OK == get_address(idx, target))
+                zauto_read_lock l(_config_lock);
+                if (_app_partition_count != -1)
                 {
-                    callback(resolve_result{
-                        ERR_OK,
-                        target,
-                        {{_app_id, idx}}
-                    });
-                    return;
+                    idx = get_partition_index(_app_partition_count, partition_hash);
+                    auto it = _config_cache.find(idx);
+                    if (it != _config_cache.end())
+                    {
+                        target = get_address(it->second->config, _app_is_stateful);
+                        if (!target.is_invalid())
+                        {
+                            app_id = _app_id;
+                        }
+                    }
                 }
+            }
+
+            if (!target.is_invalid())
+            {
+                callback(resolve_result{
+                    ERR_OK,
+                    target,
+                    {{app_id, idx}}
+                });
+                return;
             }
 
             auto rc = new request_context();
@@ -100,18 +114,28 @@ namespace dsn
                 && err != ERR_NOT_ENOUGH_MEMBER // primary won't change and we only r/w on primary in this provider
                 )
             {
+                zauto_write_lock l(_config_lock);
                 ddebug("clear partition configuration cache %d.%d due to access failure %s",
                        _app_id, partition_index, err.to_string());
 
+                auto it = _config_cache.find(partition_index);
+                if (it != _config_cache.end())
                 {
-                    zauto_write_lock l(_config_lock);
-                    auto it = _config_cache.find(partition_index);
-                    if (it != _config_cache.end())
-                    {
-                        _config_cache.erase(it);
-                    }
+                    _config_cache.erase(it);
                 }
             }
+        }
+
+        int partition_resolver_simple::get_partition_count() const
+        {
+            zauto_read_lock l(_config_lock);
+            return _app_partition_count;
+        }
+
+        int partition_resolver_simple::get_app_id() const
+        {
+            zauto_read_lock l(_config_lock);
+            return _app_id;
         }
 
         partition_resolver_simple::~partition_resolver_simple()
@@ -144,7 +168,11 @@ namespace dsn
             end_request(std::move(rc), ERR_TIMEOUT, rpc_address(), true);
         }
 
-        void partition_resolver_simple::end_request(request_context_ptr&& request, error_code err, rpc_address addr, bool called_by_timer) const
+        void partition_resolver_simple::end_request(request_context_ptr&& request,
+                                                    error_code err,
+                                                    rpc_address addr,
+                                                    bool called_by_timer,
+                                                    int app_id) const
         {
             zauto_lock l(request->lock);
             if (request->completed)
@@ -156,10 +184,15 @@ namespace dsn
             if (!called_by_timer && request->timeout_timer != nullptr)
                 request->timeout_timer->cancel(false);
 
+            if (app_id == -1)
+            {
+                app_id = get_app_id();
+            }
+
             request->callback(resolve_result{
                 err, 
                 addr, 
-                {{_app_id, request->partition_index}}
+                {{app_id, request->partition_index}}
             });
             request->completed = true;
         }
@@ -174,12 +207,13 @@ namespace dsn
             {
                 // fill target address if possible
                 rpc_address addr;
-                auto err = get_address(pindex, addr);
+                int app_id = -1;
+                auto err = get_address(pindex, addr, &app_id);
 
                 // target address known
                 if (err == ERR_OK)
                 {
-                    end_request(std::move(request), ERR_OK, addr);
+                    end_request(std::move(request), ERR_OK, addr, false, app_id);
                     return;
                 }
             }
@@ -269,7 +303,10 @@ namespace dsn
 
         task_ptr partition_resolver_simple::query_config(int partition_index)
         {
-            dinfo("%s.client: start query config, gpid = %d.%d", _app_path.c_str(), _app_id, partition_index);
+            dinfo("%s.client: start query config, gpid = %d.%d",
+                  _app_path.c_str(),
+                  get_app_id(),
+                  partition_index);
             auto msg = dsn_msg_create_request(RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX);
 
             configuration_query_by_index_request req;
@@ -303,7 +340,7 @@ namespace dsn
                 {
                     derror("%s.client: query config reply, gpid = %d.%d, invalid response: %s",
                         _app_path.c_str(),
-                        _app_id,
+                        get_app_id(),
                         partition_index,
                         decode_err.to_string()
                         );
@@ -319,7 +356,7 @@ namespace dsn
                         // division-by-zero crash in get_partition_index().
                         derror("%s.client: query config reply, gpid = %d.%d, invalid config: app_id = %d, partition_count = %d",
                             _app_path.c_str(),
-                            _app_id,
+                            get_app_id(),
                             partition_index,
                             resp.app_id,
                             resp.partition_count
@@ -392,7 +429,7 @@ namespace dsn
                 {
                     derror("%s.client: query config reply, gpid = %d.%d, err = %s",
                         _app_path.c_str(),
-                        _app_id,
+                        get_app_id(),
                         partition_index,
                         resp.err.to_string()
                         );
@@ -403,7 +440,7 @@ namespace dsn
                 {
                     derror("%s.client: query config reply, gpid = %d.%d, err = %s",
                         _app_path.c_str(),
-                        _app_id,
+                        get_app_id(),
                         partition_index,
                         resp.err.to_string()
                         );
@@ -415,7 +452,7 @@ namespace dsn
             {
                 derror("%s.client: query config reply, gpid = %d.%d, err = %s",
                     _app_path.c_str(),
-                    _app_id,
+                    get_app_id(),
                     partition_index,
                     err.to_string()
                     );
@@ -455,12 +492,14 @@ namespace dsn
              
                 if (!reqs2.empty())
                 {
-                    if (_app_partition_count != -1)
+                    int partition_count = get_partition_count();
+                    if (partition_count != -1)
                     {
                         for (auto& req : reqs2)
                         {
                             dassert(req->partition_index == -1, "");
-                            req->partition_index = get_partition_index(_app_partition_count, req->partition_hash);
+                            req->partition_index =
+                                get_partition_index(partition_count, req->partition_hash);
                         }
                     }
                     handle_pending_requests(reqs2, client_err);
@@ -484,10 +523,11 @@ namespace dsn
                 if (err == ERR_OK)
                 {
                     rpc_address addr;
-                    err = get_address(req->partition_index, addr);
+                    int app_id = -1;
+                    err = get_address(req->partition_index, addr, &app_id);
                     if (err == ERR_OK)
                     {
-                        end_request(std::move(req), err, addr);
+                        end_request(std::move(req), err, addr, false, app_id);
                     }
                     else
                     {
@@ -507,9 +547,10 @@ namespace dsn
         }
 
         /*search in cache*/
-        rpc_address partition_resolver_simple::get_address(const partition_configuration& config) const
+        rpc_address partition_resolver_simple::get_address(
+            const partition_configuration& config, bool app_is_stateful) const
         {
-            if (_app_is_stateful)
+            if (app_is_stateful)
             {
                 return config.primary;
             }
@@ -552,16 +593,22 @@ namespace dsn
         //ERR_OBJECT_NOT_FOUND  not in cache.
         //ERR_IO_PENDING        in cache but invalid, remove from cache.
         //ERR_OK                in cache and valid
-        error_code partition_resolver_simple::get_address(int partition_index, /*out*/ rpc_address& addr)
+        error_code partition_resolver_simple::get_address(int partition_index,
+                                                          /*out*/ rpc_address& addr,
+                                                          /*out*/ int* app_id)
         {
             //partition_configuration config;
             {
                 zauto_read_lock l(_config_lock);
+                if (app_id != nullptr)
+                {
+                    *app_id = _app_id;
+                }
                 auto it = _config_cache.find(partition_index);
                 if (it != _config_cache.end())
                 {
                     //config = it->second->config;
-                    addr = get_address(it->second->config);
+                    addr = get_address(it->second->config, _app_is_stateful);
                     if (addr.is_invalid())
                     {
                         return ERR_IO_PENDING;

--- a/src/plugins/dist.uri.resolver/partition_resolver_simple.h
+++ b/src/plugins/dist.uri.resolver/partition_resolver_simple.h
@@ -70,9 +70,11 @@ namespace dsn
 
             virtual int get_partition_index(int partition_count, uint64_t partition_hash) override;
 
-            int get_partition_count() const { return _app_partition_count; }
+            int get_partition_count() const;
 
         private:
+            friend class partition_resolver_simple_test;
+
             struct partition_info
             {
                 int timeout_count;
@@ -115,15 +117,23 @@ namespace dsn
             task_ptr                         _query_config_task;
 
             // local routines
-            rpc_address get_address(const partition_configuration& config) const;
-            error_code get_address(int partition_index, /*out*/ rpc_address& addr);
+            int get_app_id() const;
+            rpc_address get_address(const partition_configuration& config,
+                                    bool app_is_stateful) const;
+            error_code get_address(int partition_index,
+                                   /*out*/ rpc_address& addr,
+                                   /*out*/ int* app_id = nullptr);
             void handle_pending_requests(std::deque<request_context_ptr>& reqs, error_code err);
             void clear_all_pending_requests();
 
             // with replica
             void call(request_context_ptr&& request, bool from_meta_ack = false);
             //void replica_rw_reply(error_code err, dsn_message_t request, dsn_message_t response, request_context_ptr rc);
-            void end_request(request_context_ptr&& request, error_code err, rpc_address addr, bool called_by_timer = false) const;
+            void end_request(request_context_ptr&& request,
+                             error_code err,
+                             rpc_address addr,
+                             bool called_by_timer = false,
+                             int app_id = -1) const;
             void on_timeout(request_context_ptr&& rc) const;
 
             // with meta server

--- a/src/plugins/dist.uri.resolver/partition_resolver_simple.test.cpp
+++ b/src/plugins/dist.uri.resolver/partition_resolver_simple.test.cpp
@@ -1,0 +1,96 @@
+#include "partition_resolver_simple.h"
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace dsn {
+namespace dist {
+
+class partition_resolver_simple_test : public ::testing::Test
+{
+protected:
+    static void publish(partition_resolver_simple &resolver,
+                        int app_id,
+                        const rpc_address &primary)
+    {
+        std::unique_ptr<partition_resolver_simple::partition_info> info(
+            new partition_resolver_simple::partition_info());
+        info->timeout_count = 0;
+        info->config.pid = gpid(app_id, 0);
+        info->config.primary = primary;
+
+        service::zauto_write_lock lock(resolver._config_lock);
+        resolver._app_id = app_id;
+        resolver._app_partition_count = 1;
+        resolver._app_is_stateful = true;
+        resolver._config_cache[0] = std::move(info);
+    }
+};
+
+TEST_F(partition_resolver_simple_test, concurrent_snapshot_is_coherent)
+{
+    rpc_address meta_server;
+    meta_server.assign_group(dsn_group_build("partition_resolver_simple.test"));
+    partition_resolver_simple resolver(meta_server, "partition_resolver_simple.test");
+    const rpc_address primary_a("127.0.0.1", 21001);
+    const rpc_address primary_b("127.0.0.1", 21002);
+    publish(resolver, 1001, primary_a);
+
+    constexpr int update_count = 20000;
+    constexpr int reader_count = 4;
+    std::atomic<bool> start(false);
+    std::atomic<bool> failed(false);
+    std::thread publisher([&]() {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        for (int i = 0; i < update_count; ++i) {
+            publish(resolver, (i & 1) == 0 ? 1001 : 1002, (i & 1) == 0 ? primary_a : primary_b);
+        }
+    });
+
+    std::vector<std::thread> readers;
+    for (int reader_index = 0; reader_index < reader_count; ++reader_index) {
+        readers.emplace_back([&]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (int i = 0; i < update_count; ++i) {
+                bool callback_called = false;
+                resolver.resolve(
+                    0,
+                    [&](partition_resolver::resolve_result &&result) {
+                        callback_called = true;
+                        const int app_id = result.pid.u.app_id;
+                        const uint16_t port = result.address.port();
+                        if (result.err != ERR_OK ||
+                            !((app_id == 1001 && port == 21001) ||
+                              (app_id == 1002 && port == 21002))) {
+                            failed.store(true, std::memory_order_relaxed);
+                        }
+                    },
+                    1000);
+                if (!callback_called) {
+                    failed.store(true, std::memory_order_relaxed);
+                    return;
+                }
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+    publisher.join();
+    for (auto &reader : readers) {
+        reader.join();
+    }
+
+    EXPECT_FALSE(failed.load(std::memory_order_relaxed));
+}
+
+} // namespace dist
+} // namespace dsn

--- a/src/plugins/dist.uri.resolver/test/gtests
+++ b/src/plugins/dist.uri.resolver/test/gtests
@@ -1,0 +1,1 @@
+test.config.dist.uri.resolver.ini

--- a/src/plugins/dist.uri.resolver/test/test.config.dist.uri.resolver.ini
+++ b/src/plugins/dist.uri.resolver/test/test.config.dist.uri.resolver.ini
@@ -1,0 +1,46 @@
+[modules]
+dsn.tools.common
+dsn.dist.uri.resolver
+
+[apps..default]
+run = true
+count = 1
+network.client.RPC_CHANNEL_TCP = dsn::tools::asio_network_provider, 65536
+network.server.0.RPC_CHANNEL_TCP = dsn::tools::asio_network_provider, 65536
+
+[apps.client]
+type = test
+arguments = run
+ports = 20001
+pools = THREAD_POOL_DEFAULT
+
+[core]
+tool = nativerun
+pause_on_start = false
+cli_local = false
+cli_remote = false
+logging_start_level = LOG_LEVEL_INFORMATION
+logging_factory_name = dsn::tools::simple_logger
+start_nfs = false
+gtest = true
+gtest_arguments = --gtest_filter=partition_resolver_simple_test.*
+
+[network]
+io_service_worker_count = 2
+explicit_host_address = 127.0.0.1
+
+[task..default]
+allow_inline = false
+rpc_call_channel = RPC_CHANNEL_TCP
+rpc_message_header_format = dsn
+rpc_timeout_milliseconds = 1000
+
+[threadpool..default]
+worker_count = 2
+
+[threadpool.THREAD_POOL_DEFAULT]
+partitioned = false
+
+[core.test]
+count = 1
+run = true

--- a/src/plugins/tools.common/asio_net_provider.cpp
+++ b/src/plugins/tools.common/asio_net_provider.cpp
@@ -190,22 +190,28 @@ namespace dsn {
                 return;
             }
 
-            std::unique_ptr<char[]> packet_buffer(new char[tlen]);
+            auto packet_buffer = std::make_shared<std::vector<char>>(tlen);
             for (int i = 0; i < rcount; i ++)
             {
-                memcpy(&packet_buffer[offset], bufs[i].buf, bufs[i].sz);
+                memcpy(packet_buffer->data() + offset, bufs[i].buf, bufs[i].sz);
                 offset += bufs[i].sz;
             };
 
             ::boost::asio::ip::udp::endpoint ep(::boost::asio::ip::address_v4(request->to_address.ip()), request->to_address.port());
-            _socket->async_send_to(::boost::asio::buffer(packet_buffer.get(), tlen), ep,
-                [=](const boost::system::error_code& error, std::size_t bytes_transferred)
+            auto completion = detail::retain_udp_packet_until_send_complete(
+                packet_buffer,
+                [ep](const boost::system::error_code& error, std::size_t bytes_transferred)
                 {
+                    (void)bytes_transferred;
                     if (error) {
                         dwarn("send udp packet to ep %s:%d failed, message = %s", ep.address().to_string().c_str(), ep.port(), error.message().c_str());
                         //we do not handle failure here, rpc matcher would handle timeouts
                     }
                 });
+            _socket->async_send_to(
+                ::boost::asio::buffer(packet_buffer->data(), packet_buffer->size()),
+                ep,
+                std::move(completion));
         }
 
         asio_udp_provider::asio_udp_provider(rpc_engine* srv, network* inner_provider)

--- a/src/plugins/tools.common/asio_net_provider.h
+++ b/src/plugins/tools.common/asio_net_provider.h
@@ -37,10 +37,30 @@
 
 # include <dsn/tool_api.h>
 # include <boost/asio.hpp>
+# include <memory>
+# include <utility>
+# include <vector>
 
 namespace dsn {
     namespace tools {
-        
+
+        namespace detail {
+
+            template <typename TCompletion>
+            inline auto retain_udp_packet_until_send_complete(
+                std::shared_ptr<std::vector<char>> packet, TCompletion completion)
+            {
+                return [packet = std::move(packet), completion = std::move(completion)](
+                           const boost::system::error_code& error,
+                           std::size_t bytes_transferred)
+                {
+                    (void)packet;
+                    completion(error, bytes_transferred);
+                };
+            }
+
+        } // namespace detail
+
         class asio_network_provider : public connection_oriented_network
         {
         public:

--- a/src/plugins/tools.common/net_provider.test.cpp
+++ b/src/plugins/tools.common/net_provider.test.cpp
@@ -139,6 +139,32 @@
 //
 //    TEST_PORT++;
 //}
+
+TEST(tools_common, udp_completion_keeps_packet_alive)
+{
+    std::weak_ptr<std::vector<char>> packet_lifetime;
+    bool callback_called = false;
+
+    {
+        auto packet = std::make_shared<std::vector<char>>(16, 'x');
+        packet_lifetime = packet;
+        auto completion = dsn::tools::detail::retain_udp_packet_until_send_complete(
+            packet,
+            [&callback_called](const boost::system::error_code &ec, size_t transferred) {
+                EXPECT_FALSE(ec);
+                EXPECT_EQ(16u, transferred);
+                callback_called = true;
+            });
+
+        packet.reset();
+        EXPECT_FALSE(packet_lifetime.expired());
+        completion(boost::system::error_code(), 16);
+        EXPECT_TRUE(callback_called);
+        EXPECT_FALSE(packet_lifetime.expired());
+    }
+
+    EXPECT_TRUE(packet_lifetime.expired());
+}
 //
 //TEST(tools_common, asio_udp_provider)
 //{

--- a/src/plugins/tools.common/profiler.cpp
+++ b/src/plugins/tools.common/profiler.cpp
@@ -71,6 +71,7 @@ START<======== queue(server) ======ENQUEUE <===================== net(reply) ===
 #include <dsn/tool-api/command.h>
 #include <dsn/tool-api/perf_counter.h>
 #include <algorithm>
+#include <atomic>
 #include <cinttypes>
 #include <iomanip>
 
@@ -83,8 +84,42 @@ using namespace dsn::service;
 namespace dsn {
     namespace tools {
 
-        typedef uint64_extension_helper<task_spec_profiler, task> task_ext_for_profiler;
+        typedef object_extension_helper<profiler_detail::task_state, task> task_ext_for_profiler;
         typedef uint64_extension_helper<task_spec_profiler, message_ex> message_ext_for_profiler;
+
+        static void delete_task_profiler_state(void* state)
+        {
+            delete static_cast<profiler_detail::task_state*>(state);
+        }
+
+        static uint64_t profiler_timestamp(task* t)
+        {
+            return task_ext_for_profiler::get(t)->timestamp();
+        }
+
+        static void set_profiler_timestamp(task* t, uint64_t timestamp)
+        {
+            auto *state = task_ext_for_profiler::get(t);
+            if (state != nullptr)
+            {
+                state->set_timestamp(timestamp);
+            }
+        }
+
+        static bool mark_task_in_queue(task* t)
+        {
+            return task_ext_for_profiler::get(t)->mark_in_queue();
+        }
+
+        static bool unmark_task_in_queue(task* t)
+        {
+            return task_ext_for_profiler::get(t)->begin_execution();
+        }
+
+        static bool cancel_task_in_queue(task* t)
+        {
+            return task_ext_for_profiler::get(t)->cancel();
+        }
 
         task_spec_profiler* s_spec_profilers = nullptr;
         std::map<std::string, perf_counter_ptr_type> counter_info::pointer_type;
@@ -104,7 +139,7 @@ namespace dsn {
         // call normal task
         static void profiler_on_task_create(task* caller, task* callee)
         {
-            task_ext_for_profiler::get(callee) = dsn_now_ns();
+            task_ext_for_profiler::set(callee, new profiler_detail::task_state(dsn_now_ns()));
         }
 
         static void profiler_on_task_enqueue(task* caller, task* callee)
@@ -118,26 +153,26 @@ namespace dsn {
                 }
             }
 
-            task_ext_for_profiler::get(callee) = dsn_now_ns();
+            set_profiler_timestamp(callee, dsn_now_ns());
             if (callee->delay_milliseconds() == 0)
             {
                 auto ptr = s_spec_profilers[callee->spec().code].ptr[TASK_IN_QUEUE];
-                if (ptr != nullptr)
+                if (ptr != nullptr && mark_task_in_queue(callee))
                     ptr->increment();
             }
         }
 
         static void profiler_on_task_begin(task* this_)
         {
-            uint64_t& qts = task_ext_for_profiler::get(this_);
+            uint64_t qts = profiler_timestamp(this_);
             uint64_t now = dsn_now_ns();
             auto ptr = s_spec_profilers[this_->spec().code].ptr[TASK_QUEUEING_TIME_NS];
             if(ptr !=nullptr)
                 ptr->set(now - qts);
-            qts = now;
+            set_profiler_timestamp(this_, now);
 
             ptr = s_spec_profilers[this_->spec().code].ptr[TASK_IN_QUEUE];
-            if (ptr != nullptr)
+            if (ptr != nullptr && unmark_task_in_queue(this_))
                 ptr->decrement();
 
             ptr = s_spec_profilers[this_->spec().code].ptr[TASK_EXEC_COUNT];
@@ -147,7 +182,7 @@ namespace dsn {
 
         static void profiler_on_task_end(task* this_)
         {
-            uint64_t qts = task_ext_for_profiler::get(this_);
+            uint64_t qts = profiler_timestamp(this_);
             uint64_t now = dsn_now_ns();
             auto ptr = s_spec_profilers[this_->spec().code].ptr[TASK_EXEC_TIME_NS];
             if (ptr != nullptr)
@@ -163,6 +198,10 @@ namespace dsn {
             auto ptr = s_spec_profilers[this_->spec().code].ptr[TASK_CANCELLED];
             if (ptr != nullptr)
                 ptr->increment();
+
+            ptr = s_spec_profilers[this_->spec().code].ptr[TASK_IN_QUEUE];
+            if (ptr != nullptr && cancel_task_in_queue(this_))
+                ptr->decrement();
         }
 
         static void profiler_on_task_wait_pre(task* caller, task* callee, uint32_t timeout_ms)
@@ -193,21 +232,21 @@ namespace dsn {
             }
 
             // time disk io starts
-            task_ext_for_profiler::get(callee) = dsn_now_ns();
+            set_profiler_timestamp(callee, dsn_now_ns());
         }
 
         static void profiler_on_aio_enqueue(aio_task* this_)
         {
-            uint64_t& ats = task_ext_for_profiler::get(this_);
+            uint64_t ats = profiler_timestamp(this_);
             uint64_t now = dsn_now_ns();
 
             auto ptr = s_spec_profilers[this_->spec().code].ptr[AIO_LATENCY_NS];
             if (ptr != nullptr)
                 ptr->set(now - ats);
-            ats = now;
+            set_profiler_timestamp(this_, now);
 
             ptr = s_spec_profilers[this_->spec().code].ptr[TASK_IN_QUEUE];
-            if (ptr != nullptr)
+            if (ptr != nullptr && mark_task_in_queue(this_))
                 ptr->increment();
         }
 
@@ -226,18 +265,18 @@ namespace dsn {
             // time rpc starts
             if (nullptr != callee)
             {
-                task_ext_for_profiler::get(callee) = dsn_now_ns();
+                set_profiler_timestamp(callee, dsn_now_ns());
             }
         }
 
         static void profiler_on_rpc_request_enqueue(rpc_request_task* callee)
         {
             uint64_t now = dsn_now_ns();
-            task_ext_for_profiler::get(callee) = now;
+            set_profiler_timestamp(callee, now);
             message_ext_for_profiler::get(callee->get_request()) = now;
 
             auto ptr = s_spec_profilers[callee->spec().code].ptr[TASK_IN_QUEUE];
-            if (ptr != nullptr)
+            if (ptr != nullptr && mark_task_in_queue(callee))
                 ptr->increment();
         }
 
@@ -283,7 +322,7 @@ namespace dsn {
 
         static void profiler_on_rpc_response_enqueue(rpc_response_task* resp)
         {
-            uint64_t& cts = task_ext_for_profiler::get(resp);
+            uint64_t cts = profiler_timestamp(resp);
             uint64_t now = dsn_now_ns();
             auto& spp = s_spec_profilers[resp->spec().code];
 
@@ -316,10 +355,10 @@ namespace dsn {
                 if (ptr != nullptr)
                     ptr->increment();
             }
-            cts = now;
+            set_profiler_timestamp(resp, now);
 
             auto ptr = spp.ptr[TASK_IN_QUEUE];
-            if (ptr != nullptr)
+            if (ptr != nullptr && mark_task_in_queue(resp))
                 ptr->increment();
         }
 
@@ -403,7 +442,7 @@ namespace dsn {
         void profiler::install(service_spec& spec)
         {
             s_spec_profilers = new task_spec_profiler[dsn_task_code_max() + 1];
-            task_ext_for_profiler::register_ext();
+            task_ext_for_profiler::register_ext(delete_task_profiler_state);
             message_ext_for_profiler::register_ext();
             dassert(sizeof(counter_info_ptr) / sizeof(counter_info*) == PREF_COUNTER_COUNT, "PREF COUNTER ERROR");
 

--- a/src/plugins/tools.common/profiler.cpp
+++ b/src/plugins/tools.common/profiler.cpp
@@ -92,33 +92,34 @@ namespace dsn {
             delete static_cast<profiler_detail::task_state*>(state);
         }
 
-        static uint64_t profiler_timestamp(task* t)
+        static profiler_detail::task_state* profiler_state(task* t)
         {
-            return task_ext_for_profiler::get(t)->timestamp();
+            return t == nullptr ? nullptr : task_ext_for_profiler::get(t);
+        }
+
+        static bool profiler_timestamp(task* t, uint64_t& timestamp)
+        {
+            return profiler_detail::try_get_timestamp(profiler_state(t), timestamp);
         }
 
         static void set_profiler_timestamp(task* t, uint64_t timestamp)
         {
-            auto *state = task_ext_for_profiler::get(t);
-            if (state != nullptr)
-            {
-                state->set_timestamp(timestamp);
-            }
+            profiler_detail::set_timestamp(profiler_state(t), timestamp);
         }
 
         static bool mark_task_in_queue(task* t)
         {
-            return task_ext_for_profiler::get(t)->mark_in_queue();
+            return profiler_detail::mark_in_queue(profiler_state(t));
         }
 
         static bool unmark_task_in_queue(task* t)
         {
-            return task_ext_for_profiler::get(t)->begin_execution();
+            return profiler_detail::begin_execution(profiler_state(t));
         }
 
         static bool cancel_task_in_queue(task* t)
         {
-            return task_ext_for_profiler::get(t)->cancel();
+            return profiler_detail::cancel(profiler_state(t));
         }
 
         task_spec_profiler* s_spec_profilers = nullptr;
@@ -164,11 +165,13 @@ namespace dsn {
 
         static void profiler_on_task_begin(task* this_)
         {
-            uint64_t qts = profiler_timestamp(this_);
+            uint64_t qts;
             uint64_t now = dsn_now_ns();
             auto ptr = s_spec_profilers[this_->spec().code].ptr[TASK_QUEUEING_TIME_NS];
-            if(ptr !=nullptr)
+            if (ptr != nullptr && profiler_timestamp(this_, qts))
+            {
                 ptr->set(now - qts);
+            }
             set_profiler_timestamp(this_, now);
 
             ptr = s_spec_profilers[this_->spec().code].ptr[TASK_IN_QUEUE];
@@ -182,11 +185,13 @@ namespace dsn {
 
         static void profiler_on_task_end(task* this_)
         {
-            uint64_t qts = profiler_timestamp(this_);
+            uint64_t qts;
             uint64_t now = dsn_now_ns();
             auto ptr = s_spec_profilers[this_->spec().code].ptr[TASK_EXEC_TIME_NS];
-            if (ptr != nullptr)
+            if (ptr != nullptr && profiler_timestamp(this_, qts))
+            {
                 ptr->set(now - qts);
+            }
 
             ptr = s_spec_profilers[this_->spec().code].ptr[TASK_THROUGHPUT];
             if (ptr != nullptr)
@@ -237,12 +242,14 @@ namespace dsn {
 
         static void profiler_on_aio_enqueue(aio_task* this_)
         {
-            uint64_t ats = profiler_timestamp(this_);
+            uint64_t ats;
             uint64_t now = dsn_now_ns();
 
             auto ptr = s_spec_profilers[this_->spec().code].ptr[AIO_LATENCY_NS];
-            if (ptr != nullptr)
+            if (ptr != nullptr && profiler_timestamp(this_, ats))
+            {
                 ptr->set(now - ats);
+            }
             set_profiler_timestamp(this_, now);
 
             ptr = s_spec_profilers[this_->spec().code].ptr[TASK_IN_QUEUE];
@@ -322,14 +329,14 @@ namespace dsn {
 
         static void profiler_on_rpc_response_enqueue(rpc_response_task* resp)
         {
-            uint64_t cts = profiler_timestamp(resp);
+            uint64_t cts;
             uint64_t now = dsn_now_ns();
             auto& spp = s_spec_profilers[resp->spec().code];
 
             if (resp->get_response() != nullptr)
             {
                 auto ptr = spp.ptr[RPC_CLIENT_NON_TIMEOUT_LATENCY_NS];
-                if (ptr != nullptr)
+                if (ptr != nullptr && profiler_timestamp(resp, cts))
                 {
                     auto latency = now - cts;
                     ptr->set(latency);

--- a/src/plugins/tools.common/profiler.h
+++ b/src/plugins/tools.common/profiler.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <dsn/tool_api.h>
 
 /*!
@@ -64,6 +65,61 @@ is_profile = false
 namespace dsn {
     namespace tools {
 
+        namespace profiler_detail {
+
+            enum class queue_state
+            {
+                not_in_queue,
+                in_queue,
+                cancelled
+            };
+
+            class task_state
+            {
+            public:
+                explicit task_state(uint64_t timestamp)
+                    : _timestamp(timestamp), _queue_state(queue_state::not_in_queue)
+                {
+                }
+
+                uint64_t timestamp() const
+                {
+                    return _timestamp.load(std::memory_order_relaxed);
+                }
+
+                void set_timestamp(uint64_t timestamp)
+                {
+                    _timestamp.store(timestamp, std::memory_order_relaxed);
+                }
+
+                bool mark_in_queue()
+                {
+                    auto expected = queue_state::not_in_queue;
+                    return _queue_state.compare_exchange_strong(
+                        expected, queue_state::in_queue, std::memory_order_relaxed);
+                }
+
+                bool begin_execution()
+                {
+                    auto expected = queue_state::in_queue;
+                    return _queue_state.compare_exchange_strong(
+                        expected, queue_state::not_in_queue, std::memory_order_relaxed);
+                }
+
+                bool cancel()
+                {
+                    return _queue_state.exchange(queue_state::cancelled,
+                                                 std::memory_order_relaxed) ==
+                           queue_state::in_queue;
+                }
+
+            private:
+                std::atomic<uint64_t> _timestamp;
+                std::atomic<queue_state> _queue_state;
+            };
+
+        } // namespace profiler_detail
+
         class profiler : public toollet
         {
         public:
@@ -72,5 +128,4 @@ namespace dsn {
         };
     }
 }
-
 

--- a/src/plugins/tools.common/profiler.h
+++ b/src/plugins/tools.common/profiler.h
@@ -118,6 +118,40 @@ namespace dsn {
                 std::atomic<queue_state> _queue_state;
             };
 
+            inline bool try_get_timestamp(const task_state* state, uint64_t& timestamp)
+            {
+                if (state == nullptr)
+                {
+                    return false;
+                }
+
+                timestamp = state->timestamp();
+                return true;
+            }
+
+            inline void set_timestamp(task_state* state, uint64_t timestamp)
+            {
+                if (state != nullptr)
+                {
+                    state->set_timestamp(timestamp);
+                }
+            }
+
+            inline bool mark_in_queue(task_state* state)
+            {
+                return state != nullptr && state->mark_in_queue();
+            }
+
+            inline bool begin_execution(task_state* state)
+            {
+                return state != nullptr && state->begin_execution();
+            }
+
+            inline bool cancel(task_state* state)
+            {
+                return state != nullptr && state->cancel();
+            }
+
         } // namespace profiler_detail
 
         class profiler : public toollet
@@ -128,4 +162,3 @@ namespace dsn {
         };
     }
 }
-

--- a/src/plugins/tools.common/profiler.test.cpp
+++ b/src/plugins/tools.common/profiler.test.cpp
@@ -1,0 +1,72 @@
+#include "profiler.h"
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace dsn {
+namespace tools {
+namespace {
+
+TEST(tools_common, profiler_task_state_transitions)
+{
+    profiler_detail::task_state state(0);
+
+    EXPECT_TRUE(state.mark_in_queue());
+    EXPECT_FALSE(state.mark_in_queue());
+    EXPECT_TRUE(state.begin_execution());
+    EXPECT_FALSE(state.begin_execution());
+    EXPECT_FALSE(state.cancel());
+
+    profiler_detail::task_state cancelled(0);
+    EXPECT_TRUE(cancelled.mark_in_queue());
+    EXPECT_TRUE(cancelled.cancel());
+    EXPECT_FALSE(cancelled.begin_execution());
+    EXPECT_FALSE(cancelled.cancel());
+}
+
+TEST(tools_common, profiler_task_state_enqueue_cancel_race)
+{
+    constexpr size_t state_count = 10000;
+    std::vector<std::unique_ptr<profiler_detail::task_state>> states;
+    std::vector<unsigned char> marked(state_count);
+    std::vector<unsigned char> cancelled(state_count);
+    states.reserve(state_count);
+    for (size_t i = 0; i < state_count; ++i) {
+        states.emplace_back(new profiler_detail::task_state(0));
+    }
+
+    std::atomic<bool> start(false);
+    std::thread enqueue_thread([&]() {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        for (size_t i = 0; i < state_count; ++i) {
+            marked[i] = states[i]->mark_in_queue();
+        }
+    });
+    std::thread cancel_thread([&]() {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        for (size_t i = 0; i < state_count; ++i) {
+            cancelled[i] = states[i]->cancel();
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    enqueue_thread.join();
+    cancel_thread.join();
+
+    for (size_t i = 0; i < state_count; ++i) {
+        EXPECT_EQ(marked[i], cancelled[i]);
+        EXPECT_FALSE(states[i]->begin_execution());
+    }
+}
+
+} // anonymous namespace
+} // namespace tools
+} // namespace dsn

--- a/src/plugins/tools.common/profiler.test.cpp
+++ b/src/plugins/tools.common/profiler.test.cpp
@@ -28,6 +28,18 @@ TEST(tools_common, profiler_task_state_transitions)
     EXPECT_FALSE(cancelled.cancel());
 }
 
+TEST(tools_common, profiler_missing_task_state_is_ignored)
+{
+    uint64_t timestamp = 123;
+    EXPECT_FALSE(profiler_detail::try_get_timestamp(nullptr, timestamp));
+    EXPECT_EQ(123u, timestamp);
+
+    profiler_detail::set_timestamp(nullptr, 456);
+    EXPECT_FALSE(profiler_detail::mark_in_queue(nullptr));
+    EXPECT_FALSE(profiler_detail::begin_execution(nullptr));
+    EXPECT_FALSE(profiler_detail::cancel(nullptr));
+}
+
 TEST(tools_common, profiler_task_state_enqueue_cancel_race)
 {
     constexpr size_t state_count = 10000;

--- a/src/plugins/tools.emulator/lockp.sim.test.cpp
+++ b/src/plugins/tools.emulator/lockp.sim.test.cpp
@@ -40,10 +40,14 @@
 # include <dsn/cpp/utils.h>
 # include <dsn/utility/synchronize.h>
 # include <gtest/gtest.h>
+# include <memory>
 # include <thread>
 
 # include "task_engine.sim.h"
 # include "scheduler.h"
+
+DEFINE_TASK_CODE(
+    LPC_EVENT_WHEEL_CLEAR_TEST, TASK_PRIORITY_COMMON, dsn::THREAD_POOL_DEFAULT)
 
 TEST(tools_emulator, dsn_semaphore)
 {
@@ -115,4 +119,31 @@ TEST(tools_emulator, scheduler)
     dsn::tools::scheduler::instance().add_system_event(100, callback);
     dsn::tools::scheduler::instance().wait_schedule(true,false);
     evt->wait();
+}
+
+TEST(tools_emulator, event_wheel_clear_cancels_and_releases_events)
+{
+    dsn::tools::event_wheel wheel;
+    auto retained_state = std::make_shared<int>(1);
+    std::weak_ptr<int> retained_state_lifetime(retained_state);
+    auto task_handle = dsn_task_create(
+        LPC_EVENT_WHEEL_CLEAR_TEST, [](void *) {}, nullptr, 0, nullptr);
+    ASSERT_NE(nullptr, task_handle);
+
+    auto *pending_task = static_cast<dsn::task *>(task_handle);
+    pending_task->add_ref();
+    pending_task->add_ref();
+    wheel.add_event(1, pending_task);
+    wheel.add_system_event(1, [retained_state]() {});
+    retained_state.reset();
+
+    ASSERT_EQ(2, pending_task->get_count());
+    EXPECT_FALSE(retained_state_lifetime.expired());
+    wheel.clear();
+
+    EXPECT_EQ(dsn::TASK_STATE_CANCELLED, pending_task->state());
+    EXPECT_EQ(1, pending_task->get_count());
+    EXPECT_TRUE(retained_state_lifetime.expired());
+    EXPECT_FALSE(wheel.has_more_events());
+    pending_task->release_ref();
 }

--- a/src/plugins/tools.emulator/scheduler.cpp
+++ b/src/plugins/tools.emulator/scheduler.cpp
@@ -104,8 +104,24 @@ std::vector<event_entry>* event_wheel::pop_next_events(/*out*/ uint64_t& ts)
 
 void event_wheel::clear()
 {
-    utils::auto_lock< ::dsn::utils::ex_lock> l(_lock);
-    _events.clear();
+    Events events;
+    {
+        utils::auto_lock< ::dsn::utils::ex_lock> l(_lock);
+        events.swap(_events);
+    }
+
+    for (auto& event_batch : events)
+    {
+        for (auto& event : *event_batch.second)
+        {
+            if (event.app_task != nullptr)
+            {
+                event.app_task->cancel(false);
+                event.app_task->release_ref();
+            }
+        }
+        delete event_batch.second;
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/plugins/tools.nfs/CMakeLists.txt
+++ b/src/plugins/tools.nfs/CMakeLists.txt
@@ -20,9 +20,9 @@ set(MY_PROJ_SRC "")
 # "GLOB" for non-recursive search
 set(MY_SRC_SEARCH_MODE "GLOB")
 
-set(MY_PROJ_INC_PATH "")
+set(MY_PROJ_INC_PATH ${GTEST_INCLUDE_DIR})
 
-set(MY_PROJ_LIBS "")
+set(MY_PROJ_LIBS gtest)
 
 set(MY_PROJ_LIB_PATH "")
 
@@ -30,3 +30,5 @@ set(MY_PROJ_LIB_PATH "")
 set(MY_BINPLACES "")
 
 dsn_add_shared_library()
+
+file(COPY test/ DESTINATION "${CMAKE_BINARY_DIR}/test/${MY_PROJ_NAME}")

--- a/src/plugins/tools.nfs/nfs_client_impl.cpp
+++ b/src/plugins/tools.nfs/nfs_client_impl.cpp
@@ -469,12 +469,12 @@ namespace dsn {
                 }
 
                 // An empty source file yields a copy request with response.size == 0. The
-                // destination file has just been created (or already exists) via the
-                // O_RDWR | O_CREAT open above, so there is nothing to write: a zero-length
-                // file::write would complete with ERR_HANDLE_EOF and be reported as a
-                // failure. Finalize this segment as a success inline -- mirroring the
-                // success bookkeeping in local_write_callback -- and continue the loop
-                // (no recursion) instead of issuing the zero-length write.
+                // destination file has already been opened with the requested creation
+                // policy, so there is nothing to write: a zero-length file::write would
+                // complete with ERR_HANDLE_EOF and be reported as a failure. Finalize this
+                // segment as a success inline -- mirroring the success bookkeeping in
+                // local_write_callback -- and continue the loop (no recursion) instead of
+                // issuing the zero-length write.
                 if (reqc->response.size == 0)
                 {
                     reqc->response.file_content = blob();
@@ -621,12 +621,19 @@ namespace dsn {
 
                     f.second->file = nullptr;
 
-                    if (f.second->finished_segments != (int)f.second->copy_requests.size())
+                    const bool is_incomplete =
+                        f.second->finished_segments != (int)f.second->copy_requests.size();
+                    const bool rollback_preserving_copy =
+                        err != ERR_OK && !req->file_size_req.overwrite;
+                    if (is_incomplete || rollback_preserving_copy)
                     {
-                        std::string path = f.second->user_req->file_size_req.dst_dir + f.second->file_name;
+                        // A preserving copy creates files with O_EXCL, so every opened file
+                        // belongs to this request. Roll all of them back when any file fails;
+                        // otherwise completed siblings would make a retry fail with O_EXCL.
+                        const std::string& path = f.first;
                         if (!::dsn::utils::filesystem::remove_path(path))
                         {
-                            dwarn("failed to remove incomplete transfer file %s", path.c_str());
+                            dwarn("failed to remove transfer file %s during cleanup", path.c_str());
                         }
                     }
 

--- a/src/plugins/tools.nfs/nfs_client_impl.cpp
+++ b/src/plugins/tools.nfs/nfs_client_impl.cpp
@@ -111,6 +111,12 @@ namespace dsn {
                 return;
             }
 
+            if (resp.file_list.empty())
+            {
+                handle_completion(ureq, ERR_OK);
+                return;
+            }
+
             // file_list comes from the (untrusted) remote server and is combined with the local
             // dst_dir below to form the path this client creates and writes. Reject any name that
             // escapes dst_dir (see nfs_path_has_parent_ref) up front -- before any file_context is
@@ -446,7 +452,10 @@ namespace dsn {
                     hfile = reqc->file_ctx->file.load();
                     if (!hfile)
                     {
-                        hfile = dsn_file_open(file_path.c_str(), O_RDWR | O_CREAT | O_BINARY, 0666);
+                        int open_flags =
+                            nfs_client_detail::destination_open_flags(
+                                reqc->copy_req.overwrite);
+                        hfile = dsn_file_open(file_path.c_str(), open_flags, 0666);
                         reqc->file_ctx->file = hfile;
                     }
                 }
@@ -513,6 +522,17 @@ namespace dsn {
         {
             //dassert(reqc->local_write_task == task::get_current_task(), "");
             --_concurrent_local_write_count;
+
+            auto write_err =
+                nfs_client_detail::local_write_result(err, sz, reqc->response.size);
+            if (err == ERR_OK && write_err != ERR_OK)
+            {
+                derror("short write for nfs file '%s': expected %u bytes, wrote %zu",
+                       reqc->file_ctx->file_name.c_str(),
+                       static_cast<unsigned int>(reqc->response.size),
+                       sz);
+            }
+            err = write_err;
 
             // clear all content to release memory quickly
             reqc->response.file_content = blob();

--- a/src/plugins/tools.nfs/nfs_client_impl.h
+++ b/src/plugins/tools.nfs/nfs_client_impl.h
@@ -58,6 +58,9 @@ namespace dsn {
 
             inline int destination_open_flags(bool overwrite)
             {
+                // The public API defines overwrite=false as preserving an existing
+                // destination. O_EXCL enforces that contract atomically instead of
+                // checking first and racing another creator.
                 return O_RDWR | O_CREAT | O_BINARY | (overwrite ? O_TRUNC : O_EXCL);
             }
 

--- a/src/plugins/tools.nfs/nfs_client_impl.h
+++ b/src/plugins/tools.nfs/nfs_client_impl.h
@@ -35,11 +35,42 @@
 # pragma once
 # include "nfs_client.h"
 # include <queue>
+# include <limits>
 # include <string>
 # include <dsn/tool-api/nfs.h>
 
 namespace dsn {
     namespace service {
+
+        namespace nfs_client_detail {
+
+            static const uint32_t default_copy_block_bytes = 4 * 1024 * 1024;
+
+            inline uint32_t normalize_copy_block_bytes(uint64_t configured)
+            {
+                if (configured == 0 ||
+                    configured > static_cast<uint64_t>((std::numeric_limits<int32_t>::max)()))
+                {
+                    return default_copy_block_bytes;
+                }
+                return static_cast<uint32_t>(configured);
+            }
+
+            inline int destination_open_flags(bool overwrite)
+            {
+                return O_RDWR | O_CREAT | O_BINARY | (overwrite ? O_TRUNC : O_EXCL);
+            }
+
+            inline error_code local_write_result(error_code err,
+                                                 size_t actual_size,
+                                                 uint32_t expected_size)
+            {
+                return err == ERR_OK && actual_size != expected_size
+                           ? ERR_FILE_OPERATION_FAILED
+                           : err;
+            }
+
+        } // namespace nfs_client_detail
 
         // A copy / get-file-size RPC carries a source directory and file name(s) supplied by a
         // remote peer on BOTH sides of the transfer: the server opens source_dir/file_name to
@@ -85,8 +116,19 @@ namespace dsn {
 
             void init()
             {
-                nfs_copy_block_bytes = (uint32_t)dsn_config_get_value_uint64("nfs", "nfs_copy_block_bytes", 
-                    4*1024*1024, "maximum block size (bytes) for each network copy");
+                uint64_t configured_copy_block_bytes = dsn_config_get_value_uint64(
+                    "nfs",
+                    "nfs_copy_block_bytes",
+                    nfs_client_detail::default_copy_block_bytes,
+                    "maximum block size (bytes) for each network copy");
+                nfs_copy_block_bytes =
+                    nfs_client_detail::normalize_copy_block_bytes(configured_copy_block_bytes);
+                if (nfs_copy_block_bytes != configured_copy_block_bytes)
+                {
+                    derror("invalid nfs_copy_block_bytes = %llu; using default %u",
+                           static_cast<unsigned long long>(configured_copy_block_bytes),
+                           nfs_client_detail::default_copy_block_bytes);
+                }
                 max_concurrent_remote_copy_requests = (int)dsn_config_get_value_uint64("nfs", "max_concurrent_remote_copy_requests", 
                     50, "maximum concurrent remote copy to the same server on nfs client");
                 max_concurrent_local_writes = (int)dsn_config_get_value_uint64("nfs", "max_concurrent_local_writes", 

--- a/src/plugins/tools.nfs/nfs_client_impl.test.cpp
+++ b/src/plugins/tools.nfs/nfs_client_impl.test.cpp
@@ -1,0 +1,142 @@
+#include "nfs_client_impl.h"
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <dsn/cpp/test_utils.h>
+
+namespace dsn {
+namespace service {
+namespace {
+
+error_code copy_remote_files(const rpc_address &remote,
+                             const std::string &source_dir,
+                             const std::vector<std::string> &files,
+                             const std::string &destination_dir,
+                             bool overwrite)
+{
+    error_code result = ERR_INVALID_STATE;
+    auto task = file::copy_remote_files(remote,
+                                        source_dir,
+                                        files,
+                                        destination_dir,
+                                        overwrite,
+                                        LPC_AIO_TEST_NFS,
+                                        nullptr,
+                                        [&result](error_code err, size_t) { result = err; });
+    if (task == nullptr) {
+        return ERR_INVALID_STATE;
+    }
+    if (!task->wait(20000)) {
+        task->cancel(true);
+        return ERR_TIMEOUT;
+    }
+    return result;
+}
+
+error_code copy_remote_directory(const rpc_address &remote,
+                                 const std::string &source_dir,
+                                 const std::string &destination_dir)
+{
+    error_code result = ERR_INVALID_STATE;
+    auto task = file::copy_remote_directory(remote,
+                                            source_dir,
+                                            destination_dir,
+                                            false,
+                                            LPC_AIO_TEST_NFS,
+                                            nullptr,
+                                            [&result](error_code err, size_t) { result = err; });
+    if (task == nullptr) {
+        return ERR_INVALID_STATE;
+    }
+    if (!task->wait(20000)) {
+        task->cancel(true);
+        return ERR_TIMEOUT;
+    }
+    return result;
+}
+
+void write_file(const std::string &path, const std::string &contents)
+{
+    std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(stream.is_open());
+    stream.write(contents.data(), contents.size());
+    ASSERT_TRUE(stream.good());
+}
+
+std::string read_file(const std::string &path)
+{
+    std::ifstream stream(path, std::ios::binary);
+    EXPECT_TRUE(stream.is_open());
+    return std::string((std::istreambuf_iterator<char>(stream)),
+                       std::istreambuf_iterator<char>());
+}
+
+TEST(tools_nfs, copy_helpers_validate_configuration_and_write_results)
+{
+    using namespace nfs_client_detail;
+
+    EXPECT_EQ(default_copy_block_bytes, normalize_copy_block_bytes(0));
+    EXPECT_EQ(default_copy_block_bytes,
+              normalize_copy_block_bytes(
+                  static_cast<uint64_t>((std::numeric_limits<int32_t>::max)()) + 1));
+    EXPECT_EQ(static_cast<uint32_t>((std::numeric_limits<int32_t>::max)()),
+              normalize_copy_block_bytes((std::numeric_limits<int32_t>::max)()));
+    EXPECT_EQ(4096u, normalize_copy_block_bytes(4096));
+
+    const int preserve_flags = destination_open_flags(false);
+    EXPECT_NE(0, preserve_flags & O_EXCL);
+    EXPECT_EQ(0, preserve_flags & O_TRUNC);
+
+    const int overwrite_flags = destination_open_flags(true);
+    EXPECT_NE(0, overwrite_flags & O_TRUNC);
+    EXPECT_EQ(0, overwrite_flags & O_EXCL);
+
+    EXPECT_EQ(ERR_OK, local_write_result(ERR_OK, 64, 64));
+    EXPECT_EQ(ERR_FILE_OPERATION_FAILED, local_write_result(ERR_OK, 63, 64));
+    EXPECT_EQ(ERR_TIMEOUT, local_write_result(ERR_TIMEOUT, 63, 64));
+}
+
+TEST(tools_nfs, empty_directory_copy_completes)
+{
+    ASSERT_TRUE(utils::test::prepare_test_tmp_dir("dsn.tools.nfs.empty_directory"));
+    const std::string source =
+        utils::test::test_tmp_path("dsn.tools.nfs.empty_directory", "source");
+    const std::string destination =
+        utils::test::test_tmp_path("dsn.tools.nfs.empty_directory", "destination");
+    ASSERT_TRUE(utils::filesystem::create_directory(source));
+
+    EXPECT_EQ(ERR_OK,
+              copy_remote_directory(rpc_address("127.0.0.1", 20101), source, destination));
+}
+
+TEST(tools_nfs, overwrite_policy_preserves_or_truncates_existing_file)
+{
+    ASSERT_TRUE(utils::test::prepare_test_tmp_dir("dsn.tools.nfs.overwrite"));
+    const std::string source =
+        utils::test::test_tmp_path("dsn.tools.nfs.overwrite", "source");
+    const std::string destination =
+        utils::test::test_tmp_path("dsn.tools.nfs.overwrite", "destination");
+    ASSERT_TRUE(utils::filesystem::create_directory(source));
+    ASSERT_TRUE(utils::filesystem::create_directory(destination));
+
+    const std::string file_name = "data";
+    write_file(utils::filesystem::path_combine(source, file_name), "new");
+    write_file(utils::filesystem::path_combine(destination, file_name), "old-content");
+
+    const rpc_address remote("127.0.0.1", 20101);
+    EXPECT_EQ(ERR_FILE_OPERATION_FAILED,
+              copy_remote_files(remote, source, {file_name}, destination, false));
+    EXPECT_EQ("old-content",
+              read_file(utils::filesystem::path_combine(destination, file_name)));
+
+    EXPECT_EQ(ERR_OK, copy_remote_files(remote, source, {file_name}, destination, true));
+    EXPECT_EQ("new", read_file(utils::filesystem::path_combine(destination, file_name)));
+}
+
+} // anonymous namespace
+} // namespace service
+} // namespace dsn

--- a/src/plugins/tools.nfs/test/gtests
+++ b/src/plugins/tools.nfs/test/gtests
@@ -1,0 +1,1 @@
+test.config.tools.nfs.ini

--- a/src/plugins/tools.nfs/test/test.config.tools.nfs.ini
+++ b/src/plugins/tools.nfs/test/test.config.tools.nfs.ini
@@ -1,0 +1,55 @@
+[modules]
+dsn.tools.common
+dsn.tools.nfs
+
+[apps..default]
+run = true
+count = 1
+network.client.RPC_CHANNEL_TCP = dsn::tools::asio_network_provider, 65536
+network.server.0.RPC_CHANNEL_TCP = dsn::tools::asio_network_provider, 65536
+
+[apps.client]
+type = test
+arguments = localhost 20101
+ports = 20001
+delay_seconds = 1
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_TEST_SERVER
+
+[apps.server]
+type = test
+ports = 20101
+pools = THREAD_POOL_DEFAULT, THREAD_POOL_TEST_SERVER
+
+[core]
+tool = nativerun
+pause_on_start = false
+cli_local = false
+cli_remote = false
+logging_start_level = LOG_LEVEL_INFORMATION
+logging_factory_name = dsn::tools::simple_logger
+start_nfs = true
+gtest = true
+gtest_arguments = --gtest_filter=tools_nfs.*
+
+[network]
+io_service_worker_count = 2
+explicit_host_address = 127.0.0.1
+
+[task..default]
+allow_inline = false
+rpc_call_channel = RPC_CHANNEL_TCP
+rpc_message_header_format = dsn
+rpc_timeout_milliseconds = 5000
+
+[threadpool..default]
+worker_count = 2
+
+[threadpool.THREAD_POOL_DEFAULT]
+partitioned = false
+
+[threadpool.THREAD_POOL_TEST_SERVER]
+partitioned = false
+
+[core.test]
+count = 1
+run = true


### PR DESCRIPTION
## Summary

This PR hardens rDSN core and plugin paths exposed by fault injection, malformed inputs, concurrent callbacks, and teardown. It fixes 15 robustness issues and adds focused regression coverage.

## Changes

### NFS copy handling

- Complete requests for empty source directories instead of leaving them pending.
- Normalize invalid block sizes and cap them at the signed Thrift wire limit.
- Enforce the documented overwrite contract atomically:
  - `overwrite=false` uses `O_EXCL` and preserves existing files.
  - `overwrite=true` uses `O_TRUNC` and removes stale trailing data.
- Detect short writes instead of treating them as successful.
- Roll back every destination file created by a failed preserving multi-file request so ordinary retries are not blocked.
- Use the canonical `path_combine` result for rollback instead of raw path concatenation.
- Close destination handles before removing incomplete files.
- Clarify the overwrite behavior in the public C API documentation.

A hard process crash can still leave a partial destination that a later preserving request refuses to overwrite. This is inherent to the documented `overwrite=false` contract.

### Core AIO and utility safety

- Reject vectored writes whose aggregate size overflows the supported range.
- Keep rejected vectored writes transactional by validating before mutating the callback task.
- Publish the AIO operation type before invoking instrumentation hooks.
- Reject non-positive exponential-delay thresholds.
- Clear stale native-callback metadata when replacing join-point handlers.
- Make customizable-ID registration thread-safe, avoid recursive locking, and preserve returned name pointers.
- Synchronize singleton vector-store access.

### Resolver and networking concurrency

- Protect simple partition-resolver state with coherent configuration snapshots.
- Avoid invoking resolver callbacks while internal locks are held.
- Keep UDP send buffers alive until asynchronous completion, preventing use-after-free.

### Profiler and emulator lifecycle

- Make profiler queue-state transitions atomic and account for cancelled queued tasks exactly once.
- Safely ignore profiler hooks for tasks that do not have profiler extension state.
- Skip invalid latency samples rather than dereferencing missing state.
- Cancel and release pending emulator event-wheel tasks during teardown.

## Regression coverage

Added focused tests for:

- Vectored-write overflow and transactional rejection.
- AIO hook publication ordering.
- Exponential-delay validation.
- Join-point replacement metadata.
- Concurrent customizable-ID registration and pointer stability.
- Singleton vector-store synchronization.
- URI-resolver snapshot consistency.
- UDP asynchronous send-buffer lifetime.
- Profiler queue-state races and missing task state.
- Emulator event-wheel cleanup.
- NFS empty-directory completion, block-size handling, overwrite policy, rollback, and short writes.

Dedicated `gtests` manifests and test configurations were added for the NFS and URI-resolver plugins.

## Validation

- Clean Ubuntu build with `./run.sh build --build_plugins`.
- Rebuilt the affected core, common-tools, NFS, and URI-resolver targets after review changes.
- Repository format check passes.