### PR TITLE
Harden core perf-counters and worker affinity against config-driven aborts

### DIFF
--- a/src/core/src/perf_counters.cpp
+++ b/src/core/src/perf_counters.cpp
@@ -73,7 +73,11 @@ DSN_API dsn_handle_t dsn_perf_counter_create(const char* section, const char* na
     }
 
     auto cnode = dsn::task::get_current_node2();
-    dassert(cnode != nullptr, "cannot get current service node!");
+    if (cnode == nullptr)
+    {
+        derror("dsn_perf_counter_create must be called within a service node context");
+        return nullptr;
+    }
     auto c = dsn::perf_counters::instance().get_counter(cnode->name(), section, name, type, description, true);
     c->add_ref();
     return c.get();
@@ -186,10 +190,15 @@ perf_counters::perf_counters(void)
         "maximum number of performance counters"
         );
 
-    dassert(_max_counter_count > 0 && _max_counter_count < 1000000,
-        "invalid given perf_counter_max_count value %" PRIu64, 
-        _max_counter_count
-        );
+    // perf_counter_max_count is operator-supplied. A value of 0 or an unreasonably large one used
+    // to abort the whole process here; a huge value would also overflow / OOM the _quick_counters
+    // allocation below. Fall back to the default with a warning instead of crashing on bad config.
+    if (_max_counter_count == 0 || _max_counter_count >= 1000000)
+    {
+        dwarn("invalid [core] perf_counter_max_count value %" PRIu64 ", reset to default 10000",
+            _max_counter_count);
+        _max_counter_count = 10000;
+    }
     _quick_counters = new perf_counter*[_max_counter_count];
     memset((void*)_quick_counters, 0, sizeof(perf_counter*) * _max_counter_count);
 

--- a/src/core/src/task_worker.cpp
+++ b/src/core/src/task_worker.cpp
@@ -38,6 +38,7 @@
 # include <sstream>
 # include <errno.h>
 # include <cstring>
+# include <cinttypes>
 # include <chrono>
 
 # ifdef _WIN32
@@ -252,13 +253,40 @@ void task_worker::set_priority(worker_priority_t pri)
 
 void task_worker::set_affinity(uint64_t affinity)
 {
-    dassert(affinity > 0, "affinity cannot be 0.");
+    if (affinity == 0)
+    {
+        dwarn("task_worker::set_affinity got an empty affinity mask, skip setting affinity");
+        return;
+    }
 
     int nr_cpu = static_cast<int>(std::thread::hardware_concurrency());
-    if (nr_cpu < 64) 
+
+    // worker_affinity_mask is operator-supplied. A mask that references a nonexistent cpu used to
+    // abort the whole process here; and when hardware_concurrency() cannot determine the cpu count
+    // (returns 0) the old ((1<<0)-1)==0 bound rejected every nonzero mask. Clamp the mask to the
+    // available cpus with a warning when the count is known, and otherwise defer to the OS call
+    // below (which already warns, not aborts, on failure).
+    //
+    // The upper bound (nr_cpu < 64) is intentional: the mask is a uint64_t, so it can only ever
+    // address cpus 0..63. When the machine has 64 or more cpus every bit of the mask already maps
+    // to a real cpu, so there is nothing to clamp and we pass it through unchanged. Restricting the
+    // clamp to nr_cpu < 64 is also required for correctness -- computing (1 << nr_cpu) when
+    // nr_cpu >= 64 would be a shift by >= the operand width, which is undefined behavior.
+    if (nr_cpu > 0 && nr_cpu < 64)
     {
-        dassert(affinity <= (((uint64_t)1 << nr_cpu) - 1),
-            "There are %d cpus in total, while setting thread affinity to a nonexistent one.", nr_cpu);
+        uint64_t valid_mask = (((uint64_t)1 << nr_cpu) - 1);
+        if ((affinity & ~valid_mask) != 0)
+        {
+            uint64_t clamped = affinity & valid_mask;
+            dwarn("affinity mask 0x%" PRIx64 " references cpu(s) beyond the %d available, "
+                "clamping to 0x%" PRIx64, affinity, nr_cpu, clamped);
+            affinity = clamped;
+            if (affinity == 0)
+            {
+                dwarn("no valid cpu left in affinity mask after clamping, skip setting affinity");
+                return;
+            }
+        }
     }
 
     int err = 0;


### PR DESCRIPTION
## Summary

Robustness hardening for the rDSN **core** runtime, plus a submodule pointer
update that pulls in the merged meta/replica-server hardening.

Each core change replaces an always-on `dassert(...)` — which calls
`dsn_coredump()` → `SIGABRT` in **all** build configurations, not just debug —
on a **recoverable** condition (operator-supplied config or a missing
service-node context) with graceful `derror`/`dwarn` + fallback. None of these
conditions should take a production process down; they are now logged and
handled.

## Changes

### `src/core/src/perf_counters.cpp`
- **`perf_counters` ctor** — `[core] perf_counter_max_count` is operator-supplied.
  A value of `0` or an unreasonably large one (`>= 1000000`) used to abort the
  whole process (and a huge value would also overflow / OOM the
  `_quick_counters` allocation). Now falls back to the default `10000` with a
  `dwarn` instead of crashing on bad config.
- **`dsn_perf_counter_create`** — aborted when called outside a service-node
  context. Now returns `nullptr` with a `derror` so the caller can handle it.

### `src/core/src/task_worker.cpp`
- **`set_affinity`** — `worker_affinity_mask` is operator-supplied.
  - An empty mask (`0`) used to abort; it now warns and skips setting affinity.
  - A mask referencing a nonexistent CPU used to abort; it is now clamped to the
    available CPUs with a `dwarn` (and skips setting affinity if nothing valid
    remains).
  - When `hardware_concurrency()` returns `0` (CPU count unknown), the old
    `((1 << 0) - 1) == 0` bound rejected every nonzero mask; that case now
    defers to the OS call, which already warns (not aborts) on failure.
  - The `nr_cpu < 64` upper bound is kept intentionally: the mask is a
    `uint64_t` (only addresses CPUs 0–63), and computing `(1 << nr_cpu)` for
    `nr_cpu >= 64` would be undefined behavior. Documented inline.
  - Added `#include <cinttypes>` for the `PRIx64` format macros.

### Submodule: `src/plugins_ext/rDSN.dist.service`
Bumped to the merged master, which hardens the meta-server and replica-server
against config, ZooKeeper-race, and load-balancer aborts, and fixes a
modulo-by-zero (`SIGFPE`) in the mutation cache
(rDSN.dist.service#40).

## Testing

Builds cleanly as part of the full plugin build
(`./run.sh build --build_plugins`) on Ubuntu.